### PR TITLE
Update field.cpp

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -1790,7 +1790,7 @@ int32 field::check_synchro_material(card* pcard, int32 findex1, int32 findex2, i
 	return FALSE;
 }
 int32 field::check_tuner_material(card* pcard, card* tuner, int32 findex1, int32 findex2, int32 min, int32 max, card* smat, group* mg) {
-	if(tuner && tuner->is_position(POS_FACEUP) && (tuner->get_type() & TYPE_TUNER) && tuner->is_can_be_synchro_material(pcard)) {
+	if(tuner && tuner->is_position(POS_FACEUP) && tuner->is_can_be_synchro_material(pcard)) {
 		effect* pcheck = tuner->is_affected_by_effect(EFFECT_SYNCHRO_CHECK);
 		if(pcheck)
 			pcheck->get_value(tuner);


### PR DESCRIPTION
Recently a new Synchro monster comes up with this effect: 
When you Synchro summon this card, a Pendulum summoned Pendulum monster on your side of field can be used as Tuner. 