### PR TITLE
update Duel.Overlay

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -863,37 +863,6 @@ int32 card::get_union_count() {
 	}
 	return count;
 }
-void card::xyz_overlay(card_set* materials) {
-	if(materials->size() == 0)
-		return;
-	card_set des;
-	if(materials->size() == 1) {
-		card* pcard = *materials->begin();
-		pcard->reset(RESET_LEAVE + RESET_OVERLAY, RESET_EVENT);
-		if(pcard->unique_code)
-			pduel->game_field->remove_unique_card(pcard);
-		if(pcard->equiping_target)
-			pcard->unequip();
-		xyz_add(pcard, &des);
-	} else {
-		field::card_vector cv;
-		for(auto cit = materials->begin(); cit != materials->end(); ++cit)
-			cv.push_back(*cit);
-		std::sort(cv.begin(), cv.end(), card::card_operation_sort);
-		for(auto cvit = cv.begin(); cvit != cv.end(); ++cvit) {
-			(*cvit)->reset(RESET_LEAVE + RESET_OVERLAY, RESET_EVENT);
-			if((*cvit)->unique_code)
-				pduel->game_field->remove_unique_card(*cvit);
-			if((*cvit)->equiping_target)
-				(*cvit)->unequip();
-			xyz_add(*cvit, &des);
-		}
-	}
-	if(des.size())
-		pduel->game_field->destroy(&des, 0, REASON_LOST_TARGET + REASON_RULE, PLAYER_NONE);
-	else
-		pduel->game_field->adjust_instant();
-}
 void card::xyz_add(card* mat, card_set* des) {
 	if(mat->overlay_target == this)
 		return;

--- a/card.h
+++ b/card.h
@@ -168,7 +168,6 @@ public:
 	void equip(card *target, uint32 send_msg = TRUE);
 	void unequip();
 	int32 get_union_count();
-	void xyz_overlay(card_set* materials);
 	void xyz_add(card* mat, card_set* des);
 	void xyz_remove(card* mat);
 	void apply_field_effect();

--- a/field.h
+++ b/field.h
@@ -481,6 +481,7 @@ public:
 	void move_to_field(card* target, uint32 move_player, uint32 playerid, uint32 destination, uint32 positions, uint32 enable = FALSE, uint32 ret = FALSE, uint32 is_equip = FALSE);
 	void change_position(card_set* targets, effect* reason_effect, uint32 reason_player, uint32 au, uint32 ad, uint32 du, uint32 dd, uint32 noflip, uint32 enable = FALSE);
 	void change_position(card* target, effect* reason_effect, uint32 reason_player, uint32 npos, uint32 noflip, uint32 enable = FALSE);
+	void xyz_overlay(card* target, card_set* material, uint32 overlay);
 
 	int32 remove_counter(uint16 step, uint32 reason, card* pcard, uint8 rplayer, uint8 s, uint8 o, uint16 countertype, uint16 count);
 	int32 remove_overlay_card(uint16 step, uint32 reason, card* pcard, uint8 rplayer, uint8 s, uint8 o, uint16 min, uint16 max);
@@ -488,6 +489,7 @@ public:
 	int32 swap_control(uint16 step, effect* reason_effect, uint8 reason_player, card* pcard1, card* pcard2, uint16 reset_phase, uint8 reset_count);
 	int32 control_adjust(uint16 step);
 	int32 self_destroy(uint16 step);
+	int32 xyz_overlay(uint16 step, card* target, group* material, uint32 overlay);
 	int32 equip(uint16 step, uint8 equip_player, card* equip_card, card* target, uint32 up, uint32 is_step);
 	int32 draw(uint16 step, effect* reason_effect, uint32 reason, uint8 reason_player, uint8 playerid, uint32 count);
 	int32 damage(uint16 step, effect* reason_effect, uint32 reason, uint8 reason_player, card* pcard, uint8 playerid, uint32 amount);
@@ -528,7 +530,7 @@ public:
 	int32 select_position(uint16 step, uint8 playerid, uint32 code, uint8 positions);
 	int32 select_tribute(uint16 step, uint8 playerid, uint8 cancelable, uint8 min, uint8 max);
 	int32 select_counter(uint16 step, uint8 playerid, uint16 countertype, uint16 count);
-	int32 select_with_sum_limit(int16 step, uint8 playerid, int32 acc, int32 min, int max);
+	int32 select_with_sum_limit(int16 step, uint8 playerid, int32 acc, int32 min, int32 max);
 	int32 sort_card(int16 step, uint8 playerid, uint8 is_chain);
 	int32 announce_race(int16 step, uint8 playerid, int32 count, int32 available);
 	int32 announce_attribute(int16 step, uint8 playerid, int32 count, int32 available);
@@ -659,6 +661,7 @@ public:
 #define PROCESSOR_SWAP_CONTROL		75
 #define PROCESSOR_CONTROL_ADJUST	76
 #define PROCESSOR_SELF_DESTROY		77
+#define PROCESSOR_XYZ_OVERLAY		78
 #define PROCESSOR_PAY_LPCOST		80
 #define PROCESSOR_REMOVE_COUNTER	81
 #define PROCESSOR_ATTACK_DISABLE	82

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2467,14 +2467,18 @@ int32 scriptlib::duel_overlay(lua_State *L) {
 		pgroup = *(group**) lua_touserdata(L, 2);
 	} else
 		luaL_error(L, "Parameter %d should be \"Card\" or \"Group\".", 2);
+	uint32 overlay = FALSE;
+	if(lua_gettop(L) >= 3)
+		overlay = lua_toboolean(L, 3);
+	duel* pduel = target->pduel;
 	if(pcard) {
 		card::card_set cset;
 		cset.insert(pcard);
-		target->xyz_overlay(&cset);
+		pduel->game_field->xyz_overlay(target, &cset, overlay);
 	} else
-		target->xyz_overlay(&pgroup->container);
+		pduel->game_field->xyz_overlay(target, &pgroup->container, overlay);
 	if(target->current.location == LOCATION_MZONE)
-		target->pduel->game_field->adjust_all();
+		pduel->game_field->adjust_all();
 	return lua_yield(L, 0);
 }
 int32 scriptlib::duel_get_overlay_group(lua_State *L) {

--- a/operations.cpp
+++ b/operations.cpp
@@ -1131,7 +1131,7 @@ int32 field::xyz_overlay(uint16 step, card * target, group * material, uint32 ov
 				pcard->unequip();
 			target->xyz_add(pcard, &des);
 		} else {
-			field::card_vector cv;
+			card_vector cv;
 			for(auto cit = material->container.begin(); cit != material->container.end(); ++cit)
 				cv.push_back(*cit);
 			std::sort(cv.begin(), cv.end(), card::card_operation_sort);

--- a/operations.cpp
+++ b/operations.cpp
@@ -294,6 +294,11 @@ void field::change_position(card* target, effect* reason_effect, uint32 reason_p
 		target->operation_param |= NO_FLIP_EFFECT;
 	add_process(PROCESSOR_CHANGEPOS, 0, reason_effect, ng, reason_player, enable);
 }
+void field::xyz_overlay(card* target, card_set* material, uint32 overlay) {
+	group* ng = pduel->new_group(*material);
+	ng->is_readonly = TRUE;
+	add_process(PROCESSOR_XYZ_OVERLAY, 0, 0, ng, (ptr)target, overlay);
+}
 int32 field::draw(uint16 step, effect* reason_effect, uint32 reason, uint8 reason_player, uint8 playerid, uint32 count) {
 	switch(step) {
 	case 0: {
@@ -1084,6 +1089,65 @@ int32 field::self_destroy(uint16 step) {
 		core.self_tograve_set.clear();
 		core.operated_set.clear();
 		returns.ivalue[0] = 0;
+		return TRUE;
+	}
+	}
+	return TRUE;
+}
+int32 field::xyz_overlay(uint16 step, card * target, group * material, uint32 overlay) {
+	switch(step) {
+	case 0: {
+		for(auto cit = material->container.begin(); cit != material->container.end();) {
+			card* pcard = *cit++;
+			if(pcard == target || (pcard->data.type & TYPE_TOKEN)) {
+				material->container.erase(pcard);
+				continue;
+			}
+		}
+		if(!material->container.size())
+			return TRUE;
+		card_set submat;
+		for(auto cit = material->container.begin(); cit != material->container.end(); ++cit) {
+			card* pcard = *cit;
+			if(pcard->xyz_materials.size()) {
+				for(auto cit = pcard->xyz_materials.begin(); cit != pcard->xyz_materials.end(); ++cit)
+					submat.insert(*cit);
+			}
+		}
+		if(overlay)
+			xyz_overlay(target, &submat, FALSE);
+		else
+			send_to(&submat, 0, REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, 0);
+		return FALSE;
+	}
+	case 1: {
+		card_set des;
+		if(material->container.size() == 1) {
+			card* pcard = *material->container.begin();
+			pcard->reset(RESET_LEAVE + RESET_OVERLAY, RESET_EVENT);
+			if(pcard->unique_code)
+				remove_unique_card(pcard);
+			if(pcard->equiping_target)
+				pcard->unequip();
+			target->xyz_add(pcard, &des);
+		} else {
+			field::card_vector cv;
+			for(auto cit = material->container.begin(); cit != material->container.end(); ++cit)
+				cv.push_back(*cit);
+			std::sort(cv.begin(), cv.end(), card::card_operation_sort);
+			for(auto cvit = cv.begin(); cvit != cv.end(); ++cvit) {
+				(*cvit)->reset(RESET_LEAVE + RESET_OVERLAY, RESET_EVENT);
+				if((*cvit)->unique_code)
+					remove_unique_card(*cvit);
+				if((*cvit)->equiping_target)
+					(*cvit)->unequip();
+				target->xyz_add(*cvit, &des);
+			}
+		}
+		if(des.size())
+			destroy(&des, 0, REASON_LOST_TARGET + REASON_RULE, PLAYER_NONE);
+		else
+			adjust_instant();
 		return TRUE;
 	}
 	}

--- a/processor.cpp
+++ b/processor.cpp
@@ -467,6 +467,13 @@ int32 field::process() {
 			it->step++;
 		return pduel->bufferlen;
 	}
+	case PROCESSOR_XYZ_OVERLAY: {
+		if(xyz_overlay(it->step, (card*)it->arg1, it->ptarget, it->arg2)) {
+			core.units.pop_front();
+		} else
+			it->step++;
+		return pduel->bufferlen;
+	}
 	case PROCESSOR_PAY_LPCOST: {
 		if (pay_lp_cost(it->step, it->arg1, it->arg2))
 			core.units.pop_front();


### PR DESCRIPTION
Since the history of the main branch changed, open another pull request.

When overlaying Xyz monsters, handle their Xyz materials automatically:
Duel.Overlay(Card xcard, Card|Group mat, overlay=false)
if overlay=true, overlay all Xyz materials of mat to xcard, else send them to grave by default.
