### PR TITLE
Update interpreter with string literal for sprintf

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -645,7 +645,7 @@ int32 interpreter::load_script(char* script_name) {
 	no_action++;
 	error = luaL_loadbuffer(current_state, (const char*) buffer, len, (const char*) script_name) || lua_pcall(current_state, 0, 0, 0);
 	if (error) {
-		sprintf(pduel->strbuffer, lua_tostring(current_state, -1));
+		sprintf(pduel->strbuffer, "%s", lua_tostring(current_state, -1));
 		handle_message(pduel, 1);
 		lua_pop(current_state, 1);
 		no_action--;
@@ -780,7 +780,7 @@ int32 interpreter::call_function(int32 f, uint32 param_count, uint32 ret_count) 
 	call_depth++;
 	push_param(current_state);
 	if (lua_pcall(current_state, param_count, ret_count, 0)) {
-		sprintf(pduel->strbuffer, lua_tostring(current_state, -1));
+		sprintf(pduel->strbuffer, "%s", lua_tostring(current_state, -1));
 		handle_message(pduel, 1);
 		lua_pop(current_state, 1);
 		no_action--;
@@ -820,7 +820,7 @@ int32 interpreter::call_card_function(card* pcard, char* f, uint32 param_count, 
 	lua_remove(current_state, -2);
 	push_param(current_state);
 	if (lua_pcall(current_state, param_count, ret_count, 0)) {
-		sprintf(pduel->strbuffer, lua_tostring(current_state, -1));
+		sprintf(pduel->strbuffer, "%s", lua_tostring(current_state, -1));
 		handle_message(pduel, 1);
 		lua_pop(current_state, 1);
 		no_action--;
@@ -860,7 +860,7 @@ int32 interpreter::call_code_function(uint32 code, char* f, uint32 param_count, 
 	call_depth++;
 	push_param(current_state);
 	if (lua_pcall(current_state, param_count, ret_count, 0)) {
-		sprintf(pduel->strbuffer, lua_tostring(current_state, -1));
+		sprintf(pduel->strbuffer, "%s", lua_tostring(current_state, -1));
 		handle_message(pduel, 1);
 		lua_pop(current_state, 1);
 		no_action--;
@@ -917,7 +917,7 @@ int32 interpreter::check_matching(card* pcard, int32 findex, int32 extraargs) {
 	for(int32 i = 0; i < extraargs; ++i)
 		lua_pushvalue(current_state, (int32)(-extraargs - 2));
 	if (lua_pcall(current_state, 1 + extraargs, 1, 0)) {
-		sprintf(pduel->strbuffer, lua_tostring(current_state, -1));
+		sprintf(pduel->strbuffer, "%s", lua_tostring(current_state, -1));
 		handle_message(pduel, 1);
 		lua_pop(current_state, 1);
 		no_action--;
@@ -949,7 +949,7 @@ int32 interpreter::get_operation_value(card* pcard, int32 findex, int32 extraarg
 	for(int32 i = 0; i < extraargs; ++i)
 		lua_pushvalue(current_state, (int32)(-extraargs - 2));
 	if (lua_pcall(current_state, 1 + extraargs, 1, 0)) {
-		sprintf(pduel->strbuffer, lua_tostring(current_state, -1));
+		sprintf(pduel->strbuffer, "%s", lua_tostring(current_state, -1));
 		handle_message(pduel, 1);
 		lua_pop(current_state, 1);
 		no_action--;
@@ -1059,7 +1059,7 @@ int32 interpreter::call_coroutine(int32 f, uint32 param_count, uint32 * yield_va
 		return COROUTINE_YIELD;
 	} else {
 		coroutines.erase(f);
-		sprintf(pduel->strbuffer, lua_tostring(rthread, -1));
+		sprintf(pduel->strbuffer, "%s", lua_tostring(rthread, -1));
 		handle_message(pduel, 1);
 		lua_pop(rthread, 1);
 		current_state = lua_state;


### PR DESCRIPTION
adding "%s" as string literal does fix this warnings:
```warning: format not a string literal and no format arguments [-Wformat-security]```

this one is not fixed yet, i don't know if it might break something on some OS (probably 32bit?)
```warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 4 has type ‘std::__cxx11::list<std::pair<void*, unsigned int> >::size_type {aka long unsigned int}’ [-Wformat=]```