### PR TITLE
SendPtoExtra

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -322,7 +322,7 @@ static const struct luaL_Reg duellib[] = {
 	{ "SendtoGrave", scriptlib::duel_sendto_grave },
 	{ "SendtoHand", scriptlib::duel_sendto_hand },
 	{ "SendtoDeck", scriptlib::duel_sendto_deck },
-	{ "SendtoExtra", scriptlib::duel_sendto_extra },
+	{ "SendPtoExtra", scriptlib::duel_sendto_extra },
 	{ "GetOperatedGroup", scriptlib::duel_get_operated_group },
 	{ "Summon", scriptlib::duel_summon },
 	{ "SpecialSummonRule", scriptlib::duel_special_summon_rule },

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -455,7 +455,7 @@ int32 scriptlib::duel_sendto_deck(lua_State *L) {
 }
 int32 scriptlib::duel_sendto_extra(lua_State *L) {
 	check_action_permission(L);
-	check_param_count(L, 3);
+	check_param_count(L, 2);
 	card* pcard = 0;
 	group* pgroup = 0;
 	duel* pduel = 0;
@@ -467,14 +467,11 @@ int32 scriptlib::duel_sendto_extra(lua_State *L) {
 		pduel = pgroup->pduel;
 	} else
 		luaL_error(L, "Parameter %d should be \"Card\" or \"Group\".", 1);
-	uint32 playerid = lua_tointeger(L, 2);
-	if(lua_isnil(L, 2) || (playerid != 0 && playerid != 1))
-		playerid = PLAYER_NONE;
-	uint32 reason = lua_tointeger(L, 3);
+	uint32 reason = lua_tointeger(L, 2);
 	if(pcard)
-		pduel->game_field->send_to(pcard, pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, playerid, LOCATION_EXTRA, 0, POS_FACEUP);
+		pduel->game_field->send_to(pcard, pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, PLAYER_NONE, LOCATION_EXTRA, 0, POS_FACEUP);
 	else
-		pduel->game_field->send_to(&(pgroup->container), pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, playerid, LOCATION_EXTRA, 0, POS_FACEUP);
+		pduel->game_field->send_to(&(pgroup->container), pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, PLAYER_NONE, LOCATION_EXTRA, 0, POS_FACEUP);
 	pduel->game_field->core.subunits.begin()->type = PROCESSOR_SENDTO_S;
 	return lua_yield(L, 0);
 }

--- a/operations.cpp
+++ b/operations.cpp
@@ -235,8 +235,12 @@ void field::send_to(card_set* targets, effect* reason_effect, uint32 reason, uin
 	if(destination & LOCATION_ONFIELD)
 		return;
 	uint32 p, pos;
-	for(auto cit = targets->begin(); cit != targets->end(); ++cit) {
-		card* pcard = *cit;
+	for(auto cit = targets->begin(); cit != targets->end(); ) {
+		card* pcard = *cit++;
+		if((destination & LOCATION_EXTRA) && !(pcard->data.type & TYPE_PENDULUM)) {
+			targets->erase(pcard);
+			continue;
+		}
 		pcard->temp.reason = pcard->current.reason;
 		pcard->temp.reason_effect = pcard->current.reason_effect;
 		pcard->temp.reason_player = pcard->current.reason_player;
@@ -247,7 +251,7 @@ void field::send_to(card_set* targets, effect* reason_effect, uint32 reason, uin
 		// send to hand from deck  & playerid not given => send to the hand of controler
 		if(p == PLAYER_NONE && (destination & LOCATION_HAND) && (pcard->current.location & LOCATION_DECK) && pcard->current.controler == reason_player)
 			p = reason_player;
-		if(destination & (LOCATION_GRAVE + LOCATION_REMOVED) || p == PLAYER_NONE)
+		if(destination & (LOCATION_GRAVE + LOCATION_REMOVED + LOCATION_EXTRA) || p == PLAYER_NONE)
 			p = pcard->owner;
 		if(destination != LOCATION_REMOVED)
 			pos = POS_FACEUP;


### PR DESCRIPTION
only send pendulum cards to owner's extra deck
建议只考虑把灵摆卡送去持有者的额外卡组，因为规则上不允许额外卡组出现对方的卡，不允许出现表侧的非灵摆类型的卡。