### PR TITLE
update EFFECT_DISABLE_FIELD for Iron Dragon Tiamaton

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -4988,7 +4988,7 @@ int32 field::refresh_location_info(uint16 step) {
 		filter_field_effect(EFFECT_DISABLE_FIELD, &eset);
 		for (int32 i = 0; i < eset.size(); ++i) {
 			value = eset[i]->get_value();
-			if(value) {
+			if(value && !eset[i]->is_flag(EFFECT_FLAG_REPEAT)) {
 				player[0].disabled_location |= value & 0x1f7f;
 				player[1].disabled_location |= (value >> 16) & 0x1f7f;
 			} else


### PR DESCRIPTION
Now if the sequence of _Iron Dragon Tiamaton_ is moved, the disabled zones aren't changed.
I think this may fix it.

```lua
	local e4=Effect.CreateEffect(c)
	e4:SetType(EFFECT_TYPE_FIELD)
	e4:SetRange(LOCATION_MZONE)
	e4:SetCode(EFFECT_DISABLE_FIELD)
	e4:SetProperty(EFFECT_FLAG_REPEAT)
	e4:SetOperation(c46247282.disop)
	c:RegisterEffect(e4)
```