### PR TITLE
fix Duel.SSet

### DIFF
--- a/field.h
+++ b/field.h
@@ -227,6 +227,7 @@ struct processor {
 	card_set discarded_set;
 	card_set destroy_canceled;
 	card_set delayed_enable_set;
+	card_set set_group_pre_set;
 	card_set set_group_set;
 	effect_set_v disfield_effects;
 	effect_set_v extram_effects;


### PR DESCRIPTION
`core.operated_set` will be altered by `move_to_field` if the field spell card is replaced by the cards set, so I use another group in the procedure.
Is there any better way to do this?