### PR TITLE
ra sphere mode and rivality of warlords interaction revision

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2444,14 +2444,14 @@ int32 card::filter_summon_procedure(uint8 playerid, effect_set* peset, uint8 ign
 			peset->add_item(eset[i]);
 	}
 	// ordinary summon
-	if(!pduel->game_field->is_player_can_summon(SUMMON_TYPE_NORMAL, playerid, this))
+	if(!pduel->game_field->is_player_can_summon(SUMMON_TYPE_NORMAL, playerid, this, playerid))
 		return FALSE;
 	if(pduel->game_field->check_unique_onfield(this, playerid, LOCATION_MZONE))
 		return FALSE;
 	int32 rcount = get_summon_tribute_count();
 	int32 min = rcount & 0xffff;
 	int32 max = (rcount >> 16) & 0xffff;
-	if(!pduel->game_field->is_player_can_summon(SUMMON_TYPE_ADVANCE, playerid, this))
+	if(!pduel->game_field->is_player_can_summon(SUMMON_TYPE_ADVANCE, playerid, this, playerid))
 		max = 0;
 	if(min < min_tribute)
 		min = min_tribute;
@@ -2480,13 +2480,13 @@ int32 card::filter_summon_procedure(uint8 playerid, effect_set* peset, uint8 ign
 int32 card::check_summon_procedure(effect* peffect, uint8 playerid, uint8 ignore_count, uint8 min_tribute, uint32 zone) {
 	if(!peffect->check_count_limit(playerid))
 		return FALSE;
-	if(!pduel->game_field->is_player_can_summon(peffect->get_value(this), playerid, this))
-		return FALSE;
 	uint8 toplayer = playerid;
 	if(peffect->is_flag(EFFECT_FLAG_SPSUM_PARAM)) {
 		if(peffect->o_range)
 			toplayer = 1 - playerid;
 	}
+	if(!pduel->game_field->is_player_can_summon(peffect->get_value(this), playerid, this, toplayer))
+		return FALSE;
 	if(pduel->game_field->check_unique_onfield(this, toplayer, LOCATION_MZONE))
 		return FALSE;
 	// the script will check min_tribute, Duel.CheckTribute()
@@ -2943,7 +2943,7 @@ int32 card::is_can_be_summoned(uint8 playerid, uint8 ignore_count, effect* peffe
 		if(is_position(POS_FACEDOWN)
 		        || !is_affected_by_effect(EFFECT_DUAL_SUMMONABLE)
 		        || is_affected_by_effect(EFFECT_DUAL_STATUS)
-		        || !pduel->game_field->is_player_can_summon(SUMMON_TYPE_DUAL, playerid, this)
+		        || !pduel->game_field->is_player_can_summon(SUMMON_TYPE_DUAL, playerid, this, playerid)
 		        || is_affected_by_effect(EFFECT_CANNOT_SUMMON)) {
 			pduel->game_field->restore_lp_cost();
 			return FALSE;
@@ -2956,7 +2956,7 @@ int32 card::is_can_be_summoned(uint8 playerid, uint8 ignore_count, effect* peffe
 		effect_set proc;
 		int32 res = filter_summon_procedure(playerid, &proc, ignore_count, min_tribute, zone);
 		if(peffect) {
-			if(res < 0 || !pduel->game_field->is_player_can_summon(peffect->get_value(), playerid, this)) {
+			if(res < 0 || !pduel->game_field->is_player_can_summon(peffect->get_value(), playerid, this, playerid)) {
 				pduel->game_field->restore_lp_cost();
 				return FALSE;
 			}

--- a/card.cpp
+++ b/card.cpp
@@ -2529,12 +2529,12 @@ int32 card::filter_set_procedure(uint8 playerid, effect_set* peset, uint8 ignore
 		if(check_set_procedure(eset[i], playerid, ignore_count, min_tribute, zone))
 			peset->add_item(eset[i]);
 	}
-	if(!pduel->game_field->is_player_can_mset(SUMMON_TYPE_NORMAL, playerid, this))
+	if(!pduel->game_field->is_player_can_mset(SUMMON_TYPE_NORMAL, playerid, this, playerid))
 		return FALSE;
 	int32 rcount = get_set_tribute_count();
 	int32 min = rcount & 0xffff;
 	int32 max = (rcount >> 16) & 0xffff;
-	if(!pduel->game_field->is_player_can_mset(SUMMON_TYPE_ADVANCE, playerid, this))
+	if(!pduel->game_field->is_player_can_mset(SUMMON_TYPE_ADVANCE, playerid, this, playerid))
 		max = 0;
 	if(min < min_tribute)
 		min = min_tribute;
@@ -2563,13 +2563,13 @@ int32 card::filter_set_procedure(uint8 playerid, effect_set* peset, uint8 ignore
 int32 card::check_set_procedure(effect* peffect, uint8 playerid, uint8 ignore_count, uint8 min_tribute, uint32 zone) {
 	if(!peffect->check_count_limit(playerid))
 		return FALSE;
-	if(!pduel->game_field->is_player_can_mset(peffect->get_value(this), playerid, this))
-		return FALSE;
 	uint8 toplayer = playerid;
 	if(peffect->is_flag(EFFECT_FLAG_SPSUM_PARAM)) {
 		if(peffect->o_range)
 			toplayer = 1 - playerid;
 	}
+	if(!pduel->game_field->is_player_can_mset(peffect->get_value(this), playerid, this, toplayer))
+		return FALSE;
 	if(!ignore_count && !pduel->game_field->core.extra_summon[playerid]
 			&& pduel->game_field->core.summon_count[playerid] >= pduel->game_field->get_summon_count_limit(playerid)) {
 		effect_set eset;
@@ -3147,7 +3147,7 @@ int32 card::is_setable_mzone(uint8 playerid, uint8 ignore_count, effect* peffect
 	effect_set eset;
 	int32 res = filter_set_procedure(playerid, &eset, ignore_count, min_tribute, zone);
 	if(peffect) {
-		if(res < 0 || !pduel->game_field->is_player_can_mset(peffect->get_value(), playerid, this)) {
+		if(res < 0 || !pduel->game_field->is_player_can_mset(peffect->get_value(), playerid, this, playerid)) {
 			pduel->game_field->restore_lp_cost();
 			return FALSE;
 		}

--- a/field.cpp
+++ b/field.cpp
@@ -3065,14 +3065,13 @@ int32 field::is_player_can_summon(uint32 sumtype, uint8 playerid, card * pcard, 
 		pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		pduel->lua->add_param(sumtype, PARAM_TYPE_INT);
-		pduel->lua->add_param(POS_FACEUP_ATTACK, PARAM_TYPE_INT);
 		pduel->lua->add_param(toplayer, PARAM_TYPE_INT);
-		if(pduel->lua->check_condition(eset[i]->target, 6))
+		if(pduel->lua->check_condition(eset[i]->target, 5))
 			return FALSE;
 	}
 	return TRUE;
 }
-int32 field::is_player_can_mset(uint32 sumtype, uint8 playerid, card * pcard) {
+int32 field::is_player_can_mset(uint32 sumtype, uint8 playerid, card * pcard, uint8 toplayer) {
 	effect_set eset;
 	sumtype |= SUMMON_TYPE_NORMAL;
 	filter_player_effect(playerid, EFFECT_CANNOT_MSET, &eset);
@@ -3083,7 +3082,8 @@ int32 field::is_player_can_mset(uint32 sumtype, uint8 playerid, card * pcard) {
 		pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		pduel->lua->add_param(sumtype, PARAM_TYPE_INT);
-		if (pduel->lua->check_condition(eset[i]->target, 4))
+		pduel->lua->add_param(toplayer, PARAM_TYPE_INT);
+		if (pduel->lua->check_condition(eset[i]->target, 5))
 			return FALSE;
 	}
 	return TRUE;

--- a/field.cpp
+++ b/field.cpp
@@ -3054,7 +3054,7 @@ int32 field::is_player_can_summon(uint8 playerid) {
 	}
 	return TRUE;
 }
-int32 field::is_player_can_summon(uint32 sumtype, uint8 playerid, card * pcard) {
+int32 field::is_player_can_summon(uint32 sumtype, uint8 playerid, card * pcard, uint8 toplayer) {
 	effect_set eset;
 	sumtype |= SUMMON_TYPE_NORMAL;
 	filter_player_effect(playerid, EFFECT_CANNOT_SUMMON, &eset);
@@ -3065,7 +3065,9 @@ int32 field::is_player_can_summon(uint32 sumtype, uint8 playerid, card * pcard) 
 		pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		pduel->lua->add_param(sumtype, PARAM_TYPE_INT);
-		if(pduel->lua->check_condition(eset[i]->target, 4))
+		pduel->lua->add_param(POS_FACEUP_ATTACK, PARAM_TYPE_INT);
+		pduel->lua->add_param(toplayer, PARAM_TYPE_INT);
+		if(pduel->lua->check_condition(eset[i]->target, 6))
 			return FALSE;
 	}
 	return TRUE;

--- a/field.h
+++ b/field.h
@@ -445,7 +445,7 @@ public:
 	int32 is_player_can_discard_hand(uint8 playerid, card* pcard, effect* peffect, uint32 reason);
 	int32 is_player_can_summon(uint8 playerid);
 	int32 is_player_can_summon(uint32 sumtype, uint8 playerid, card* pcard, uint8 toplayer);
-	int32 is_player_can_mset(uint32 sumtype, uint8 playerid, card* pcard);
+	int32 is_player_can_mset(uint32 sumtype, uint8 playerid, card* pcard, uint8 toplayer);
 	int32 is_player_can_sset(uint8 playerid, card* pcard);
 	int32 is_player_can_spsummon(uint8 playerid);
 	int32 is_player_can_spsummon(effect* peffect, uint32 sumtype, uint8 sumpos, uint8 playerid, uint8 toplayer, card* pcard);

--- a/field.h
+++ b/field.h
@@ -444,7 +444,7 @@ public:
 	int32 is_player_can_discard_deck_as_cost(uint8 playerid, int32 count);
 	int32 is_player_can_discard_hand(uint8 playerid, card* pcard, effect* peffect, uint32 reason);
 	int32 is_player_can_summon(uint8 playerid);
-	int32 is_player_can_summon(uint32 sumtype, uint8 playerid, card* pcard);
+	int32 is_player_can_summon(uint32 sumtype, uint8 playerid, card* pcard, uint8 toplayer);
 	int32 is_player_can_mset(uint32 sumtype, uint8 playerid, card* pcard);
 	int32 is_player_can_sset(uint8 playerid, card* pcard);
 	int32 is_player_can_spsummon(uint8 playerid);

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3425,7 +3425,7 @@ int32 scriptlib::duel_is_player_can_summon(lua_State * L) {
 		int32 sumtype = lua_tointeger(L, 2);
 		card* pcard = *(card**) lua_touserdata(L, 3);
 		int32 toplayer = playerid;
-		lua_pushboolean(L, pduel->game_field->is_player_can_summon(sumtype, playerid, pcard, playerid));
+		lua_pushboolean(L, pduel->game_field->is_player_can_summon(sumtype, playerid, pcard, toplayer));
 	}
 	return 1;
 }

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3424,7 +3424,8 @@ int32 scriptlib::duel_is_player_can_summon(lua_State * L) {
 		check_param(L, PARAM_TYPE_CARD, 3);
 		int32 sumtype = lua_tointeger(L, 2);
 		card* pcard = *(card**) lua_touserdata(L, 3);
-		lua_pushboolean(L, pduel->game_field->is_player_can_summon(sumtype, playerid, pcard));
+		int32 toplayer = playerid;
+		lua_pushboolean(L, pduel->game_field->is_player_can_summon(sumtype, playerid, pcard, playerid));
 	}
 	return 1;
 }

--- a/operations.cpp
+++ b/operations.cpp
@@ -1461,7 +1461,7 @@ int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, ui
 				return TRUE;
 			if(target->is_affected_by_effect(EFFECT_DUAL_STATUS))
 				return TRUE;
-			if(!is_player_can_summon(SUMMON_TYPE_DUAL, sumplayer, target))
+			if(!is_player_can_summon(SUMMON_TYPE_DUAL, sumplayer, target, sumplayer))
 				return TRUE;
 		} else {
 			effect_set eset;
@@ -1553,7 +1553,7 @@ int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, ui
 					int32 rcount = target->get_summon_tribute_count();
 					int32 min = rcount & 0xffff;
 					int32 max = (rcount >> 16) & 0xffff;
-					if(!is_player_can_summon(SUMMON_TYPE_ADVANCE, sumplayer, target))
+					if(!is_player_can_summon(SUMMON_TYPE_ADVANCE, sumplayer, target, sumplayer))
 						max = 0;
 					if(min < (int32)min_tribute)
 						min = min_tribute;
@@ -1608,7 +1608,7 @@ int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, ui
 		if(min < min_tribute) {
 			min = min_tribute;
 		}
-		uint32 adv = is_player_can_summon(SUMMON_TYPE_ADVANCE, sumplayer, target);
+		uint32 adv = is_player_can_summon(SUMMON_TYPE_ADVANCE, sumplayer, target, sumplayer);
 		if(max == 0 || !adv) {
 			returns.bvalue[0] = 0;
 			core.units.begin()->step = 3;
@@ -2101,7 +2101,7 @@ int32 field::mset(uint16 step, uint8 setplayer, card* target, effect* proc, uint
 					int32 rcount = target->get_set_tribute_count();
 					int32 min = rcount & 0xffff;
 					int32 max = (rcount >> 16) & 0xffff;
-					if(!is_player_can_summon(SUMMON_TYPE_ADVANCE, setplayer, target))
+					if(!is_player_can_summon(SUMMON_TYPE_ADVANCE, setplayer, target, setplayer))
 						max = 0;
 					if(min < (int32)min_tribute)
 						min = min_tribute;

--- a/operations.cpp
+++ b/operations.cpp
@@ -2156,7 +2156,7 @@ int32 field::mset(uint16 step, uint8 setplayer, card* target, effect* proc, uint
 		if(min < min_tribute) {
 			min = min_tribute;
 		}
-		uint32 adv = is_player_can_mset(SUMMON_TYPE_ADVANCE, setplayer, target);
+		uint32 adv = is_player_can_mset(SUMMON_TYPE_ADVANCE, setplayer, target, setplayer);
 		if(max == 0 || !adv) {
 			returns.bvalue[0] = 0;
 			core.units.begin()->step = 3;


### PR DESCRIPTION
Currently, EFFECT_FLAG_SPSUM_PARAM only informs the zone of which the player going to summon to **after** the actual validity check of the zone of which player will summon to, without passing this info into EFFECT_CANNOT_SUMMON, making it almost impossible for that effect check correct player field, which causes Ra Sphere Mode interacts incorrectly with Rivality of Warlords and Gozen Match.
I changed the order of it and added the params, but set proc probably would need to be changed too, SpSummon Proc is alright as far as I can see.