### PR TITLE
add metamethod to get the length of Group

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -331,6 +331,7 @@ static const struct luaL_Reg grouplib[] = {
 	{ "GetNext", scriptlib::group_get_next },
 	{ "GetFirst", scriptlib::group_get_first },
 	{ "GetCount", scriptlib::group_get_count },
+	{ "__len", scriptlib::group_get_count },
 	{ "ForEach", scriptlib::group_for_each },
 	{ "Filter", scriptlib::group_filter },
 	{ "FilterCount", scriptlib::group_filter_count },


### PR DESCRIPTION
so now we could use #g instead of g:GetCount() to simplify the scripts