### PR TITLE
Update card::get_link()

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -963,7 +963,7 @@ uint32 card::get_link() {
 		return 0;
 	uint32 link = 0;
 	uint32 link_marker = get_link_marker();
-	while(link_marker)  
+	while(link_marker > 0)
 	{
 		link_marker = link_marker & (link_marker - 1);
 		link++;

--- a/card.cpp
+++ b/card.cpp
@@ -961,7 +961,16 @@ uint32 card::get_rank() {
 uint32 card::get_link() {
 	if(!(data.type & TYPE_LINK) || (status & STATUS_NO_LEVEL))
 		return 0;
-	return data.level;
+	uint32 link = 0;
+	uint32 link_marker = get_link_marker();
+	while(link_marker)  
+	{
+		link_marker = link_marker & (link_marker - 1);
+		link++;
+	}
+	// link is number of "1" in "link_marker" as binary
+	return link;
+	//return data.level;
 }
 uint32 card::get_synchro_level(card* pcard) {
 	if((data.type & (TYPE_XYZ | TYPE_LINK)) || (status & STATUS_NO_LEVEL))


### PR DESCRIPTION
For "Link Number", official cards reference "リンクＸ (Link X)" while comparing it with a designated value and "リンクマーカーの数 (count of link markers)" while calculating the sum of it or using it as a counter. "Link Number", unlike level or rank, is referencing to the "count of link markers", rather than some sort of card attribute.

Cards that referenced "リンクマーカーの数" instead of "リンクＸ" (18th, April, 2018):
●V−LAN ヒドラ
●ザ・アキュムレーター
●天火の牢獄
●サイバーサル・サイクロン
●バウンドリンク
●ショートヴァレル・ドラゴン