### PR TITLE
added EFFECT_FORCE_MZONE

### DIFF
--- a/effect.h
+++ b/effect.h
@@ -381,6 +381,7 @@ inline effect_flag operator|(effect_flag flag1, effect_flag flag2)
 #define EFFECT_USE_EXTRA_SZONE			262
 #define EFFECT_MAX_MZONE				263
 #define EFFECT_MAX_SZONE				264
+#define EFFECT_FORCE_MZONE				265
 #define EFFECT_HAND_LIMIT				270
 #define EFFECT_DRAW_COUNT				271
 #define EFFECT_SPIRIT_DONOT_RETURN		280

--- a/field.cpp
+++ b/field.cpp
@@ -587,12 +587,12 @@ int32 field::get_useable_count(uint8 playerid, uint8 location, uint8 uplayer, ui
 int32 field::get_tofield_count(uint8 playerid, uint8 location, uint32 zone, uint32* list, uint32 reason, uint32 uplayer) {
 	if (location != LOCATION_MZONE && location != LOCATION_SZONE)
 		return 0;
-	uint32 flag = player[playerid].disabled_location |  player[playerid].used_location;
+	uint32 flag = player[playerid].disabled_location | player[playerid].used_location;
 	effect_set eset;
 	uint32 value;
 	if(uplayer == 2)
 		uplayer = playerid;
-	if((reason & (LOCATION_REASON_TOFIELD | LOCATION_REASON_CONTROL) != 0) && location == LOCATION_MZONE)
+	if((reason & (LOCATION_REASON_TOFIELD) != 0) && location == LOCATION_MZONE)
 		filter_player_effect(uplayer, EFFECT_FORCE_MZONE, &eset);
 	for(int32 i = 0; i < eset.size(); ++i) {
 		value = eset[i]->get_value();

--- a/field.cpp
+++ b/field.cpp
@@ -569,12 +569,12 @@ int32 field::get_useable_count(card* pcard, uint8 playerid, uint8 location, uint
 }
 int32 field::get_spsummonable_count(card* pcard, uint8 playerid, uint32 zone, uint32* list) {
 	if(core.duel_rule >= 4 && pcard->current.location == LOCATION_EXTRA)
-		return get_spsummonable_count_fromex(pcard, playerid, zone, list);
+		return get_spsummonable_count_fromex(pcard, playerid, playerid, zone, list);
 	else
 		return get_tofield_count(playerid, LOCATION_MZONE, zone, list);
 }
 int32 field::get_useable_count(uint8 playerid, uint8 location, uint8 uplayer, uint32 reason, uint32 zone, uint32* list, uint8 neglect_used) {
-	int32 count = get_tofield_count(playerid, location, zone, list, neglect_used, reason);
+	int32 count = get_tofield_count(playerid, location, zone, list, neglect_used, reason, uplayer);
 	int32 limit;
 	if(location == LOCATION_MZONE)
 		limit = get_mzone_limit(playerid, uplayer, LOCATION_REASON_TOFIELD);
@@ -584,18 +584,25 @@ int32 field::get_useable_count(uint8 playerid, uint8 location, uint8 uplayer, ui
 		count = limit;
 	return count;
 }
-int32 field::get_tofield_count(uint8 playerid, uint8 location, uint32 zone, uint32* list, uint8 neglect_used, uint32 reason) {
+int32 field::get_tofield_count(uint8 playerid, uint8 location, uint32 zone, uint32* list, uint8 neglect_used, uint32 reason, uint32 uplayer) {
 	if (location != LOCATION_MZONE && location != LOCATION_SZONE)
 		return 0;
 	uint32 flag = player[playerid].disabled_location | (neglect_used ? 0 : player[playerid].used_location);
 	effect_set eset;
 	uint32 value;
+	if(uplayer == 2)
+		uplayer = playerid;
 	if((reason & (LOCATION_REASON_TOFIELD | LOCATION_REASON_CONTROL) != 0) && location == LOCATION_MZONE)
-		filter_player_effect(playerid, EFFECT_FORCE_MZONE, &eset);
-	for (int32 i = 0; i < eset.size(); ++i) {
+		filter_player_effect(uplayer, EFFECT_FORCE_MZONE, &eset);
+	for(int32 i = 0; i < eset.size(); ++i) {
 		value = eset[i]->get_value();
-		if((flag & value)==0)
-			flag |= ~(value >> 16 * playerid) & 0xff7f;
+		uint32 flag1 = ~(value) & 0xff7f;
+		uint32 flag2 = ~(value >> 16) & 0xff7f;
+		if ((flag1 & flag) != flag1 && (uplayer == playerid)) {
+			flag |= flag1;
+		} else if ((flag2 & flag) != flag2 && (uplayer != playerid)) {
+			flag |= flag2;
+		}
 	}
 	eset.clear();
 	if (location == LOCATION_MZONE)
@@ -610,21 +617,26 @@ int32 field::get_tofield_count(uint8 playerid, uint8 location, uint32 zone, uint
 	return count;
 }
 int32 field::get_useable_count_fromex(card* pcard, uint8 playerid, uint8 uplayer, uint32 zone, uint32* list) {
-	int32 count = get_spsummonable_count_fromex(pcard, playerid, zone, list);
+	int32 count = get_spsummonable_count_fromex(pcard, playerid, uplayer, zone, list);
 	int32 limit = get_mzone_limit(playerid, uplayer, LOCATION_REASON_TOFIELD);
 	if(count > limit)
 		count = limit;
 	return count;
 }
-int32 field::get_spsummonable_count_fromex(card* pcard, uint8 playerid, uint32 zone, uint32* list) {
+int32 field::get_spsummonable_count_fromex(card* pcard, uint8 playerid, uint8 uplayer, uint32 zone, uint32* list) {
 	uint32 flag = player[playerid].disabled_location | player[playerid].used_location;
 	effect_set eset;
 	uint32 value;
-	filter_player_effect(playerid, EFFECT_FORCE_MZONE, &eset);
-	for (int32 i = 0; i < eset.size(); ++i) {
+	filter_player_effect(uplayer, EFFECT_FORCE_MZONE, &eset);
+	for(int32 i = 0; i < eset.size(); ++i) {
 		value = eset[i]->get_value();
-		if((flag & value)==0)
-			flag |= ~(value >> 16 * playerid) & 0xff7f;
+		uint32 flag1 = ~(value) & 0xff7f;
+		uint32 flag2 = ~(value >> 16) & 0xff7f;
+		if ((flag1 & flag) != flag1 && (uplayer == playerid)) {
+			flag |= flag1;
+		} else if ((flag2 & flag) != flag2 && (uplayer != playerid)) {
+			flag |= flag2;
+		}
 	}
 	eset.clear();
 	uint32 linked_zone = get_linked_zone(playerid) | (1u << 5) | (1u << 6);

--- a/field.h
+++ b/field.h
@@ -356,7 +356,7 @@ public:
 	int32 get_useable_count(card* pcard, uint8 playerid, uint8 location, uint8 uplayer, uint32 reason, uint32 zone = 0xff, uint32* list = 0, uint8 neglect_used = 0);
 	int32 get_spsummonable_count(card* pcard, uint8 playerid, uint32 zone = 0xff, uint32* list = 0);
 	int32 get_useable_count(uint8 playerid, uint8 location, uint8 uplayer, uint32 reason, uint32 zone = 0xff, uint32* list = 0, uint8 neglect_used = 0);
-	int32 get_tofield_count(uint8 playerid, uint8 location, uint32 zone = 0xff, uint32* list = 0, uint8 neglect_used = 0);
+	int32 get_tofield_count(uint8 playerid, uint8 location, uint32 zone = 0xff, uint32* list = 0, uint8 neglect_used = 0, uint32 reason = 0x1);
 	int32 get_useable_count_fromex(card* pcard, uint8 playerid, uint8 uplayer, uint32 zone = 0xff, uint32* list = 0);
 	int32 get_spsummonable_count_fromex(card* pcard, uint8 playerid, uint32 zone = 0xff, uint32* list = 0);
 	int32 get_mzone_limit(uint8 playerid, uint8 uplayer, uint32 reason);
@@ -589,6 +589,7 @@ public:
 //Location Use Reason
 #define LOCATION_REASON_TOFIELD	0x1
 #define LOCATION_REASON_CONTROL	0x2
+#define LOCATION_REASON_COUNT	0x4
 //Chain Info
 #define CHAIN_DISABLE_ACTIVATE	0x01
 #define CHAIN_DISABLE_EFFECT	0x02

--- a/field.h
+++ b/field.h
@@ -356,9 +356,9 @@ public:
 	int32 get_useable_count(card* pcard, uint8 playerid, uint8 location, uint8 uplayer, uint32 reason, uint32 zone = 0xff, uint32* list = 0, uint8 neglect_used = 0);
 	int32 get_spsummonable_count(card* pcard, uint8 playerid, uint32 zone = 0xff, uint32* list = 0);
 	int32 get_useable_count(uint8 playerid, uint8 location, uint8 uplayer, uint32 reason, uint32 zone = 0xff, uint32* list = 0, uint8 neglect_used = 0);
-	int32 get_tofield_count(uint8 playerid, uint8 location, uint32 zone = 0xff, uint32* list = 0, uint8 neglect_used = 0, uint32 reason = 0x1);
+	int32 get_tofield_count(uint8 playerid, uint8 location, uint32 zone = 0xff, uint32* list = 0, uint8 neglect_used = 0, uint32 reason = 0x1, uint32 uplayer = 2);
 	int32 get_useable_count_fromex(card* pcard, uint8 playerid, uint8 uplayer, uint32 zone = 0xff, uint32* list = 0);
-	int32 get_spsummonable_count_fromex(card* pcard, uint8 playerid, uint32 zone = 0xff, uint32* list = 0);
+	int32 get_spsummonable_count_fromex(card* pcard, uint8 playerid, uint8 uplayer, uint32 zone = 0xff, uint32* list = 0);
 	int32 get_mzone_limit(uint8 playerid, uint8 uplayer, uint32 reason);
 	int32 get_szone_limit(uint8 playerid, uint8 uplayer, uint32 reason);
 	uint32 get_linked_zone(int32 playerid);

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1550,7 +1550,7 @@ int32 scriptlib::duel_get_location_count(lua_State *L) {
 	duel* pduel = interpreter::get_duel_info(L);
 	uint32 uplayer = pduel->game_field->core.reason_player;
 	uint32 reason = LOCATION_REASON_TOFIELD;
-	if(lua_gettop(L) >= 3)
+	if(lua_gettop(L) >= 3 && !lua_isnil(L,3))
 		uplayer = lua_tointeger(L, 3);
 	if(lua_gettop(L) >= 4)
 		reason = lua_tointeger(L, 4);

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1629,7 +1629,7 @@ int32 scriptlib::duel_get_usable_mzone_count(lua_State *L) {
 	if(pduel->game_field->core.duel_rule >= 4) {
 		uint32 flag1, flag2;
 		int32 ct1 = pduel->game_field->get_tofield_count(playerid, LOCATION_MZONE, zone, &flag1);
-		int32 ct2 = pduel->game_field->get_spsummonable_count_fromex(0, playerid, zone, &flag2);
+		int32 ct2 = pduel->game_field->get_spsummonable_count_fromex(0, playerid, uplayer, zone, &flag2);
 		int32 ct3 = field::field_used_count[~(flag1 | flag2) & 0x1f];
 		int32 count = ct1 + ct2 - ct3;
 		int32 limit = pduel->game_field->get_mzone_limit(playerid, uplayer, LOCATION_REASON_TOFIELD);

--- a/operations.cpp
+++ b/operations.cpp
@@ -2723,7 +2723,7 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		if(core.duel_rule >= 4) {
 			uint32 flag1, flag2;
 			int32 ct1 = get_tofield_count(sumplayer, LOCATION_MZONE, zone, &flag1);
-			int32 ct2 = get_spsummonable_count_fromex(pcard, sumplayer, zone, &flag2);
+			int32 ct2 = get_spsummonable_count_fromex(pcard, sumplayer, sumplayer, zone, &flag2);
 			for(auto it = pgroup->it; it != pgroup->container.end(); ++it) {
 				if((*it)->current.location != LOCATION_EXTRA)
 					ct1--;


### PR DESCRIPTION
This effect forces the player to use the zones put as value for a summon/set. This will require to change cards that use `Duel.GetLocationCount` for reasons different from control change and movetofield, like Ground Collapse to use `Duel.GetLocationCount(tp,LOCATION_MZONE,nil,LOCATION_REASON_COUNT)`