### PR TITLE
fix EVENT_BATTLE_DESTROYING/ED

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -3568,7 +3568,7 @@ int32 field::process_battle_command(uint16 step) {
 		card_set ed;
 		if(core.attacker->is_status(STATUS_BATTLE_DESTROYED) 
 				&& !(core.attacker->current.reason & REASON_RULE) 
-				&& !((core.attacker->current.reason & REASON_EFFECT + REASON_DESTROY) == REASON_EFFECT + REASON_DESTROY)) {
+				&& (core.attacker->current.reason & REASON_BATTLE)) {
 			raise_single_event(core.attack_target, 0, EVENT_BATTLE_DESTROYING, 0, core.attacker->current.reason, core.attack_target->current.controler, 0, 1);
 			raise_single_event(core.attacker, 0, EVENT_BATTLE_DESTROYED, 0, core.attacker->current.reason, core.attack_target->current.controler, 0, 0);
 			raise_single_event(core.attacker, 0, EVENT_DESTROYED, 0, core.attacker->current.reason, core.attack_target->current.controler, 0, 0);
@@ -3577,7 +3577,7 @@ int32 field::process_battle_command(uint16 step) {
 		}
 		if(core.attack_target && core.attack_target->is_status(STATUS_BATTLE_DESTROYED) 
 				&& !(core.attack_target->current.reason & REASON_RULE) 
-				&& !((core.attack_target->current.reason & REASON_EFFECT + REASON_DESTROY) == REASON_EFFECT + REASON_DESTROY)) {
+				&& (core.attack_target->current.reason & REASON_BATTLE)) {
 			raise_single_event(core.attacker, 0, EVENT_BATTLE_DESTROYING, 0, core.attack_target->current.reason, core.attacker->current.controler, 0, 0);
 			raise_single_event(core.attack_target, 0, EVENT_BATTLE_DESTROYED, 0, core.attack_target->current.reason, core.attacker->current.controler, 0, 1);
 			raise_single_event(core.attack_target, 0, EVENT_DESTROYED, 0, core.attack_target->current.reason, core.attacker->current.controler, 0, 1);


### PR DESCRIPTION
fix: If Dark Magician of Chao affected by Spellbook of Power battle destroyes and removes the attack target, the effect of Spellbook of Power cannot be activated. 
Because the destroyed attack target has reason REASON_EFFECT(removed by effect)+REASON_BATTLE+REASON_DESTROY

the modification of operations.cpp in https://github.com/Fluorohydride/ygopro/commit/fd5d5bf7272a6e4153a6b87d8610dccacb642bbf is enough.