### PR TITLE
remove EVENT_DAMAGE_CALCULATING

### DIFF
--- a/effect.h
+++ b/effect.h
@@ -484,7 +484,7 @@ inline effect_flag operator|(effect_flag flag1, effect_flag flag2)
 #define EVENT_BATTLE_START			1132
 #define EVENT_BATTLE_CONFIRM		1133
 #define EVENT_PRE_DAMAGE_CALCULATE	1134
-#define EVENT_DAMAGE_CALCULATING	1135
+//#define EVENT_DAMAGE_CALCULATING	1135
 #define EVENT_PRE_BATTLE_DAMAGE		1136
 //#define EVENT_BATTLE_END			1137
 #define EVENT_BATTLED				1138

--- a/processor.cpp
+++ b/processor.cpp
@@ -3308,15 +3308,6 @@ int32 field::process_battle_command(uint16 step) {
 			core.units.begin()->step = 32;
 			return FALSE;
 		}
-		raise_single_event(core.attacker, 0, EVENT_DAMAGE_CALCULATING, 0, 0, 0, 0, 0);
-		if(core.attack_target)
-			raise_single_event(core.attack_target, 0, EVENT_DAMAGE_CALCULATING, 0, 0, 0, 0, 1);
-		raise_event((card*)0, EVENT_DAMAGE_CALCULATING, 0, 0, 0, 0, 0);
-		process_single_event();
-		process_instant_event();
-		//this timing does not exist in Master Rule 3
-		core.new_ochain.clear();
-		core.new_fchain.clear();
 		return FALSE;
 	}
 	case 26: {
@@ -3707,12 +3698,6 @@ int32 field::process_damage_step(uint16 step, uint32 new_attack) {
 	}
 	case 1: {
 		infos.phase = PHASE_DAMAGE_CAL;
-		raise_single_event(core.attacker, 0, EVENT_DAMAGE_CALCULATING, 0, 0, 0, 0, 0);
-		if(core.attack_target)
-			raise_single_event(core.attack_target, 0, EVENT_DAMAGE_CALCULATING, 0, 0, 0, 0, 1);
-		raise_event((card*)0, EVENT_DAMAGE_CALCULATING, 0, 0, 0, 0, 0);
-		process_single_event();
-		process_instant_event();
 		add_process(PROCESSOR_BATTLE_COMMAND, 26, 0, 0, 0, 0);
 		core.units.begin()->step = 2;
 		core.reserved = core.units.front();


### PR DESCRIPTION
No such timing in the rule.
It was used to implement the continuous effect that only applies during damage calculation.
But continuous effect should be available as long as the condition is satisfied, not becomes available at some timing.

Its usage has been remove from scripts two years ago. see Fluorohydride/ygopro-scripts@c9c9485 and Fluorohydride/ygopro-scripts@7cfab27
~and the commit Fluorohydride/ygopro-scripts@89a8c44 fixed a little gap of effects like _Skyscraper_~.