### PR TITLE
revert 'remove EFFECT_INDESTRUCTABLE'

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2333,6 +2333,8 @@ int32 card::is_destructable() {
 		return FALSE;
 	if(current.location & (LOCATION_GRAVE + LOCATION_REMOVED))
 		return FALSE;
+	if(is_affected_by_effect(EFFECT_INDESTRUCTABLE))
+		return FALSE;
 	return TRUE;
 }
 int32 card::is_destructable_by_battle(card * pcard) {


### PR DESCRIPTION
https://github.com/Fluorohydride/ygopro-pre-script/commit/2a1b259419ecfd7b5e413d3be6ec8081cb943a0d
Block Dragon cannot use `EFFECT_INDESTRUCTABLE`.
So, during the End Phase, if Block Dragon is on the field, Koa'ki Meiru destroy.