### PR TITLE
Update field.cpp

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -369,12 +369,14 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 				return;
 			}
 		} else {
-			if((pcard->data.type & TYPE_PENDULUM) && (location == LOCATION_GRAVE)
-			        && pcard->is_capable_send_to_extra(playerid)
-			        && (((pcard->current.location == LOCATION_MZONE) && !pcard->is_status(STATUS_SUMMON_DISABLED))
-			        || ((pcard->current.location == LOCATION_SZONE) && !pcard->is_status(STATUS_ACTIVATE_DISABLED)))) {
-				location = LOCATION_EXTRA;
-				pcard->operation_param = (pcard->operation_param & 0x00ffffff) | (POS_FACEUP_DEFENCE << 24);
+			if((pcard->data.type & TYPE_PENDULUM) && pcard->is_capable_send_to_extra(playerid)) {
+				//Duel.SendtoDeck + Sequence == 3 = Pendulum to Extra Faceup, others to Deck Shuffle
+				if(((sequence == 3) && (location == LOCATION_DECK)) || ((location == LOCATION_GRAVE)
+					&& (((pcard->current.location == LOCATION_MZONE) && !pcard->is_status(STATUS_SUMMON_DISABLED))
+					|| ((pcard->current.location == LOCATION_SZONE) && !pcard->is_status(STATUS_ACTIVATE_DISABLED))))) {
+					location = LOCATION_EXTRA;
+					pcard->operation_param = (pcard->operation_param & 0x00ffffff) | (POS_FACEUP_DEFENCE << 24);
+				}
 			}
 			remove_card(pcard);
 		}

--- a/field.cpp
+++ b/field.cpp
@@ -265,7 +265,8 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 		return;
 	uint8 preplayer = pcard->current.controler;
 	uint8 presequence = pcard->current.sequence;
-	if((pcard->data.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ)) && (location & (LOCATION_HAND | LOCATION_DECK))) {
+	if((pcard->data.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ)) && (location & (LOCATION_HAND | LOCATION_DECK))
+		&& !((pcard->data.type & TYPE_PENDULUM) && (sequence == 3))) {
 		location = LOCATION_EXTRA;
 		pcard->operation_param = (pcard->operation_param & 0x00ffffff) | (POS_FACEDOWN_DEFENCE << 24);
 	}


### PR DESCRIPTION
因为最新的龙呼相打，需要一个直接把P怪兽表侧表示加入额外卡组的方法，所以我修改了这里。
如此：
Duel.SendtoDeck(Card|Group targets, int player|nil, int seq, int reason)
seq==3
则会把targets里的、可以加入额外卡组的怪兽以表侧表示加入额外卡组，其余的正常洗回卡组。