### PR TITLE
fix unique on field

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -1491,7 +1491,7 @@ effect* field::check_unique_onfield(card* pcard, uint8 controler, uint8 location
 	for(auto iter = core.unique_cards[controler].begin(); iter != core.unique_cards[controler].end(); ++iter) {
 		card* ucard = *iter;
 		if((ucard != pcard) && ucard->is_position(POS_FACEUP) && ucard->get_status(STATUS_EFFECT_ENABLED)
-			&& (ucard->unique_code == pcard->unique_code) && (ucard->unique_location & location)
+			&& (ucard->unique_code == pcard->unique_code) && (ucard->unique_location & location) && (ucard->get_code() == ucard->unique_code)
 			&& (!(pcard->current.location & ucard->unique_location) || pcard->is_position(POS_FACEDOWN)
 				|| ((!pcard->get_status(STATUS_DISABLED | STATUS_FORBIDDEN) || !ucard->get_status(STATUS_DISABLED | STATUS_FORBIDDEN)) && ucard->unique_uid < pcard->unique_uid)))
 			return pcard->unique_effect;


### PR DESCRIPTION
if the name of a monster with set unique on field changes, the unique on field won't be applied until the monster has the name changed:
Q. 
武神－ミカヅチ 
私は、フィールドや使用上のこのカードを持っている場合 ヒーロー・マスク 
私は別のものを召喚することはできますか？もしそうであればエンドフェイズには何が起こりますか？ 
A. 
自分フィールド上の「武神－ミカヅチ」が、「ヒーロー・マスク」の効果でカード名が「E・HERO」と名のついたモンスターとして扱われている場合、自分は2体目の「武神－ミカヅチ」を召喚できます。 
なお、「ヒーロー・マスク」の効果が適用されなくなり、1体目の「武神－ミカヅチ」のカード名が「武神－ミカヅチ」に戻った際、1体目の「武神－ミカヅチ」は破壊されます。
Q.
God of military arts - Mikadzuchi
If I have this card on the field and use Hero mask
I will be able to summon another one? What happens in the end phase and if so?
A.
"God of military arts - Mikadzuchi" on your field, if the effect in the card name of "Hero Mask" has been treated as a monster with a name as "E · HERO", yourself of the two bodies first "god of military arts - Mikadzuchi you can summon. "
It should be noted, will not be applied, the effect of "Hero Mask", of one body first "god of military arts - Mikadzuchi" - when you went back to, of one body first "god of military arts - Mikadzuchi" card name of "Mikadzuchi god of military arts" will be destroyed .