### PR TITLE
update attacking process

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -60,6 +60,14 @@ void card::attacker_map::addcard(card* pcard) {
 	auto pr = emplace(fid, std::make_pair(pcard, 0));
 	pr.first->second.second++;
 }
+uint32 card::attacker_map::findcard(card* pcard) {
+	uint16 fid = pcard ? pcard->fieldid_r : 0;
+	auto it = find(fid);
+	if(it == end())
+		return 0;
+	else
+		return it->second.second;
+}
 void card_data::clear() {
 	std::memset(this, 0, sizeof(card_data));
 }
@@ -1957,6 +1965,7 @@ void card::reset(uint32 id, uint32 reset_type) {
 			indestructable_effects.clear();
 			announced_cards.clear();
 			attacked_cards.clear();
+			attack_announce_count = 0;
 			announce_count = 0;
 			attacked_count = 0;
 			attack_all_target = TRUE;

--- a/card.h
+++ b/card.h
@@ -105,6 +105,7 @@ public:
 	class attacker_map : public std::unordered_map<uint16, std::pair<card*, uint32> > {
 	public:
 		void addcard(card* pcard);
+		uint32 findcard(card* pcard);
 	};
 	struct sendto_param_t {
 		void set(uint8 p, uint8 pos, uint8 loc, uint8 seq = 0) {
@@ -141,6 +142,7 @@ public:
 	uint32 position_param;
 	uint32 spsummon_param;
 	uint32 to_field_param;
+	uint8 attack_announce_count;
 	uint8 direct_attackable;
 	uint8 announce_count;
 	uint8 attacked_count;

--- a/field.cpp
+++ b/field.cpp
@@ -2251,31 +2251,27 @@ int32 field::effect_replace_check(uint32 code, const tevent& e) {
 	}
 	return FALSE;
 }
-int32 field::get_attack_target(card* pcard, card_vector* v, uint8 chain_attack) {
-	uint8 p = pcard->current.controler;
-	effect* peffect;
-	card_vector* pv = NULL;
-	int32 atype = 0;
-	card_vector must_attack;
-	card_vector only_be_attack;
-	card_vector only_attack;
-	// find the universal set pv
+int32 field::get_attack_target(card* pcard, card_vector* v, uint8 chain_attack, bool select_target) {
 	pcard->direct_attackable = 0;
+	uint8 p = pcard->current.controler;
+	card_vector auto_attack, only_attack, must_attack;
 	for(auto cit = player[1 - p].list_mzone.begin(); cit != player[1 - p].list_mzone.end(); ++cit) {
 		card* atarget = *cit;
 		if(atarget) {
 			if(atarget->is_affected_by_effect(EFFECT_ONLY_BE_ATTACKED))
-				only_be_attack.push_back(atarget);
-			if(pcard->is_affected_by_effect(EFFECT_MUST_ATTACK_MONSTER, atarget))
-				must_attack.push_back(atarget);
+				auto_attack.push_back(atarget);
 			if(pcard->is_affected_by_effect(EFFECT_ONLY_ATTACK_MONSTER, atarget))
 				only_attack.push_back(atarget);
+			if(pcard->is_affected_by_effect(EFFECT_MUST_ATTACK_MONSTER, atarget))
+				must_attack.push_back(atarget);
 		}
 	}
-	if(only_be_attack.size()) {
+	card_vector* pv = nullptr;
+	int32 atype = 0;
+	if(auto_attack.size()) {
 		atype = 1;
-		if(only_be_attack.size() == 1)
-			pv = &only_be_attack;
+		if(auto_attack.size() == 1)
+			pv = &auto_attack;
 		else
 			return atype;
 	} else if(pcard->is_affected_by_effect(EFFECT_ONLY_ATTACK_MONSTER)) {
@@ -2294,113 +2290,63 @@ int32 field::get_attack_target(card* pcard, card_vector* v, uint8 chain_attack) 
 		atype = 4;
 		pv = &player[1 - p].list_mzone;
 	}
-	// extra count
-	int32 ct1 = 0, ct2 = 0;
-	int32 tmp = 0;
-	effect_set exts1, exts2;
+	int32 extra_count = 0;
+	effect_set eset;
+	pcard->filter_effect(EFFECT_EXTRA_ATTACK, &eset);
+	for(int32 i = 0; i < eset.size(); ++i) {
+		int32 val = eset[i]->get_value(pcard);
+		if(val > extra_count)
+			extra_count = val;
+	}
+	int32 extra_count_m = 0;
+	eset.clear();
+	pcard->filter_effect(EFFECT_EXTRA_ATTACK_MONSTER, &eset);
+	for(int32 i = 0; i < eset.size(); ++i) {
+		int32 val = eset[i]->get_value(pcard);
+		if(val > extra_count_m)
+			extra_count_m = val;
+	}
 	bool dir = true;
-	pcard->filter_effect(EFFECT_EXTRA_ATTACK, &exts1);
-	for(int32 i = 0; i < exts1.size(); ++i) {
-		tmp = exts1[i]->get_value(pcard);
-		if(tmp > ct1)
-			ct1 = tmp;
-	}
-	pcard->filter_effect(EFFECT_EXTRA_ATTACK_MONSTER, &exts2);
-	for(int32 i = 0; i < exts2.size(); ++i) {
-		tmp = exts2[i]->get_value(pcard);
-		if(tmp > ct2)
-			ct2 = tmp;
-	}
-	if(pcard != core.attacker) {
-		if(pcard->announce_count < ct1 + 1)
-			dir = true;
-		else if(chain_attack && !core.chain_attack_target)
-			dir = true;
-		else if(ct2 && pcard->announce_count < ct2 + 1
-				&& pcard->announced_cards.find(0) == pcard->announced_cards.end() && pcard->battled_cards.find(0) == pcard->battled_cards.end())
-			dir = false;
-		else {
-			// effects with target limit
-			if((peffect = pcard->is_affected_by_effect(EFFECT_ATTACK_ALL))
-					&& pcard->announced_cards.find(0) == pcard->announced_cards.end() && pcard->battled_cards.find(0) == pcard->battled_cards.end()
-					&& pcard->attack_all_target) {
-				for(auto cit = pv->begin(); cit != pv->end(); ++cit) {
-					card* atarget = *cit;
-					if(!atarget)
-						continue;
-					// valid target
-					pduel->lua->add_param(atarget, PARAM_TYPE_CARD);
-					if(!peffect->check_value_condition(1))
-						continue;
-					// enough effect count
-					auto it = pcard->announced_cards.find(atarget->fieldid_r);
-					if(it != pcard->announced_cards.end() && (int32)it->second.second >= peffect->get_value(atarget)) {
-						continue;
-					}
-					it = pcard->battled_cards.find(atarget->fieldid_r);
-					if(it != pcard->battled_cards.end() && (int32)it->second.second >= peffect->get_value(atarget)) {
-						continue;
-					}
-					if(atype == 4 && !atarget->is_capable_be_battle_target(pcard))
-						continue;
-					v->push_back(atarget);
-				}
+	if(pcard->announce_count < extra_count + 1)
+		dir = true;
+	else if(chain_attack && !core.chain_attack_target)
+		dir = true;
+	else if(extra_count_m && pcard->announce_count < extra_count_m + 1
+		&& pcard->announced_cards.findcard(0) == 0
+		&& pcard->battled_cards.findcard(0) == 0)
+		dir = false;
+	else {
+		effect* peffect;
+		if((peffect = pcard->is_affected_by_effect(EFFECT_ATTACK_ALL)) && pcard->attack_all_target
+			&& pcard->announced_cards.findcard(0) == 0
+			&& pcard->battled_cards.findcard(0) == 0) {
+			for(auto cit = pv->begin(); cit != pv->end(); ++cit) {
+				card* atarget = *cit;
+				if(!atarget)
+					continue;
+				pduel->lua->add_param(atarget, PARAM_TYPE_CARD);
+				if(!peffect->check_value_condition(1))
+					continue;
+				if(pcard->announced_cards.findcard(atarget) >= (uint32)peffect->get_value(atarget))
+					continue;
+				if(pcard->battled_cards.findcard(atarget) >= (uint32)peffect->get_value(atarget))
+					continue;
+				if(select_target && atype == 4 && !atarget->is_capable_be_battle_target(pcard))
+					continue;
+				v->push_back(atarget);
 			}
-			if(chain_attack && core.chain_attack_target
-					&& std::find(pv->begin(), pv->end(), core.chain_attack_target) != pv->end()
-					&& (atype != 4 || core.chain_attack_target->is_capable_be_battle_target(pcard))) {
-				v->push_back(core.chain_attack_target);
-			}
-			return atype;
 		}
-	} else {
-		if(pcard->announce_count <= ct1 + 1)
-			dir = true;
-		else if(chain_attack && !core.chain_attack_target)
-			dir = true;
-		else if(ct2 && pcard->announce_count <= ct2 + 1
-				&& pcard->announced_cards.find(0) == pcard->announced_cards.end() && pcard->battled_cards.find(0) == pcard->battled_cards.end())
-			dir = false;
-		else {
-			// effects with target limit
-			if((peffect = pcard->is_affected_by_effect(EFFECT_ATTACK_ALL)) && pcard->attack_all_target) {
-				for(auto cit = pv->begin(); cit != pv->end(); ++cit) {
-					card* atarget = *cit;
-					if(!atarget)
-						continue;
-					// valid target
-					pduel->lua->add_param(atarget, PARAM_TYPE_CARD);
-					if(!peffect->check_value_condition(1))
-						continue;
-					// enough effect count
-					auto it = pcard->announced_cards.find(atarget->fieldid_r);
-					if(it != pcard->announced_cards.end()
-							&& (atarget == core.attack_target ? (int32)it->second.second > peffect->get_value(atarget) : (int32)it->second.second >= peffect->get_value(atarget))) {
-						continue;
-					}
-					it = pcard->battled_cards.find(atarget->fieldid_r);
-					if(it != pcard->battled_cards.end()
-							&& (atarget == core.attack_target ? (int32)it->second.second > peffect->get_value(atarget) : (int32)it->second.second >= peffect->get_value(atarget))) {
-						continue;
-					}
-					if(atype == 4 && !atarget->is_capable_be_battle_target(pcard))
-						continue;
-					v->push_back(atarget);
-				}
-			}
-			if(chain_attack && core.chain_attack_target
-					&& std::find(pv->begin(), pv->end(), core.chain_attack_target) != pv->end()
-					&& (atype != 4 || core.chain_attack_target->is_capable_be_battle_target(pcard))) {
-				v->push_back(core.chain_attack_target);
-			}
-			return atype;
+		if(chain_attack && core.chain_attack_target
+			&& std::find(pv->begin(), pv->end(), core.chain_attack_target) != pv->end()
+			&& (!select_target || atype != 4 || core.chain_attack_target->is_capable_be_battle_target(pcard))) {
+			v->push_back(core.chain_attack_target);
 		}
+		return atype;
 	}
 	if(atype <= 3) {
 		*v = *pv;
 		return atype;
 	}
-	// For atype=4(normal), check all cards in pv.
 	uint32 mcount = 0;
 	for(auto cit = pv->begin(); cit != pv->end(); ++cit) {
 		card* atarget = *cit;
@@ -2409,10 +2355,12 @@ int32 field::get_attack_target(card* pcard, card_vector* v, uint8 chain_attack) 
 		if(atarget->is_affected_by_effect(EFFECT_IGNORE_BATTLE_TARGET))
 			continue;
 		mcount++;
-		if(atarget->is_affected_by_effect(EFFECT_CANNOT_BE_BATTLE_TARGET, pcard))
-			continue;
-		if(pcard->is_affected_by_effect(EFFECT_CANNOT_SELECT_BATTLE_TARGET, atarget))
-			continue;
+		if(select_target) {
+			if(atarget->is_affected_by_effect(EFFECT_CANNOT_BE_BATTLE_TARGET, pcard))
+				continue;
+			if(pcard->is_affected_by_effect(EFFECT_CANNOT_SELECT_BATTLE_TARGET, atarget))
+				continue;
+		}
 		v->push_back(atarget);
 	}
 	if((mcount == 0 || pcard->is_affected_by_effect(EFFECT_DIRECT_ATTACK) || core.attack_player)
@@ -2420,113 +2368,11 @@ int32 field::get_attack_target(card* pcard, card_vector* v, uint8 chain_attack) 
 		pcard->direct_attackable = 1;
 	return atype;
 }
-// return: core.attack_target is valid or not
 bool field::confirm_attack_target() {
-	card* pcard = core.attacker;
-	uint8 p = pcard->current.controler;
-	effect* peffect;
-	card_vector* pv = NULL;
-	int32 atype = 0;
-	card_vector must_attack;
-	card_vector only_be_attack;
-	card_vector only_attack;
-	effect_set eset;
-
-	// find the universal set
-	for(auto cit = player[1 - p].list_mzone.begin(); cit != player[1 - p].list_mzone.end(); ++cit) {
-		card* atarget = *cit;
-		if(atarget) {
-			if(atarget->is_affected_by_effect(EFFECT_ONLY_BE_ATTACKED))
-				only_be_attack.push_back(atarget);
-			if(pcard->is_affected_by_effect(EFFECT_MUST_ATTACK_MONSTER, atarget))
-				must_attack.push_back(atarget);
-			if(pcard->is_affected_by_effect(EFFECT_ONLY_ATTACK_MONSTER, atarget))
-				only_attack.push_back(atarget);
-		}
-	}
-	if(only_be_attack.size()) {
-		atype = 1;
-		if(only_be_attack.size() == 1)
-			pv = &only_be_attack;
-		else
-			return false;
-	} else if(pcard->is_affected_by_effect(EFFECT_ONLY_ATTACK_MONSTER)) {
-		atype = 2;
-		if(only_attack.size() == 1)
-			pv = &only_attack;
-		else
-			return false;
-	} else if(pcard->is_affected_by_effect(EFFECT_MUST_ATTACK_MONSTER)) {
-		atype = 3;
-		if(must_attack.size())
-			pv = &must_attack;
-		else
-			return false;
-	} else {
-		atype = 4;
-		pv = &player[1 - p].list_mzone;
-	}
-	// extra count
-	int32 ct1 = 0, ct2 = 0;
-	int32 tmp = 0;
-	effect_set exts1, exts2;
-	bool dir = true;
-	pcard->filter_effect(EFFECT_EXTRA_ATTACK, &exts1);
-	for(int32 i = 0; i < exts1.size(); ++i) {
-		tmp = exts1[i]->get_value(pcard);
-		if(tmp > ct1)
-			ct1 = tmp;
-	}
-	pcard->filter_effect(EFFECT_EXTRA_ATTACK_MONSTER, &exts2);
-	for(int32 i = 0; i < exts2.size(); ++i) {
-		tmp = exts2[i]->get_value(pcard);
-		if(tmp > ct2)
-			ct2 = tmp;
-	}
-	if(pcard->announce_count <= ct1 + 1)
-		dir = true;
-	else if(core.chain_attack && !core.chain_attack_target)
-		dir = true;
-	else if(ct2 && pcard->announce_count <= ct2 + 1
-			&& pcard->announced_cards.find(0) == pcard->announced_cards.end() && pcard->battled_cards.find(0) == pcard->battled_cards.end())
-		dir = false;
-	else {
-		// effects with target limit
-		if((peffect = pcard->is_affected_by_effect(EFFECT_ATTACK_ALL)) && pcard->attack_all_target && core.attack_target) {
-			// valid target
-			pduel->lua->add_param(core.attack_target, PARAM_TYPE_CARD);
-			if(!peffect->check_value_condition(1))
-				return false;
-			// enough effect count
-			auto it = pcard->announced_cards.find(core.attack_target->fieldid_r);
-			if(it != pcard->announced_cards.end() && (int32)it->second.second > peffect->get_value(core.attack_target)) {
-				return false;
-			}
-			it = pcard->battled_cards.find(core.attack_target->fieldid_r);
-			if(it != pcard->battled_cards.end() && (int32)it->second.second > peffect->get_value(core.attack_target)) {
-				return false;
-			}
-			return true;
-		}
-		if(core.chain_attack && core.chain_attack_target && core.chain_attack_target == core.attack_target) {
-			return true;
-		}
-		return false;
-	}
-	uint32 mcount = 0;
-	for(auto cit = pv->begin(); cit != pv->end(); ++cit) {
-		card* atarget = *cit;
-		if(!atarget)
-			continue;
-		if(atarget->is_affected_by_effect(EFFECT_IGNORE_BATTLE_TARGET))
-			continue;
-		mcount++;
-	}
-	if(core.attack_target)
-		return std::find(pv->begin(), pv->end(), core.attack_target) != pv->end();
-	else
-		return (mcount == 0 || pcard->is_affected_by_effect(EFFECT_DIRECT_ATTACK) || core.attack_player)
-			&& !pcard->is_affected_by_effect(EFFECT_CANNOT_DIRECT_ATTACK) && dir;
+	card_vector cv;
+	get_attack_target(core.attacker, &cv, core.chain_attack, false);
+	return core.attack_target && std::find(cv.begin(), cv.end(), core.attack_target) != cv.end()
+		|| !core.attack_target && core.attacker->direct_attackable;
 }
 // update the validity for EFFECT_ATTACK_ALL (approximate solution)
 void field::attack_all_target_check() {

--- a/field.h
+++ b/field.h
@@ -429,7 +429,7 @@ public:
 
 	uint32 get_field_counter(uint8 self, uint8 s, uint8 o, uint16 countertype);
 	int32 effect_replace_check(uint32 code, const tevent& e);
-	int32 get_attack_target(card* pcard, card_vector* v, uint8 chain_attack = FALSE);
+	int32 get_attack_target(card* pcard, card_vector* v, uint8 chain_attack = FALSE, bool select_target = true);
 	bool confirm_attack_target();
 	void attack_all_target_check();
 	int32 check_synchro_material(card* pcard, int32 findex1, int32 findex2, int32 min, int32 max, card* smat, group* mg);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -1325,10 +1325,10 @@ int32 scriptlib::card_is_direct_attacked(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	bool ret = false;
-	if(pcard->attacked_cards.find(0) != pcard->attacked_cards.end())
-		ret = true;
-	lua_pushboolean(L, ret);
+	if(pcard->attacked_cards.findcard(0))
+		lua_pushboolean(L, 1);
+	else
+		lua_pushboolean(L, 0);
 	return 1;
 }
 int32 scriptlib::card_set_card_target(lua_State *L) {

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -1318,7 +1318,7 @@ int32 scriptlib::card_get_attack_announced_count(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	lua_pushinteger(L, pcard->announce_count);
+	lua_pushinteger(L, pcard->attack_announce_count);
 	return 1;
 }
 int32 scriptlib::card_is_direct_attacked(lua_State *L) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1417,6 +1417,7 @@ int32 scriptlib::duel_change_attacker(lua_State *L) {
 	card* attack_target = pduel->game_field->core.attack_target;
 	pduel->game_field->core.attacker->announce_count++;
 	pduel->game_field->core.attacker->announced_cards.addcard(attack_target);
+	pduel->game_field->attack_all_target_check();
 	pduel->game_field->core.attacker = attacker;
 	attacker->attack_controler = attacker->current.controler;
 	pduel->game_field->core.pre_field[0] = attacker->fieldid_r;
@@ -1458,7 +1459,6 @@ int32 scriptlib::duel_change_attack_target(lua_State *L) {
 			if(pcard)
 				pduel->game_field->core.opp_mzone.insert(pcard->fieldid_r);
 		}
-		pduel->game_field->attack_all_target_check();
 		pduel->write_buffer8(MSG_ATTACK);
 		pduel->write_buffer32(attacker->get_info_location());
 		if(target) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1414,13 +1414,14 @@ int32 scriptlib::duel_change_attacker(lua_State *L) {
 	duel* pduel = attacker->pduel;
 	if(pduel->game_field->core.attacker == attacker)
 		return 0;
+	card* attack_target = pduel->game_field->core.attack_target;
+	pduel->game_field->core.attacker->announce_count++;
+	pduel->game_field->core.attacker->announced_cards.addcard(attack_target);
 	pduel->game_field->core.attacker = attacker;
 	attacker->attack_controler = attacker->current.controler;
 	pduel->game_field->core.pre_field[0] = attacker->fieldid_r;
 	if(!ignore_count) {
-		card* attack_target = pduel->game_field->core.attack_target;
-		attacker->announce_count++;
-		attacker->announced_cards.addcard(attack_target);
+		attacker->attack_announce_count++;
 		if(pduel->game_field->infos.phase == PHASE_DAMAGE) {
 			attacker->attacked_count++;
 			attacker->attacked_cards.addcard(attack_target);
@@ -1447,25 +1448,29 @@ int32 scriptlib::duel_change_attack_target(lua_State *L) {
 	}
 	field::card_vector cv;
 	pduel->game_field->get_attack_target(attacker, &cv, pduel->game_field->core.chain_attack);
-	auto turnp = pduel->game_field->infos.turn_player;
 	if(target && std::find(cv.begin(), cv.end(), target) != cv.end()
-			|| !target && !attacker->is_affected_by_effect(EFFECT_CANNOT_DIRECT_ATTACK)) {
+		|| !target && !attacker->is_affected_by_effect(EFFECT_CANNOT_DIRECT_ATTACK)) {
 		pduel->game_field->core.attack_target = target;
 		pduel->game_field->core.attack_rollback = FALSE;
 		pduel->game_field->core.opp_mzone.clear();
-		for(uint32 i = 0; i < pduel->game_field->player[1 - turnp].list_mzone.size(); ++i) {
-			card* pcard = pduel->game_field->player[1 - turnp].list_mzone[i];
+		uint8 turnp = pduel->game_field->infos.turn_player;
+		for(auto& pcard : pduel->game_field->player[1 - turnp].list_mzone) {
 			if(pcard)
 				pduel->game_field->core.opp_mzone.insert(pcard->fieldid_r);
 		}
 		pduel->game_field->attack_all_target_check();
+		pduel->write_buffer8(MSG_ATTACK);
+		pduel->write_buffer32(attacker->get_info_location());
 		if(target) {
 			pduel->game_field->raise_single_event(target, 0, EVENT_BE_BATTLE_TARGET, 0, REASON_REPLACE, 0, 1 - turnp, 0);
 			pduel->game_field->raise_event(target, EVENT_BE_BATTLE_TARGET, 0, REASON_REPLACE, 0, 1 - turnp, 0);
 			pduel->game_field->process_single_event();
 			pduel->game_field->process_instant_event();
-		} else
+			pduel->write_buffer32(target->get_info_location());
+		} else {
 			pduel->game_field->core.attack_player = TRUE;
+			pduel->write_buffer32(0);
+		}
 		lua_pushboolean(L, 1);
 	} else
 		lua_pushboolean(L, 0);
@@ -1478,7 +1483,7 @@ int32 scriptlib::duel_calculate_damage(lua_State *L) {
 	card* attacker = *(card**)lua_touserdata(L, 1);
 	card* attack_target;
 	if(lua_isnil(L, 2))
-		attack_target = NULL;
+		attack_target = 0;
 	else {
 		check_param(L, PARAM_TYPE_CARD, 2);
 		attack_target = *(card**)lua_touserdata(L, 2);

--- a/processor.cpp
+++ b/processor.cpp
@@ -3067,7 +3067,6 @@ int32 field::process_battle_command(uint16 step) {
 		return FALSE;
 	}
 	case 8: {
-		attack_all_target_check();
 		pduel->write_buffer8(MSG_ATTACK);
 		pduel->write_buffer32(core.attacker->get_info_location());
 		if(core.attack_target) {
@@ -3140,6 +3139,7 @@ int32 field::process_battle_command(uint16 step) {
 		if(!rollback) {
 			core.attacker->announce_count++;
 			core.attacker->announced_cards.addcard(core.attack_target);
+			attack_all_target_check();
 			core.units.begin()->step = 18;
 			return FALSE;
 		}
@@ -3170,6 +3170,8 @@ int32 field::process_battle_command(uint16 step) {
 	case 13: {
 		core.attacker->announce_count++;
 		core.attacker->announced_cards.addcard(core.attack_target);
+		if(core.attacker->fieldid_r == core.pre_field[0])
+			attack_all_target_check();
 		core.chain_attack = FALSE;
 		core.units.begin()->step = -1;
 		reset_phase(PHASE_DAMAGE);
@@ -3680,6 +3682,7 @@ int32 field::process_damage_step(uint16 step, uint32 new_attack) {
 			core.battled_count[infos.turn_player]++;
 			check_card_counter(core.attacker, 5, infos.turn_player);
 		}
+		core.attacker->announced_cards.addcard(core.attack_target);
 		attack_all_target_check();
 		pduel->write_buffer8(MSG_ATTACK);
 		pduel->write_buffer32(core.attacker->get_info_location());


### PR DESCRIPTION
Use another `attack_announce_count` for announce count in scripts.
`announce_count` is only used in ocgcore. 

When selecting attack target, `announce_count` don't increase. It increases only when the attacking is passed or stopped.
So that the behavior of `get_attack_target` is the same when getting attackable monsters and selecting attack target.
And merge `confirm_attack_target` into `get_attack_target` via a parameter `select_target`.

All these can reduce much repeated code in `get_attack_target` and `confirm_attack_target` and make it easier to maintain them.