### PR TITLE
change announce card behavior

### DIFF
--- a/playerop.cpp
+++ b/playerop.cpp
@@ -1010,22 +1010,26 @@ int32 field::announce_card(int16 step, uint8 playerid, uint32 ttype) {
 		return FALSE;
 	} else {
 		int32 code = returns.ivalue[0];
+		bool retry = false;
 		card_data data;
 		read_card(code, &data);
 		if(!data.code) {
-			pduel->write_buffer8(MSG_RETRY);
-			return FALSE;
-		}
-		if(core.select_options.size() == 0) {
+			retry = true;
+		} else if(core.select_options.size() == 0) {
 			if(!(data.type & ttype)) {
-				pduel->write_buffer8(MSG_RETRY);
-				return FALSE;
+				retry = true;
 			}
 		} else {
 			if(!is_declarable(data, core.select_options)) {
-				pduel->write_buffer8(MSG_RETRY);
-				return FALSE;
+				retry = true;
 			}
+		}
+		if(retry) {
+			pduel->write_buffer8(MSG_HINT);
+			pduel->write_buffer8(HINT_MESSAGE);
+			pduel->write_buffer8(playerid);
+			pduel->write_buffer32(1421);
+			return announce_card(0, playerid, ttype);
 		}
 		pduel->write_buffer8(MSG_HINT);
 		pduel->write_buffer8(HINT_CODE);

--- a/processor.cpp
+++ b/processor.cpp
@@ -601,7 +601,8 @@ int32 field::process() {
 			pduel->lua->add_param(returns.ivalue[0], PARAM_TYPE_INT);
 			core.units.pop_front();
 		} else {
-			it->step++;
+			if(it->step == 0)
+				it->step++;
 		}
 		return PROCESSOR_WAITING + pduel->bufferlen;
 	}


### PR DESCRIPTION
Some user may use custom expansion databases, and declare card that only exists in those databases.
Now because the client don't actually support MSG_RETRY, those declaration will break the duel.
So we should make it able to actually retry when the user declare illegal card.

> !system 1421 宣言的卡不符合条件，或无法被主机识别。
