### PR TITLE
Update Duel.SelectMatchingCard

### DIFF
--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2226,8 +2226,91 @@ int32 scriptlib::duel_select_matching_cards(lua_State *L) {
 	uint32 location2 = lua_tointeger(L, 5);
 	uint32 min = lua_tointeger(L, 6);
 	uint32 max = lua_tointeger(L, 7);
+	
+	// see if we can search deck
+	int32 can_search_1;
+	int32 can_search_2;
+	if (playerid == self)
+	{
+		int32 can_search_1 = location1 & LOCATION_DECK > 0;
+		int32 can_search_2 = location2 & LOCATION_DECK > 0;
+	}
+	else
+	{
+		int32 can_search_1 = location2 & LOCATION_DECK > 0;
+		int32 can_search_2 = location1 & LOCATION_DECK > 0;
+	}
+	
+	// generate selectable group from deck
 	group* pgroup = pduel->new_group();
+	group* pgroup_sd = pduel->new_group();
+	group* pgroup_od = pduel->new_group();
+	if (can_search_1)
+		pduel->game_field->filter_matching_card(2, (uint8)playerid, LOCATION_DECK, 0, pgroup_sd, pexception, pexgroup, extraargs);
+	if (can_search_2)
+		pduel->game_field->filter_matching_card(2, (uint8)playerid, 0, LOCATION_DECK, pgroup_od, pexception, pexgroup, extraargs);
+	
+	// generate selectable group from other locations
+	location1 -= location1 & LOCATION_DECK;
+	location2 -= location2 & LOCATION_DECK;
 	pduel->game_field->filter_matching_card(2, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs);
+	
+	// deside if we should search from deck or not
+	int32 has_searched_1 = FALSE;
+	if (can_search_1)
+	{
+		if (pgroup->container.size() + pgroup_od->container.size() < min)
+		{
+			has_searched_1 = TRUE;
+		}
+		else
+		{
+			int32 desc = 600;
+			if (pgroup_sd->container.size()==0)
+				desc = 601;
+			pduel->game_field->select_yes_no(0, playerid, desc);
+			int32 flag = FALSE;
+			while (!flag)
+			{
+				flag = pduel->game_field->select_yes_no(1, playerid, desc);
+			}
+			has_searched_1 = pduel->bufferlen;
+		}
+	}
+	if (has_searched_1)
+	{
+		pgroup->container.insert(pgroup_sd->container.begin(), pgroup_sd->container.end());
+		pduel->game_field->core.shuffle_deck_check[playerid] = TRUE;
+	}
+	
+	// deside if we should search from opponent's deck or not
+	int32 has_searched_2 = FALSE;
+	if (can_search_2)
+	{
+		if (pgroup->container.size() < min)
+		{
+			has_searched_2 = TRUE;
+		}
+		else
+		{
+			int32 desc = 602;
+			if (pgroup_od->container.size()==0)
+				desc = 603;
+			pduel->game_field->select_yes_no(0, playerid, desc);
+			int32 flag = FALSE;
+			while (!flag)
+			{
+				flag = pduel->game_field->select_yes_no(1, playerid, desc);
+			}
+			has_searched_2 = pduel->bufferlen;
+		}
+	}
+	if (has_searched_2)
+	{
+		pgroup->container.insert(pgroup_od->container.begin(), pgroup_od->container.end());
+		pduel->game_field->core.shuffle_deck_check[1-playerid] = TRUE;
+	}
+	
 	pduel->game_field->core.select_cards.assign(pgroup->container.begin(), pgroup->container.end());
 	pduel->game_field->add_process(PROCESSOR_SELECT_CARD_S, 0, 0, 0, playerid, min + (max << 16));
 	return lua_yield(L, 0);

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2232,13 +2232,13 @@ int32 scriptlib::duel_select_matching_cards(lua_State *L) {
 	int32 can_search_2;
 	if (playerid == self)
 	{
-		int32 can_search_1 = location1 & LOCATION_DECK > 0;
-		int32 can_search_2 = location2 & LOCATION_DECK > 0;
+		can_search_1 = (location1 & LOCATION_DECK) > 0;
+		can_search_2 = (location2 & LOCATION_DECK) > 0;
 	}
 	else
 	{
-		int32 can_search_1 = location2 & LOCATION_DECK > 0;
-		int32 can_search_2 = location1 & LOCATION_DECK > 0;
+		can_search_1 = (location2 & LOCATION_DECK) > 0;
+		can_search_2 = (location1 & LOCATION_DECK) > 0;
 	}
 	
 	// generate selectable group from deck
@@ -2251,8 +2251,8 @@ int32 scriptlib::duel_select_matching_cards(lua_State *L) {
 		pduel->game_field->filter_matching_card(2, (uint8)playerid, 0, LOCATION_DECK, pgroup_od, pexception, pexgroup, extraargs);
 	
 	// generate selectable group from other locations
-	location1 -= location1 & LOCATION_DECK;
-	location2 -= location2 & LOCATION_DECK;
+	location1 -= (location1 & LOCATION_DECK);
+	location2 -= (location2 & LOCATION_DECK);
 	pduel->game_field->filter_matching_card(2, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs);
 	
 	// deside if we should search from deck or not
@@ -2268,12 +2268,7 @@ int32 scriptlib::duel_select_matching_cards(lua_State *L) {
 			int32 desc = 600;
 			if (pgroup_sd->container.size()==0)
 				desc = 601;
-			pduel->game_field->select_yes_no(0, playerid, desc);
-			int32 flag = FALSE;
-			while (!flag)
-			{
-				flag = pduel->game_field->select_yes_no(1, playerid, desc);
-			}
+			pduel->game_field->add_process(PROCESSOR_SELECT_YESNO_S, 0, 0, 0, playerid, desc);
 			has_searched_1 = pduel->bufferlen;
 		}
 	}
@@ -2296,12 +2291,7 @@ int32 scriptlib::duel_select_matching_cards(lua_State *L) {
 			int32 desc = 602;
 			if (pgroup_od->container.size()==0)
 				desc = 603;
-			pduel->game_field->select_yes_no(0, playerid, desc);
-			int32 flag = FALSE;
-			while (!flag)
-			{
-				flag = pduel->game_field->select_yes_no(1, playerid, desc);
-			}
+			pduel->game_field->add_process(PROCESSOR_SELECT_YESNO_S, 0, 0, 0, playerid, desc);
 			has_searched_2 = pduel->bufferlen;
 		}
 	}


### PR DESCRIPTION
当前的ygopro的表现：
1. 无论其他区域是否有足量的符合条件的卡，都会查看卡组。
2. 玩家能清楚地知道卡组中的符合条件的卡各自的位置。
3. 只要没有将卡从卡组取出，就不会洗牌。

应有的表现：
1. 如果其他区域有足量的符合条件的卡，无需查看卡组。
2. 如果查看了卡组，即便没有从卡组将卡取出，也要洗牌。
3. 即便卡组没有符合条件的卡，也可以查看卡组，并洗牌。

----------------------------------------------------------------------------------------------------

How it goes in current ygopro:
1. Will always search the deck regardless of whether there are enough eligible cards in other locations.
2. The player will clearly know the sequence of each eligible card in deck.
3. As long as it hasn't take any cards from the deck, it won't shuffle the deck.

How it should goes:
1. If there are enough eligible cards in other locations, there is no need to search the deck.
2. The deck will be shuffled after the search even if no cards were taken from it.
3. Can still search the deck then shuffle it even if there are no eligible cards in the deck.