### PR TITLE
update summon proc

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2868,7 +2868,6 @@ int32 card::check_cost_condition(int32 ecode, int32 playerid, int32 sumtype) {
 	}
 	return TRUE;
 }
-// check if this is a normal summonable card
 int32 card::is_summonable_card() {
 	if(!(data.type & TYPE_MONSTER) || (data.type & TYPE_TOKEN))
 		return FALSE;
@@ -2938,18 +2937,17 @@ int32 card::is_summonable(effect* peffect, uint8 min_tribute, uint32 zone, uint3
 	pduel->lua->add_param(min_tribute, PARAM_TYPE_INT);
 	pduel->lua->add_param(zone, PARAM_TYPE_INT);
 	pduel->lua->add_param(releasable, PARAM_TYPE_INT);
+	pduel->game_field->core.limit_extra_summon_zone = zone;
+	pduel->game_field->core.limit_extra_summon_releasable = releasable;
 	if(pduel->lua->check_condition(peffect->condition, 5))
 		result = TRUE;
+	pduel->game_field->core.limit_extra_summon_zone = 0;
+	pduel->game_field->core.limit_extra_summon_releasable = 0;
 	pduel->game_field->restore_lp_cost();
 	pduel->game_field->core.reason_effect = oreason;
 	pduel->game_field->core.reason_player = op;
 	return result;
 }
-// if this does not have a summon procedure, it will check ordinary summon
-// ignore_count: ignore the summon count in this turn or not
-// peffect: effects that change the ordinary summon procedure (c80921533)
-// min_tribute: the limit of min tribute number by EFFECT_EXTRA_SUMMON_COUNT
-// return: whether playerid can summon this or not
 int32 card::is_can_be_summoned(uint8 playerid, uint8 ignore_count, effect* peffect, uint8 min_tribute, uint32 zone) {
 	if(!is_summonable_card())
 		return FALSE;
@@ -2994,7 +2992,6 @@ int32 card::is_can_be_summoned(uint8 playerid, uint8 ignore_count, effect* peffe
 	pduel->game_field->restore_lp_cost();
 	return TRUE;
 }
-// return: the min/max number of tribute for an ordinary advance summon of this
 int32 card::get_summon_tribute_count() {
 	int32 min = 0, max = 0;
 	int32 minul = 0, maxul = 0;

--- a/field.h
+++ b/field.h
@@ -258,6 +258,8 @@ struct processor {
 	uint8 summon_cancelable;
 	card* attacker;
 	card* attack_target;
+	uint32 limit_extra_summon_zone;
+	uint32 limit_extra_summon_releasable;
 	card* limit_tuner;
 	group* limit_syn;
 	group* limit_xyz;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2469,11 +2469,16 @@ int32 scriptlib::duel_check_tribute(lua_State *L) {
 	uint8 toplayer = target->current.controler;
 	if(lua_gettop(L) >= 5 && !lua_isnil(L, 5))
 		toplayer = lua_tointeger(L, 5);
+	duel* pduel = target->pduel;
 	uint32 zone = 0x1f;
+	if(pduel->game_field->core.limit_extra_summon_zone)
+		zone= pduel->game_field->core.limit_extra_summon_zone;
 	if(lua_gettop(L) >= 6 && !lua_isnil(L, 6))
 		zone = lua_tointeger(L, 6);
-	duel* pduel = target->pduel;
-	lua_pushboolean(L, pduel->game_field->check_tribute(target, min, max, mg, toplayer, zone));
+	uint32 releasable = 0xff00ff;
+	if(pduel->game_field->core.limit_extra_summon_releasable)
+		releasable = pduel->game_field->core.limit_extra_summon_releasable;
+	lua_pushboolean(L, pduel->game_field->check_tribute(target, min, max, mg, toplayer, zone, releasable));
 	return 1;
 }
 int32 scriptlib::duel_select_tribute(lua_State *L) {
@@ -2499,12 +2504,17 @@ int32 scriptlib::duel_select_tribute(lua_State *L) {
 	uint32 ex = FALSE;
 	if(toplayer != playerid)
 		ex = TRUE;
-	uint32 zone = 0x1f;
 	duel* pduel = interpreter::get_duel_info(L);
+	uint32 zone = 0x1f;
+	if(pduel->game_field->core.limit_extra_summon_zone)
+		zone = pduel->game_field->core.limit_extra_summon_zone;
+	uint32 releasable = 0xff00ff;
+	if(pduel->game_field->core.limit_extra_summon_releasable)
+		releasable = pduel->game_field->core.limit_extra_summon_releasable;
 	pduel->game_field->core.release_cards.clear();
 	pduel->game_field->core.release_cards_ex.clear();
 	pduel->game_field->core.release_cards_ex_oneof.clear();
-	pduel->game_field->get_summon_release_list(target, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, mg, ex);
+	pduel->game_field->get_summon_release_list(target, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, mg, ex, releasable);
 	pduel->game_field->select_tribute_cards(0, playerid, 0, min, max, toplayer, zone);
 	pduel->game_field->core.subunits.back().type = PROCESSOR_SELECT_TRIBUTE_S;
 	return lua_yield(L, 0);

--- a/operations.cpp
+++ b/operations.cpp
@@ -1551,6 +1551,7 @@ int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, ui
 				min_tribute = new_min_tribute;
 			zone &= new_zone;
 			core.units.begin()->arg1 = sumplayer + (ignore_count << 8) + (min_tribute << 16) + (zone << 24);
+			core.units.begin()->arg3 = releasable;
 		}
 		if(proc) {
 			core.units.begin()->step = 3;
@@ -1704,9 +1705,14 @@ int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, ui
 		target->summon_info = (proc->get_value(target) & 0xfffffff) | SUMMON_TYPE_NORMAL | (LOCATION_HAND << 16);
 		target->current.reason_effect = proc;
 		target->current.reason_player = sumplayer;
+		int32 releasable = core.units.begin()->arg3;
 		if(proc->operation) {
 			pduel->lua->add_param(target, PARAM_TYPE_CARD);
 			pduel->lua->add_param(min_tribute, PARAM_TYPE_INT);
+			pduel->lua->add_param(zone, PARAM_TYPE_INT);
+			pduel->lua->add_param(releasable, PARAM_TYPE_INT);
+			pduel->game_field->core.limit_extra_summon_zone = zone;
+			pduel->game_field->core.limit_extra_summon_releasable = releasable;
 			core.sub_solving_event.push_back(nil_event);
 			add_process(PROCESSOR_EXECUTE_OPERATION, 0, proc, 0, sumplayer, 0);
 		}
@@ -1714,6 +1720,8 @@ int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, ui
 		return FALSE;
 	}
 	case 7: {
+		pduel->game_field->core.limit_extra_summon_zone = 0;
+		pduel->game_field->core.limit_extra_summon_releasable = 0;
 		core.summon_depth--;
 		if(core.summon_depth)
 			return TRUE;


### PR DESCRIPTION
when monster use `EFFECT_SUMMON_PROC`, for extra opportunity of normal summon count, it ignores the zone and releasable parameter of extra summon count, so the scripts of that kind of monsters need update.
This pull request set the parameter internally to avoid updating scripts.