### PR TITLE
fix

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -3091,7 +3091,7 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 		uint32 dest, redirect, redirect_seq, check_cb;
 		for(auto cit = targets->container.begin(); cit != targets->container.end(); ++cit)
 			(*cit)->enable_field_effect(FALSE);
-		adjust_instant();
+		adjust_disable_check_list();
 		for(auto cit = targets->container.begin(); cit != targets->container.end(); ++cit) {
 			card* pcard = *cit;
 			dest = (pcard->operation_param >> 8) & 0xff;


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro/issues/1575
Fix: If 魔サイの戦士/Fiendish Rhino Warrior leaves field, the Burning Abyss monsters is self destroyed.