### PR TITLE
fix returning of trap monster

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -3623,7 +3623,7 @@ int32 field::move_to_field(uint16 step, card * target, uint32 enable, uint32 ret
 			uint32 flag;
 			uint32 lreason = (target->current.location == LOCATION_MZONE) ? LOCATION_REASON_CONTROL : LOCATION_REASON_TOFIELD;
 			uint32 ct = get_useable_count(playerid, location, move_player, lreason, &flag);
-			if((ret == 1) && (ct <= 0 || !(target->data.type & TYPE_MONSTER))) {
+			if((ret == 1) && (ct <= 0)) {
 				core.units.begin()->step = 3;
 				send_to(target, core.reason_effect, REASON_EFFECT, core.reason_player, PLAYER_NONE, LOCATION_GRAVE, 0, 0);
 				return FALSE;
@@ -3734,6 +3734,8 @@ int32 field::move_to_field(uint16 step, card * target, uint32 enable, uint32 ret
 			target->unequip();
 		if(enable || ((ret == 1) && target->is_position(POS_FACEUP)))
 			target->enable_field_effect(TRUE);
+		if(ret == 1 && target->current.location == LOCATION_MZONE && !(target->data.type & TYPE_MONSTER))
+			send_to(target, 0, REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, 0);
 		adjust_disable_check_list();
 		return FALSE;
 	}


### PR DESCRIPTION
fix https://github.com/Fluorohydride/ygopro/issues/1640
The returning of trap monsters to field should be treated as follows:
first return to monster zone,
since it is not a monster card now, send it to grave immediately

see http://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=11586&keyword=&tag=-1
>また、「銀河眼の光子竜」が「アポピスの化神」と戦闘する際に効果を発動した場合、バトルフェイズ終了時にはどちらともフィールド上に戻りますが、フィールド上へ戻ってきた「アポピスの化神」は罠カードとしての扱いのみになり、ただちに墓地へ送られます。