### PR TITLE
fix leave field redirect

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -3125,7 +3125,7 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 			check_cb = 0;
 			if((dest & LOCATION_GRAVE) && pcard->is_affected_by_effect(EFFECT_TO_GRAVE_REDIRECT_CB))
 				check_cb = 1;
-			if((pcard->current.location & LOCATION_ONFIELD) && !pcard->is_status(STATUS_SUMMON_DISABLED)) {
+			if((pcard->current.location & LOCATION_ONFIELD) && !pcard->is_status(STATUS_SUMMON_DISABLED) && !pcard->is_status(STATUS_ACTIVATE_DISABLED)) {
 				redirect = pcard->leave_field_redirect(pcard->current.reason);
 				redirect_seq = redirect >> 16;
 				redirect &= 0xffff;


### PR DESCRIPTION
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14248&keyword=&tag=-1
If the activation of Spell/Trap cards is negated, EFFECT_LEAVE_FIELD_REDIRECT should not be applied.