### PR TITLE
Add Card.SetEntityCode

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2932,3 +2932,10 @@ int32 card::is_can_be_xyz_material(card* scard) {
 			return FALSE;
 	return TRUE;
 }
+uint32 card::set_entity_code(uint32 entity_code) {
+	card_data dat;
+	::read_card(entity_code, &dat);
+	uint32 code = data.code;
+	data = dat;
+	return code;
+}

--- a/card.h
+++ b/card.h
@@ -185,6 +185,7 @@ public:
 	void set_status(uint32 status, int32 enabled);
 	int32 get_status(uint32 status);
 	int32 is_status(uint32 status);
+	uint32 set_entity_code(uint32 entity_code);
 
 	void equip(card *target, uint32 send_msg = TRUE);
 	void unequip();

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -221,6 +221,7 @@ static const struct luaL_Reg cardlib[] = {
 	{ "ResetNegateEffect", scriptlib::card_reset_negate_effect },
 	{ "AssumeProperty", scriptlib::card_assume_prop },
 	{ "SetSPSummonOnce", scriptlib::card_set_spsummon_once },
+	{ "SetEntityCode", scriptlib::card_set_entity_code },
 	{ NULL, NULL }
 };
 

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2339,3 +2339,11 @@ int32 scriptlib::card_set_spsummon_once(lua_State *L) {
 	pcard->pduel->game_field->core.global_flag |= GLOBALFLAG_SPSUMMON_ONCE;
 	return 0;
 }
+int32 scriptlib::card_set_entity_code(lua_State *L) {
+	check_param_count(L, 2);
+	check_param(L, PARAM_TYPE_CARD, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
+	uint32 trace = lua_tointeger(L, 2);
+	lua_pushinteger(L, pcard->set_entity_code(trace));
+	return 1;
+}

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -223,6 +223,7 @@ public:
 	static int32 card_reset_negate_effect(lua_State *L);
 	static int32 card_assume_prop(lua_State *L);
 	static int32 card_set_spsummon_once(lua_State *L);
+	static int32 card_set_entity_code(lua_State *L);
 	
 	//Effect functions
 	static int32 effect_new(lua_State *L);


### PR DESCRIPTION
```
c:SetEntityCode(code)
```

This will **completely** change "c" to another card named "code". That is, it's image, original code, text attack, text defense, text attribute, text race and setnames are changed to "code"'s.

Note that this function doesn't overwrite "c"'s effect to "code"'s. That is, if you change a "Blue-Eyes Alternative White Dragon" to a "Dark Eradicator Warlock", this card will still have effects of "Blue-Eyes Alternative White Dragon", not effects of "Dark Eradicator Warlock". To switch it's effect, you may have to:

```
c:SetEntityCode(29436665)
c:ResetEffect(38517737,RESET_CARD)
c29436665.initial_effect(c)
```

However, if you just wanted to switch "Blue-Eyes White Dragon"'s image to another, you will not have any problems.
