### PR TITLE
Update special_summon_step

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -2911,10 +2911,10 @@ int32 field::special_summon_step(uint16 step, group* targets, card* target, uint
 			}
 			if(target->current.location != LOCATION_EXTRA) {
 				if(ct2 == 0)
-					zone = flag2;
+					zone &= flag2;
 			} else {
 				if(ct1 == 0)
-					zone = flag1;
+					zone &= flag1;
 			}
 		}
 		move_to_field(target, move_player, playerid, LOCATION_MZONE, positions, FALSE, 0, FALSE, zone);


### PR DESCRIPTION
Fixed a bug where extra monster zone limited special summon effects like 閃刀姫－レイ's first effect mistakenly ignored zone limitation.
Perhaps additional algorithm optimizations could be carried out in the future.