### PR TITLE
fix for duel win

### DIFF
--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1007,6 +1007,9 @@ int32 scriptlib::duel_win(lua_State *L) {
 	if(pduel->game_field->core.win_player == 5) {
 		pduel->game_field->core.win_player = playerid;
 		pduel->game_field->core.win_reason = reason;
+	} else if((pduel->game_field->core.win_player == 0 && playerid == 1) || (pduel->game_field->core.win_player == 1 && playerid == 0)) {
+		pduel->game_field->core.win_player = 2;
+		pduel->game_field->core.win_reason = reason;
 	}
 	return 0;
 }


### PR DESCRIPTION
if two duel win are made at same time, only the first duel win takes effect, example:
relay soul and exodia: both are executed but relay soul is done first, so the game simply understand relay soul and disregard exodia, giving a loss by relay soul effect when it would be a draw.