### PR TITLE
small mend for undefined behaviour

### DIFF
--- a/duel.cpp
+++ b/duel.cpp
@@ -116,17 +116,17 @@ void duel::restore_assumes() {
 	assumes.clear();
 }
 void duel::write_buffer32(uint32 value) {
-	*((uint32*)bufferp) = value;
+	std::memcpy(bufferp, &value, sizeof(value));
 	bufferp += 4;
 	bufferlen += 4;
 }
 void duel::write_buffer16(uint16 value) {
-	*((uint16*)bufferp) = value;
+	std::memcpy(bufferp, &value, sizeof(value));
 	bufferp += 2;
 	bufferlen += 2;
 }
 void duel::write_buffer8(uint8 value) {
-	*((uint8*)bufferp) = value;
+	std::memcpy(bufferp, &value, sizeof(value));
 	bufferp += 1;
 	bufferlen += 1;
 }


### PR DESCRIPTION
Under C++ standard, type punning is
Undefined Behaviour and strict aliasing rules
forbids writing data to an array of different type,
this is a small change that attempts to fix this issue
by just using std::memcpy, which is effectively
optimized by modern compilers.