### PR TITLE
update query_field_info

### DIFF
--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -287,52 +287,52 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(ptr pduel, uint8 playerid, uint
 extern "C" DECL_DLLEXPORT int32 query_field_info(ptr pduel, byte* buf) {
 	duel* ptduel = (duel*)pduel;
 	byte* p = buf;
-	*buf++ = MSG_RELOAD_FIELD;
-	*buf++ = ptduel->game_field->core.duel_rule;
+	*p++ = MSG_RELOAD_FIELD;
+	*p++ = ptduel->game_field->core.duel_rule;
 	for(int playerid = 0; playerid < 2; ++playerid) {
 		auto& player = ptduel->game_field->player[playerid];
-		*((int*)buf) = player.lp;
-		buf += 4;
+		*((int*)p) = player.lp;
+		p += 4;
 		for(auto cit = player.list_mzone.begin(); cit != player.list_mzone.end(); ++cit) {
 			card* pcard = *cit;
 			if(pcard) {
-				*buf++ = 1;
-				*buf++ = pcard->current.position;
-				*buf++ = pcard->xyz_materials.size();
+				*p++ = 1;
+				*p++ = pcard->current.position;
+				*p++ = pcard->xyz_materials.size();
 			} else {
-				*buf++ = 0;
+				*p++ = 0;
 			}
 		}
 		for(auto cit = player.list_szone.begin(); cit != player.list_szone.end(); ++cit) {
 			card* pcard = *cit;
 			if(pcard) {
-				*buf++ = 1;
-				*buf++ = pcard->current.position;
+				*p++ = 1;
+				*p++ = pcard->current.position;
 			} else {
-				*buf++ = 0;
+				*p++ = 0;
 			}
 		}
-		*buf++ = player.list_main.size();
-		*buf++ = player.list_hand.size();
-		*buf++ = player.list_grave.size();
-		*buf++ = player.list_remove.size();
-		*buf++ = player.list_extra.size();
-		*buf++ = player.extra_p_count;
+		*p++ = player.list_main.size();
+		*p++ = player.list_hand.size();
+		*p++ = player.list_grave.size();
+		*p++ = player.list_remove.size();
+		*p++ = player.list_extra.size();
+		*p++ = player.extra_p_count;
 	}
-	*buf++ = ptduel->game_field->core.current_chain.size();
+	*p++ = ptduel->game_field->core.current_chain.size();
 	for(auto chit = ptduel->game_field->core.current_chain.begin(); chit != ptduel->game_field->core.current_chain.end(); ++chit) {
 		effect* peffect = chit->triggering_effect;
-		*((int*)buf) = peffect->get_handler()->data.code;
-		buf += 4;
-		*((int*)buf) = peffect->get_handler()->get_info_location();
-		buf += 4;
-		*buf++ = chit->triggering_controler;
-		*buf++ = (uint8)chit->triggering_location;
-		*buf++ = chit->triggering_sequence;
-		*((int*)buf) = peffect->description;
-		buf += 4;
+		*((int*)p) = peffect->get_handler()->data.code;
+		p += 4;
+		*((int*)p) = peffect->get_handler()->get_info_location();
+		p += 4;
+		*p++ = chit->triggering_controler;
+		*p++ = (uint8)chit->triggering_location;
+		*p++ = chit->triggering_sequence;
+		*((int*)p) = peffect->description;
+		p += 4;
 	}
-	return (int32)(buf - p);
+	return (int32)(p - buf);
 }
 extern "C" DECL_DLLEXPORT void set_responsei(ptr pduel, int32 value) {
 	((duel*)pduel)->set_responsei(value);


### PR DESCRIPTION
Like other API function that read buffer such as `query_field_card`, do not change the `buf` parameter, whick makes it easier to use.
Before:
```
char query_buffer[256];
char* qbuf = query_buffer;
int length = query_field_info(pduel, (unsigned char*)qbuf);
NetServer::SendBufferToPlayer(dp, STOC_GAME_MSG, query_buffer, length);
```
After:
```
char query_buffer[256];
int length = query_field_info(pduel, query_buffer);
NetServer::SendBufferToPlayer(dp, STOC_GAME_MSG, query_buffer, length);
```