### PR TITLE
fix

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -2237,6 +2237,17 @@ int32 field::is_player_can_remove(uint8 playerid, card * pcard) {
 	}
 	return TRUE;
 }
+int32 field::is_chain_triggerable(chain pchain) {
+	effect* peffect = pchain.triggering_effect;
+	if(peffect->code == EVENT_FLIP && infos.phase == PHASE_DAMAGE)
+		return TRUE;
+	if(pchain.triggering_location & (LOCATION_DECK | LOCATION_HAND))
+		return TRUE;
+	card* pcard = peffect->handler;
+	if(!(pcard->current.location & (LOCATION_DECK | LOCATION_HAND)) || pcard->is_position(POS_FACEUP))
+		return TRUE;
+	return FALSE;
+}
 int32 field::is_chain_negatable(uint8 chaincount, uint8 naga_check) {
 	effect_set eset;
 	if(chaincount < 0 || chaincount > core.current_chain.size())

--- a/field.cpp
+++ b/field.cpp
@@ -2244,6 +2244,8 @@ int32 field::is_chain_triggerable(chain pchain) {
 	if(pchain.triggering_location & (LOCATION_DECK | LOCATION_HAND))
 		return TRUE;
 	card* pcard = peffect->handler;
+	if((peffect->active_type & TYPE_MONSTER) && !(pcard->get_type() & TYPE_MONSTER))
+		return FALSE;
 	if(!(pcard->current.location & (LOCATION_DECK | LOCATION_HAND)) || pcard->is_position(POS_FACEUP))
 		return TRUE;
 	return FALSE;

--- a/field.h
+++ b/field.h
@@ -411,6 +411,7 @@ public:
 	int32 is_player_can_send_to_hand(uint8 playerid, card* pcard);
 	int32 is_player_can_send_to_deck(uint8 playerid, card* pcard);
 	int32 is_player_can_remove(uint8 playerid, card* pcard);
+	int32 is_chain_triggerable(chain pchain);
 	int32 is_chain_negatable(uint8 chaincount, uint8 naga_check = FALSE);
 	int32 is_chain_disablable(uint8 chaincount, uint8 naga_check = FALSE);
 	int32 check_chain_target(uint8 chaincount, card* pcard);

--- a/processor.cpp
+++ b/processor.cpp
@@ -1610,9 +1610,7 @@ int32 field::process_point_event(int16 step, int32 skip_trigger, int32 skip_free
 			}
 			uint8 tp = clit->triggering_player;
 			bool act = true;
-			if(peffect->is_chainable(tp) && peffect->is_activateable(tp, clit->evt, TRUE)
-			        && (peffect->code == EVENT_FLIP && infos.phase == PHASE_DAMAGE || (clit->triggering_location & 0x3) 
-						|| !(peffect->handler->current.location & 0x3) || peffect->handler->is_position(POS_FACEUP))) {
+			if(peffect->is_chainable(tp) && peffect->is_activateable(tp, clit->evt, TRUE) && is_chain_triggerable(*clit)) {
 				if(peffect->is_flag(EFFECT_FLAG_CHAIN_UNIQUE)) {
 					if(tp == infos.turn_player) {
 						for(auto tpit = core.tpchain.begin(); tpit != core.tpchain.end(); ++tpit) {
@@ -1713,9 +1711,7 @@ int32 field::process_point_event(int16 step, int32 skip_trigger, int32 skip_free
 		effect* peffect = clit->triggering_effect;
 		uint8 tp = clit->triggering_player;
 		bool act = true;
-		if(peffect->is_chainable(tp) && peffect->is_activateable(tp, clit->evt, TRUE)
-		        && (peffect->code == EVENT_FLIP && infos.phase == PHASE_DAMAGE || (clit->triggering_location & 0x3)
-		            || !(peffect->handler->current.location & 0x3) || peffect->handler->is_position(POS_FACEUP))) {
+		if(peffect->is_chainable(tp) && peffect->is_activateable(tp, clit->evt, TRUE) && is_chain_triggerable(*clit)) {
 			if(!(peffect->is_flag(EFFECT_FLAG_FIELD_ONLY)) && clit->triggering_location == LOCATION_HAND
 			        && (((peffect->type & EFFECT_TYPE_SINGLE) && !(peffect->is_flag(EFFECT_FLAG_SINGLE_RANGE)) && peffect->handler->is_has_relation(peffect))
 			            || (peffect->range & LOCATION_HAND))) {
@@ -1774,9 +1770,7 @@ int32 field::process_point_event(int16 step, int32 skip_trigger, int32 skip_free
 			if(pcard != peffect->handler)
 				continue;
 			bool act = true;
-			if(peffect->is_chainable(tp) && peffect->is_activateable(tp, clit->evt, TRUE)
-			        && (peffect->code == EVENT_FLIP && infos.phase == PHASE_DAMAGE || (clit->triggering_location & 0x3)
-			            || !(peffect->handler->current.location & 0x3) || peffect->handler->is_position(POS_FACEUP))) {
+			if(peffect->is_chainable(tp) && peffect->is_activateable(tp, clit->evt, TRUE) && is_chain_triggerable(*clit)) {
 				if(!(peffect->is_flag(EFFECT_FLAG_FIELD_ONLY)) && clit->triggering_location == LOCATION_HAND
 				        && (((peffect->type & EFFECT_TYPE_SINGLE) && !(peffect->is_flag(EFFECT_FLAG_SINGLE_RANGE)) && peffect->handler->is_has_relation(peffect))
 				            || (peffect->range & LOCATION_HAND))) {


### PR DESCRIPTION
Trigger effect of monster cannot be activated when that monster is treated as a spell card.
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13238&keyword=&tag=-1
その場合、特殊召喚された「月華竜 ブラック・ローズ」は装備カード扱いとなり、モンスターカードとして扱われない状態となりますので、一連のチェーン処理後に、「月華竜 ブラック・ローズ」の『このカードが特殊召喚に成功した時、または相手フィールド上にレベル５以上のモンスターが特殊召喚された時に発動する。相手フィールド上の特殊召喚されたモンスター１体を選択して持ち主の手札に戻す』効果が発動する事はありません。
http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=16633&keyword=&tag=-1
その際に、『その後、破壊したそのカードを自分のPゾーンに置く事ができる』効果を適用した場合には、その「ブンボーグ００６」は魔法カードの扱いとなっていますので、「ブンボーグ００６」のモンスター効果を発動する事はできません。