### PR TITLE
fix strange compile problem

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -52,7 +52,7 @@ void card::attacker_map::addcard(card* pcard) {
 	pr.first->second.second++;
 }
 card::card(duel* pd) {
-	scrtype = 1;
+	scrtype = ScriptType::Card;
 	ref_handle = 0;
 	pduel = pd;
 	owner = PLAYER_NONE;

--- a/card.h
+++ b/card.h
@@ -79,7 +79,7 @@ struct query_cache {
 	uint32 rscale;
 };
 
-class card {
+class card : public ScriptClaxx {
 public:
 	struct effect_relation_hash {
 		inline std::size_t operator()(const std::pair<effect*, uint16>& v) const {
@@ -98,8 +98,6 @@ public:
 	public:
 		void addcard(card* pcard);
 	};
-	int32 scrtype;
-	int32 ref_handle;
 	duel* pduel;
 	card_data data;
 	card_state previous;

--- a/common.h
+++ b/common.h
@@ -42,4 +42,18 @@ struct card_sort {
 	bool operator()(void* const & c1, void* const & c2) const;
 };
 
+enum class ScriptType
+{
+	Card = 1,
+	Group = 2,
+	Effect = 3,
+};
+
+class ScriptClaxx
+{
+public:
+	ScriptType scrtype;
+	int32 ref_handle;
+};
+
 #endif /* COMMON_H_ */

--- a/effect.cpp
+++ b/effect.cpp
@@ -15,7 +15,7 @@ bool effect_sort_id(const effect* e1, const effect* e2) {
 	return e1->id < e2->id;
 };
 effect::effect(duel* pd) {
-	scrtype = 3;
+	scrtype = ScriptType::Effect;
 	ref_handle = 0;
 	pduel = pd;
 	owner = 0;

--- a/effect.h
+++ b/effect.h
@@ -25,10 +25,8 @@ struct effect_set_v;
 enum effect_flag : uint32;
 enum effect_flag2 : uint32;
 
-class effect {
+class effect : public ScriptClaxx {
 public:
-	int32 scrtype;
-	int32 ref_handle;
 	duel* pduel;
 	card* owner;
 	card* handler;

--- a/group.cpp
+++ b/group.cpp
@@ -10,20 +10,20 @@
 #include "duel.h"
 
 group::group(duel* pd) {
-	scrtype = 2;
+	scrtype = ScriptType::Group;
 	ref_handle = 0;
 	pduel = pd;
 	is_readonly = FALSE;
 }
 group::group(duel* pd, card* pcard) {
 	container.insert(pcard);
-	scrtype = 2;
+	scrtype = ScriptType::Group;
 	ref_handle = 0;
 	pduel = pd;
 	is_readonly = FALSE;
 }
 group::group(duel* pd, const card_set& cset): container(cset) {
-	scrtype = 2;
+	scrtype = ScriptType::Group;
 	ref_handle = 0;
 	pduel = pd;
 	is_readonly = FALSE;

--- a/group.h
+++ b/group.h
@@ -15,11 +15,9 @@
 class card;
 class duel;
 
-class group {
+class group : public ScriptClaxx {
 public:
 	typedef std::set<card*, card_sort> card_set;
-	int32 scrtype;
-	int32 ref_handle;
 	duel* pduel;
 	card_set container;
 	card_set::iterator it;

--- a/scriptlib.cpp
+++ b/scriptlib.cpp
@@ -8,12 +8,12 @@
 #include "duel.h"
 
 int32 scriptlib::check_param(lua_State* L, int32 param_type, int32 index, int32 retfalse) {
-	int32 result;
+	ScriptType result;
 	switch (param_type) {
 	case PARAM_TYPE_CARD:
 		if (lua_isuserdata(L, index)) {
-			result = **(int32**)lua_touserdata(L, index);
-			if(result == 1)
+			result = (*(ScriptClaxx**)lua_touserdata(L, index))->scrtype;
+			if(result == ScriptType::Card)
 				return TRUE;
 		}
 		if(retfalse)
@@ -22,8 +22,8 @@ int32 scriptlib::check_param(lua_State* L, int32 param_type, int32 index, int32 
 		break;
 	case PARAM_TYPE_GROUP:
 		if (lua_isuserdata(L, index)) {
-			result = **(int32**)lua_touserdata(L, index);
-			if(result == 2)
+			result = (*(ScriptClaxx**)lua_touserdata(L, index))->scrtype;
+			if(result == ScriptType::Group)
 				return TRUE;
 		}
 		if(retfalse)
@@ -32,8 +32,8 @@ int32 scriptlib::check_param(lua_State* L, int32 param_type, int32 index, int32 
 		break;
 	case PARAM_TYPE_EFFECT:
 		if (lua_isuserdata(L, index)) {
-			result = **(int32**)lua_touserdata(L, index);
-			if(result == 3)
+			result = (*(ScriptClaxx**)lua_touserdata(L, index))->scrtype;
+			if(result == ScriptType::Effect)
 				return TRUE;
 		}
 		if(retfalse)


### PR DESCRIPTION
编译器可能会在类成员变量的前后插入无用的字节，因此最好不要直接用偏移量访问类成员变量。