### PR TITLE
change priority of loading scripts

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -680,9 +680,9 @@ int32 interpreter::load_card_script(uint32 code) {
 		lua_pushvalue(current_state, -2);
 		lua_rawset(current_state, -3);
 		//load extra scripts
-		sprintf(script_name, "./script/c%d.lua", code);
+		sprintf(script_name, "./expansions/script/c%d.lua", code);
 		if (!load_script(script_name)) {
-			sprintf(script_name, "./expansions/script/c%d.lua", code);
+			sprintf(script_name, "./script/c%d.lua", code);
 	 		if (!load_script(script_name)) {
 	 			return OPERATION_FAIL;
  			}


### PR DESCRIPTION
expansions中的脚本应优先读取，以便扩展包实现对OCG效果的修改
例：暗黑圣域、真竜皇V.F.D.