### PR TITLE
fix check of EFFECT_EXTRA_RELEASE_NONSUM

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -1661,6 +1661,11 @@ int32 field::get_release_list(uint8 playerid, card_set* release_list, card_set* 
 				effect* peffect = pcard->is_affected_by_effect(EFFECT_EXTRA_RELEASE_NONSUM);
 				if(!peffect || (peffect->is_flag(EFFECT_FLAG_COUNT_LIMIT) && peffect->count_limit == 0))
 					continue;
+				pduel->lua->add_param(core.reason_effect, PARAM_TYPE_EFFECT);
+				pduel->lua->add_param(REASON_COST, PARAM_TYPE_INT);
+				pduel->lua->add_param(core.reason_player, PARAM_TYPE_INT);
+				if(!peffect->check_value_condition(3))
+					continue;
 				if(ex_list_oneof)
 					ex_list_oneof->insert(pcard);
 				ex_oneof_max = 1;


### PR DESCRIPTION
Fix: _Lair of Darkness_ can make cards like _Destiny HERO - Plasma_ release cards from opponent because the val check of `EFFECT_EXTRA_RELEASE_NONSUM` didn't work in `Duel.GetReleaseGroup`.

We should update the script of _Lair of Darkness_ too.
```lua
function c59160188.relval(e,re,r,rp)
	return re:IsActivated() and bit.band(r,REASON_COST)~=0
end
```
