### PR TITLE
fix undefined behavior caused by lua_yield

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1534,11 +1534,6 @@ int32 card::get_old_union_count() {
 	}
 	return count;
 }
-void card::xyz_overlay(card* pcard) {
-	card_set materials;
-	materials.insert(pcard);
-	xyz_overlay(&materials);
-}
 void card::xyz_overlay(card_set* materials) {
 	if(materials->size() == 0)
 		return;
@@ -1571,6 +1566,11 @@ void card::xyz_overlay(card_set* materials) {
 		pduel->game_field->destroy(&des, 0, REASON_LOST_TARGET + REASON_RULE, PLAYER_NONE);
 	else
 		pduel->game_field->adjust_instant();
+}
+void card::xyz_overlay(card* pcard) {
+	card_set materials;
+	materials.insert(pcard);
+	xyz_overlay(&materials);
 }
 void card::xyz_add(card* mat, card_set* des) {
 	if(mat->overlay_target == this)

--- a/card.cpp
+++ b/card.cpp
@@ -1534,6 +1534,11 @@ int32 card::get_old_union_count() {
 	}
 	return count;
 }
+void card::xyz_overlay(card* pcard) {
+	card_set materials;
+	materials.insert(pcard);
+	xyz_overlay(&materials);
+}
 void card::xyz_overlay(card_set* materials) {
 	if(materials->size() == 0)
 		return;

--- a/card.h
+++ b/card.h
@@ -242,6 +242,7 @@ public:
 	void unequip();
 	int32 get_union_count();
 	int32 get_old_union_count();
+	void xyz_overlay(card* pcard);
 	void xyz_overlay(card_set* materials);
 	void xyz_add(card* mat, card_set* des);
 	void xyz_remove(card* mat);

--- a/card.h
+++ b/card.h
@@ -242,8 +242,8 @@ public:
 	void unequip();
 	int32 get_union_count();
 	int32 get_old_union_count();
-	void xyz_overlay(card* pcard);
 	void xyz_overlay(card_set* materials);
+	void xyz_overlay(card* pcard);
 	void xyz_add(card* mat, card_set* des);
 	void xyz_remove(card* mat);
 	void apply_field_effect();

--- a/field.h
+++ b/field.h
@@ -524,6 +524,7 @@ public:
 	void mset(uint32 setplayer, card* target, effect* proc, uint32 ignore_count, uint32 min_tribute, uint32 zone = 0x1f);
 	void special_summon_rule(uint32 sumplayer, card* target, uint32 summon_type);
 	void special_summon(card_set* target, uint32 sumtype, uint32 sumplayer, uint32 playerid, uint32 nocheck, uint32 nolimit, uint32 positions, uint32 zone);
+	void special_summon(card* target, uint32 sumtype, uint32 sumplayer, uint32 playerid, uint32 nocheck, uint32 nolimit, uint32 positions, uint32 zone);
 	void special_summon_step(card* target, uint32 sumtype, uint32 sumplayer, uint32 playerid, uint32 nocheck, uint32 nolimit, uint32 positions, uint32 zone);
 	void special_summon_complete(effect* reason_effect, uint8 reason_player);
 	void destroy(card_set* targets, effect* reason_effect, uint32 reason, uint32 reason_player, uint32 playerid = 2, uint32 destination = 0, uint32 sequence = 0);

--- a/operations.cpp
+++ b/operations.cpp
@@ -172,6 +172,11 @@ void field::special_summon(card_set* target, uint32 sumtype, uint32 sumplayer, u
 	pgroup->is_readonly = TRUE;
 	add_process(PROCESSOR_SPSUMMON, 0, core.reason_effect, pgroup, core.reason_player, zone);
 }
+void field::special_summon(card* target, uint32 sumtype, uint32 sumplayer, uint32 playerid, uint32 nocheck, uint32 nolimit, uint32 positions, uint32 zone) {
+	card_set cset;
+	cset.insert(target);
+	special_summon(&cset, sumtype, sumplayer, playerid, nocheck, nolimit, positions, zone);
+}
 void field::special_summon_step(card* target, uint32 sumtype, uint32 sumplayer, uint32 playerid, uint32 nocheck, uint32 nolimit, uint32 positions, uint32 zone) {
 	if((positions & POS_FACEDOWN) && is_player_affected_by_effect(sumplayer, EFFECT_DEVINE_LIGHT))
 		positions = (positions & POS_FACEUP) | ((positions & POS_FACEDOWN) >> 1);

--- a/processor.cpp
+++ b/processor.cpp
@@ -826,7 +826,18 @@ int32 field::process() {
 	}
 	case PROCESSOR_SELECT_SUM_S: {
 		if(it->step == 0) {
-			add_process(PROCESSOR_SELECT_SUM, 0, it->peffect, it->ptarget, it->arg1, it->arg2);
+			card_vector cv(core.must_select_cards);
+			int32 mcount = cv.size();
+			cv.insert(cv.end(), core.select_cards.begin(), core.select_cards.end());
+			int32 acc = it->arg1;
+			int32 min = (it->arg2 >> 16) & 0xff;
+			int32 max = (it->arg2 >> 24) & 0xff;
+			if(max && !check_with_sum_limit_m(cv, acc, 0, min, max, mcount)
+				|| !check_with_sum_greater_limit_m(cv, acc, 0, 0xffff, mcount)) {
+				core.must_select_cards.clear();
+				returns.bvalue[0] = 0;
+			} else
+				add_process(PROCESSOR_SELECT_SUM, 0, it->peffect, it->ptarget, it->arg1, it->arg2);
 			it->step++;
 		} else {
 			group* pgroup = pduel->new_group();


### PR DESCRIPTION
There is a `longjmp` behind `lua_yield` (jump to `setjmp` behind `lua_resume`), so if there are local variables that have non-trivial destructor used before `lua_yield`, the behavior is undefined.

Another solution is to build lua library as C++ code. `lua_resume`/`lua_yield` will use `try{}catch(...)`/`throw`, so destructor will be called normally.

I think this is the reason of these issues: Fluorohydride/ygopro#1854 Fluorohydride/ygopro#1682 #141