### PR TITLE
fix

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3562,6 +3562,8 @@ int32 card::is_capable_turn_set(uint8 playerid) {
 		return FALSE;
 	if(is_position(POS_FACEDOWN))
 		return FALSE;
+	if(current.location != LOCATION_PZONE)
+		return FALSE;
 	if(is_affected_by_effect(EFFECT_CANNOT_TURN_SET))
 		return FALSE;
 	if(pduel->game_field->is_player_affected_by_effect(playerid, EFFECT_CANNOT_TURN_SET))


### PR DESCRIPTION
Added pendulum card limitation from the master rulebook: ペンデュラムモンスターはモンスターカードではありますが、ペンデュラムゾーンに置く際には、魔法カードとして発動し、その処理によって置かれる事になります。
　（ペンデュラムモンスターをペンデュラムゾーンにセットする事はできません。）
Pendulum monster is a monster card , but when putting it in the pendulum zone it will be activated as a magic card and will be placed by that process.
(You can not set a pendulum monster in the pendulum zone .)