### PR TITLE
Added Duel.IsDuelType()

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -483,6 +483,7 @@ static const struct luaL_Reg duellib[] = {
 	{ "GetDiceResult", scriptlib::duel_get_dice_result },
 	{ "SetCoinResult", scriptlib::duel_set_coin_result },
 	{ "SetDiceResult", scriptlib::duel_set_dice_result },
+	{ "IsDuelType", scriptlib::duel_is_duel_type },
 	{ "IsPlayerAffectedByEffect", scriptlib::duel_is_player_affected_by_effect },
 	{ "IsPlayerCanDraw", scriptlib::duel_is_player_can_draw },
 	{ "IsPlayerCanDiscardDeck", scriptlib::duel_is_player_can_discard_deck },

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2965,6 +2965,16 @@ int32 scriptlib::duel_set_dice_result(lua_State * L) {
 	}
 	return 0;
 }
+int32 scriptlib::duel_is_duel_type(lua_State *L) {
+	check_param_count(L, 1);
+	duel* pduel = interpreter::get_duel_info(L);
+	int32 duel_type = lua_tointeger(L, 1);
+	if (pduel->game_field->core.duel_options & duel_type)
+		lua_pushboolean(L, TRUE);
+	else
+		lua_pushboolean(L, FALSE);
+	return 1;
+}
 int32 scriptlib::duel_is_player_affected_by_effect(lua_State *L) {
 	check_param_count(L, 2);
 	duel* pduel = interpreter::get_duel_info(L);

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -483,6 +483,7 @@ public:
 	static int32 duel_set_coin_result(lua_State *L);
 	static int32 duel_set_dice_result(lua_State *L);
 
+	static int32 duel_is_duel_type(lua_State *L);
 	static int32 duel_is_player_affected_by_effect(lua_State *L);
 	static int32 duel_is_player_can_draw(lua_State *L);
 	static int32 duel_is_player_can_discard_deck(lua_State *L);


### PR DESCRIPTION
I made this function a while ago, and i think now it would be needed, in case of adding the actual duel rules and field as an obsolete ruling and making backward compatible scripts