### PR TITLE
update to lua 5.3

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -596,8 +596,6 @@ interpreter::interpreter(duel* pd): coroutines(256) {
 	lua_setglobal(lua_state, "io");
 	lua_pushnil(lua_state);
 	lua_setglobal(lua_state, "os");
-	lua_getglobal(lua_state, "bit32");
-	lua_setglobal(lua_state, "bit");
 	//open all libs
 	luaL_newlib(lua_state, cardlib);
 	lua_pushstring(lua_state, "__index");
@@ -1022,7 +1020,7 @@ int32 interpreter::get_operation_value(card* pcard, int32 findex, int32 extraarg
 		}
 		return OPERATION_FAIL;
 	}
-	result = lua_tointeger(current_state, -1);
+	result = round(lua_tonumber(current_state, -1));
 	lua_pop(current_state, 1);
 	no_action--;
 	call_depth--;
@@ -1044,7 +1042,7 @@ int32 interpreter::get_function_value(int32 f, uint32 param_count) {
 		if (lua_isboolean(current_state, -1))
 			result = lua_toboolean(current_state, -1);
 		else
-			result = lua_tointeger(current_state, -1);
+			result = round(lua_tonumber(current_state, -1));
 		lua_pop(current_state, 1);
 		no_action--;
 		call_depth--;
@@ -1078,7 +1076,7 @@ int32 interpreter::get_function_value(int32 f, uint32 param_count, std::vector<i
 			if (lua_isboolean(current_state, index))
 				return_value = lua_toboolean(current_state, index);
 			else
-				return_value = lua_tointeger(current_state, index);
+				return_value = round(lua_tonumber(current_state, index));
 			result->push_back(return_value);
 		}
 		lua_settop(current_state, stack_top);
@@ -1139,7 +1137,7 @@ int32 interpreter::call_coroutine(int32 f, uint32 param_count, uint32 * yield_va
 	if (result == 0) {
 		coroutines.erase(f);
 		if(yield_value)
-			*yield_value = lua_isboolean(rthread, -1) ? lua_toboolean(rthread, -1) : lua_tointeger(rthread, -1);
+			*yield_value = lua_isboolean(rthread, -1) ? lua_toboolean(rthread, -1) : round(lua_tonumber(rthread, -1));
 		current_state = lua_state;
 		call_depth--;
 		if(call_depth == 0) {

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -1011,7 +1011,7 @@ int32 scriptlib::card_is_status(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	uint32 tstatus = lua_tounsigned(L, 2);
+	uint32 tstatus = lua_tointeger(L, 2);
 	if(pcard->status & tstatus)
 		lua_pushboolean(L, 1);
 	else
@@ -1035,7 +1035,7 @@ int32 scriptlib::card_set_status(lua_State *L) {
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	if(pcard->status & STATUS_COPYING_EFFECT)
 		return 0;
-	uint32 tstatus = lua_tounsigned(L, 2);
+	uint32 tstatus = lua_tointeger(L, 2);
 	int32 enable = lua_toboolean(L, 3);
 	pcard->set_status(tstatus, enable);
 	return 0;
@@ -1563,7 +1563,7 @@ int32 scriptlib::card_set_flag_effect_label(lua_State *L) {
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	uint32 code = (lua_tounsigned(L, 2) & 0xfffffff) | 0x10000000;
+	uint32 code = (lua_tointeger(L, 2) & 0xfffffff) | 0x10000000;
 	int32 lab = lua_tointeger(L, 3);
 	auto eit = pcard->single_effect.find(code);
 	if(eit == pcard->single_effect.end())
@@ -1578,7 +1578,7 @@ int32 scriptlib::card_get_flag_effect_label(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	uint32 code = (lua_tounsigned(L, 2) & 0xfffffff) | 0x10000000;
+	uint32 code = (lua_tointeger(L, 2) & 0xfffffff) | 0x10000000;
 	auto rg = pcard->single_effect.equal_range(code);
 	int32 count = 0;
 	for(; rg.first != rg.second; ++rg.first) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -33,7 +33,7 @@ int32 scriptlib::duel_get_lp(lua_State *L) {
 int32 scriptlib::duel_set_lp(lua_State *L) {
 	check_param_count(L, 2);
 	int32 p = lua_tointeger(L, 1);
-	int32 lp = lua_tointeger(L, 2);
+	int32 lp = round(lua_tonumber(L, 2));
 	if(lp < 0) lp = 0;
 	if(p != 0 && p != 1)
 		return 0;
@@ -146,7 +146,7 @@ int32 scriptlib::duel_set_flag_effect_label(lua_State *L) {
 	int32 playerid = lua_tointeger(L, 1);
 	if(playerid != 0 && playerid != 1)
 		return 0;
-	uint32 code = (lua_tounsigned(L, 2) & 0xfffffff) | 0x10000000;
+	uint32 code = (lua_tointeger(L, 2) & 0xfffffff) | 0x10000000;
 	int32 lab = lua_tointeger(L, 3);
 	duel* pduel = interpreter::get_duel_info(L);
 	effect_set eset;
@@ -164,7 +164,7 @@ int32 scriptlib::duel_get_flag_effect_label(lua_State *L) {
 	int32 playerid = lua_tointeger(L, 1);
 	if(playerid != 0 && playerid != 1)
 		return 0;
-	uint32 code = (lua_tounsigned(L, 2) & 0xfffffff) | 0x10000000;
+	uint32 code = (lua_tointeger(L, 2) & 0xfffffff) | 0x10000000;
 	duel* pduel = interpreter::get_duel_info(L);
 	effect_set eset;
 	pduel->game_field->filter_player_effect(playerid, code, &eset);

--- a/libeffect.cpp
+++ b/libeffect.cpp
@@ -61,7 +61,7 @@ int32 scriptlib::effect_set_description(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 v = lua_tounsigned(L, 2);
+	uint32 v = lua_tointeger(L, 2);
 	peffect->description = v;
 	return 0;
 }
@@ -69,7 +69,7 @@ int32 scriptlib::effect_set_code(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 v = lua_tounsigned(L, 2);
+	uint32 v = lua_tointeger(L, 2);
 	peffect->code = v;
 	return 0;
 }
@@ -77,7 +77,7 @@ int32 scriptlib::effect_set_range(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 v = lua_tounsigned(L, 2);
+	uint32 v = lua_tointeger(L, 2);
 	peffect->range = v;
 	return 0;
 }
@@ -85,8 +85,8 @@ int32 scriptlib::effect_set_target_range(lua_State *L) {
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 s = lua_tounsigned(L, 2);
-	uint32 o = lua_tounsigned(L, 3);
+	uint32 s = lua_tointeger(L, 2);
+	uint32 o = lua_tointeger(L, 3);
 	peffect->s_range = s;
 	peffect->o_range = o;
 	peffect->flag[0] &= ~EFFECT_FLAG_ABSOLUTE_TARGET;
@@ -96,9 +96,9 @@ int32 scriptlib::effect_set_absolute_range(lua_State *L) {
 	check_param_count(L, 4);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 playerid = lua_tounsigned(L, 2);
-	uint32 s = lua_tounsigned(L, 3);
-	uint32 o = lua_tounsigned(L, 4);
+	uint32 playerid = lua_tointeger(L, 2);
+	uint32 s = lua_tointeger(L, 3);
+	uint32 o = lua_tointeger(L, 4);
 	if(playerid == 0) {
 		peffect->s_range = s;
 		peffect->o_range = o;
@@ -113,10 +113,10 @@ int32 scriptlib::effect_set_count_limit(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 v = lua_tounsigned(L, 2);
+	uint32 v = lua_tointeger(L, 2);
 	uint32 code = 0;
 	if(lua_gettop(L) >= 3)
-		code = lua_tounsigned(L, 3);
+		code = lua_tointeger(L, 3);
 	if(v == 0)
 		v = 1;
 	peffect->flag[0] |= EFFECT_FLAG_COUNT_LIMIT;
@@ -129,8 +129,8 @@ int32 scriptlib::effect_set_reset(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 v = lua_tounsigned(L, 2);
-	uint32 c = lua_tounsigned(L, 3);
+	uint32 v = lua_tointeger(L, 2);
+	uint32 c = lua_tointeger(L, 3);
 	if(c == 0)
 		c = 1;
 	if(v & (RESET_PHASE) && !(v & (RESET_SELF_TURN | RESET_OPPO_TURN)))
@@ -143,7 +143,7 @@ int32 scriptlib::effect_set_type(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 v = lua_tounsigned(L, 2);
+	uint32 v = lua_tointeger(L, 2);
 	if (v & 0x0ff0)
 		v |= EFFECT_TYPE_ACTIONS;
 	else
@@ -164,8 +164,8 @@ int32 scriptlib::effect_set_property(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 v1 = lua_tounsigned(L, 2);
-	uint32 v2 = lua_tounsigned(L, 3);
+	uint32 v1 = lua_tointeger(L, 2);
+	uint32 v2 = lua_tointeger(L, 3);
 	peffect->flag[0] = (peffect->flag[0] & 0x4f) | (v1 & ~0x4f);
 	peffect->flag[1] = v2;
 	return 0;
@@ -174,7 +174,7 @@ int32 scriptlib::effect_set_label(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 v = lua_tounsigned(L, 2);
+	uint32 v = lua_tointeger(L, 2);
 	peffect->label = v;
 	return 0;
 }
@@ -196,7 +196,7 @@ int32 scriptlib::effect_set_category(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 v = lua_tounsigned(L, 2);
+	uint32 v = lua_tointeger(L, 2);
 	peffect->category = v;
 	return 0;
 }
@@ -204,10 +204,10 @@ int32 scriptlib::effect_set_hint_timing(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 vs = lua_tounsigned(L, 2);
+	uint32 vs = lua_tointeger(L, 2);
 	uint32 vo = vs;
 	if(lua_gettop(L) >= 3)
-		vo = lua_tounsigned(L, 3);
+		vo = lua_tointeger(L, 3);
 	peffect->hint_timing[0] = vs;
 	peffect->hint_timing[1] = vo;
 	return 0;
@@ -256,7 +256,7 @@ int32 scriptlib::effect_set_value(lua_State *L) {
 		if(lua_isboolean(L, 2))
 			peffect->value = lua_toboolean(L, 2);
 		else
-			peffect->value = lua_tointeger(L, 2);
+			peffect->value = round(lua_tonumber(L, 2));
 	}
 	return 0;
 }
@@ -277,7 +277,7 @@ int32 scriptlib::effect_set_owner_player(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 p = lua_tounsigned(L, 2);
+	uint32 p = lua_tointeger(L, 2);
 	if(p != 0 && p != 1)
 		return 0;
 	peffect->effect_owner = p;
@@ -318,8 +318,8 @@ int32 scriptlib::effect_get_property(lua_State *L) {
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
 	if (peffect) {
-		lua_pushunsigned(L, peffect->flag[0]);
-		lua_pushunsigned(L, peffect->flag[1]);
+		lua_pushinteger(L, peffect->flag[0]);
+		lua_pushinteger(L, peffect->flag[1]);
 		return 2;
 	}
 	return 0;
@@ -468,8 +468,8 @@ int32 scriptlib::effect_is_has_property(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 tflag1 = lua_tounsigned(L, 2);
-	uint32 tflag2 = lua_tounsigned(L, 3);
+	uint32 tflag1 = lua_tointeger(L, 2);
+	uint32 tflag2 = lua_tointeger(L, 3);
 	if (peffect && (!tflag1 || (peffect->flag[0] & tflag1)) && (!tflag2 || (peffect->flag[1] & tflag2)))
 		lua_pushboolean(L, 1);
 	else

--- a/premake4.lua
+++ b/premake4.lua
@@ -7,4 +7,4 @@ project "ocgcore"
     configuration "not vs*"
         buildoptions { "-std=gnu++0x" }
     configuration "not windows"
-        includedirs { "/usr/include/lua", "/usr/include/lua5.2", "/usr/include/lua/5.2" }
+        includedirs { "/usr/include/lua", "/usr/include/lua5.3", "/usr/include/lua/5.3" }


### PR DESCRIPTION
`lua_tounsigned` is removed in lua 5.3, so we can replace it with `lua_tointeger`
`lua_tointeger` will return 0 on decimal number, so in some place it should use `round(lua_tonumber(...))`
`bit32` it removed in lua 5.3, we can add those codes to utility.lua to avoid mass change of scripts
```lua
--the lua port of bit32 lib, which is removed in lua 5.3
bit={}
function bit.band(a,b)
	return a&b
end
function bit.bor(a,b)
	return a|b
end
function bit.bxor(a,b)
	return a~b
end
function bit.lshift(a,b)
	return a<<b
end
function bit.rshift(a,b)
	return a>>b
end
function bit.bnot(a)
	return ~a
end
local function fieldargs(f,width)
	w=width or 1
	assert(f>=0,"field cannot be negative")
	assert(w>0,"width must be positive")
	assert(f+w<=32,"trying to access non-existent bits")
	return f,~(-1<<w)
end
function bit.extract(r,field,width)
	local f,m=fieldargs(field,width)
	return (r>>f)&m
end
function bit.replace(r,v,field,width)
	local f,m=fieldargs(field,width)
	return (r&~(m<<f))|((v&m)<< f)
end
```