### PR TITLE
fix & update select_unselect_card

### DIFF
--- a/field.h
+++ b/field.h
@@ -582,7 +582,7 @@ public:
 	int32 select_yes_no(uint16 step, uint8 playerid, uint32 description);
 	int32 select_option(uint16 step, uint8 playerid);
 	int32 select_card(uint16 step, uint8 playerid, uint8 cancelable, uint8 min, uint8 max);
-	int32 select_unselect_card(uint16 step, uint8 playerid, uint8 cancelable, uint8 min, uint8 max, uint8 ok);
+	int32 select_unselect_card(uint16 step, uint8 playerid, uint8 cancelable, uint8 min, uint8 max, uint8 finishable);
 	int32 select_chain(uint16 step, uint8 playerid, uint8 spe_count, uint8 forced);
 	int32 select_place(uint16 step, uint8 playerid, uint32 flag, uint8 count);
 	int32 select_position(uint16 step, uint8 playerid, uint32 code, uint8 positions);

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -268,9 +268,9 @@ int32 scriptlib::group_select_unselect(lua_State *L) {
 			}
 		}
 	}
-	uint32 buttonok = FALSE;
+	uint32 finishable = FALSE;
 	if(lua_gettop(L) > 3) {
-		buttonok = lua_toboolean(L, 4);
+		finishable = lua_toboolean(L, 4);
 	}
 	uint32 cancelable = FALSE;
 	if(lua_gettop(L) > 4) {
@@ -294,7 +294,7 @@ int32 scriptlib::group_select_unselect(lua_State *L) {
 	for(auto it = pgroup2->container.begin(); it != pgroup2->container.end(); ++it) {
 		pduel->game_field->core.unselect_cards.push_back(*it);
 	}
-	pduel->game_field->add_process(PROCESSOR_SELECT_UNSELECT_CARD_S, 0, 0, 0, playerid + (cancelable << 16), min + (max << 16), buttonok);
+	pduel->game_field->add_process(PROCESSOR_SELECT_UNSELECT_CARD_S, 0, 0, 0, playerid + (cancelable << 16), min + (max << 16), finishable);
 	return lua_yield(L, 0);
 }
 int32 scriptlib::group_random_select(lua_State *L) {

--- a/playerop.cpp
+++ b/playerop.cpp
@@ -287,7 +287,7 @@ int32 field::select_card(uint16 step, uint8 playerid, uint8 cancelable, uint8 mi
 		return TRUE;
 	}
 }
-int32 field::select_unselect_card(uint16 step, uint8 playerid, uint8 cancelable, uint8 min, uint8 max, uint8 buttonok) {
+int32 field::select_unselect_card(uint16 step, uint8 playerid, uint8 cancelable, uint8 min, uint8 max, uint8 finishable) {
 	if(step == 0) {
 		returns.bvalue[0] = 0;
 		if(core.select_cards.empty() && core.unselect_cards.empty())
@@ -300,7 +300,7 @@ int32 field::select_unselect_card(uint16 step, uint8 playerid, uint8 cancelable,
 		}
 		pduel->write_buffer8(MSG_SELECT_UNSELECT_CARD);
 		pduel->write_buffer8(playerid);
-		pduel->write_buffer8(buttonok);
+		pduel->write_buffer8(finishable);
 		pduel->write_buffer8(cancelable);
 		pduel->write_buffer8(min);
 		pduel->write_buffer8(max);
@@ -321,21 +321,20 @@ int32 field::select_unselect_card(uint16 step, uint8 playerid, uint8 cancelable,
 		return FALSE;
 	} else {
 		if(returns.ivalue[0] == -1) {
-			if(cancelable)
+			if(cancelable || finishable)
 				return TRUE;
 			pduel->write_buffer8(MSG_RETRY);
 			return FALSE;
 		}
-		byte c[64];
-		memset(c, 0, 64);
-		uint8 m = core.select_cards.size() + core.unselect_cards.size(), v = 0;
-		for(int32 i = 0; i < returns.bvalue[0]; ++i) {
-			v = returns.bvalue[i + 1];
-			if(v < 0 || v >= m || v >= 63 || c[v]) {
-				pduel->write_buffer8(MSG_RETRY);
-				return FALSE;
-			}
-			c[v] = 1;
+		if(returns.bvalue[0] > 1) {
+			pduel->write_buffer8(MSG_RETRY);
+			return FALSE;
+		}
+		uint8 m = core.select_cards.size() + core.unselect_cards.size();
+		uint8 v = returns.bvalue[1];
+		if(v < 0 || v >= m) {
+			pduel->write_buffer8(MSG_RETRY);
+			return FALSE;
 		}
 		return TRUE;
 	}

--- a/processor.cpp
+++ b/processor.cpp
@@ -699,7 +699,6 @@ int32 field::process() {
 			if(returns.bvalue[0] == -1)
 				pduel->lua->add_param((void*)0, PARAM_TYPE_GROUP);
 			else {
-				group* pgroup = pduel->new_group();
 				card* pcard;
 				if(returns.bvalue[1] < core.select_cards.size())
 					pcard = core.select_cards[returns.bvalue[1]];


### PR DESCRIPTION
`finishable` and `cancelable` will do the same thing: allow the client to send -1 as select result, and in this situation return nil to lua.
The script can try to handle "cancel when part select" by enabling `cancelable`, see the PRs below.