### PR TITLE
Coding convention fix (like unify) for another project

### DIFF
--- a/libcard.cpp
+++ b/libcard.cpp
@@ -375,7 +375,7 @@ int32 scriptlib::card_get_linked_zone(lua_State *L) {
 int32 scriptlib::card_get_mutual_linked_group(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	card::card_set cset;
 	pcard->get_mutual_linked_cards(&cset);
 	group* pgroup = pcard->pduel->new_group(cset);
@@ -385,7 +385,7 @@ int32 scriptlib::card_get_mutual_linked_group(lua_State *L) {
 int32 scriptlib::card_get_mutual_linked_group_count(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	card::card_set cset;
 	pcard->get_mutual_linked_cards(&cset);
 	lua_pushinteger(L, cset.size());
@@ -394,7 +394,7 @@ int32 scriptlib::card_get_mutual_linked_group_count(lua_State *L) {
 int32 scriptlib::card_get_mutual_linked_zone(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 zone = pcard->get_mutual_linked_zone();
 	int32 cp = pcard->current.controler;
 	if(lua_gettop(L) >= 2 && !lua_isnil(L, 2))
@@ -480,7 +480,7 @@ int32 scriptlib::card_get_origin_attribute(lua_State *L) {
 int32 scriptlib::card_get_fusion_attribute(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	int32 playerid = PLAYER_NONE;
 	if(lua_gettop(L) > 1 && !lua_isnil(L, 2))
 		playerid = lua_tointeger(L, 2);
@@ -492,7 +492,7 @@ int32 scriptlib::card_get_fusion_attribute(lua_State *L) {
 int32 scriptlib::card_get_link_attribute(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	int32 playerid = PLAYER_NONE;
 	if(lua_gettop(L) > 1 && !lua_isnil(L, 2))
 		playerid = lua_tointeger(L, 2);
@@ -521,7 +521,7 @@ int32 scriptlib::card_get_origin_race(lua_State *L) {
 int32 scriptlib::card_get_link_race(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	int32 playerid = PLAYER_NONE;
 	if(lua_gettop(L) > 1 && !lua_isnil(L, 2))
 		playerid = lua_tointeger(L, 2);
@@ -987,7 +987,7 @@ int32 scriptlib::card_is_race(lua_State *L) {
 int32 scriptlib::card_is_link_race(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 trace = lua_tointeger(L, 2);
 	int32 playerid = PLAYER_NONE;
 	if(lua_gettop(L) > 2 && !lua_isnil(L, 3))
@@ -1014,7 +1014,7 @@ int32 scriptlib::card_is_attribute(lua_State *L) {
 int32 scriptlib::card_is_fusion_attribute(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 tattrib = lua_tointeger(L, 2);
 	int32 playerid = PLAYER_NONE;
 	if(lua_gettop(L) > 2 && !lua_isnil(L, 3))
@@ -1030,7 +1030,7 @@ int32 scriptlib::card_is_fusion_attribute(lua_State *L) {
 int32 scriptlib::card_is_link_attribute(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 tattrib = lua_tointeger(L, 2);
 	int32 playerid = PLAYER_NONE;
 	if(lua_gettop(L) > 2 && !lua_isnil(L, 3))
@@ -1057,7 +1057,7 @@ int32 scriptlib::card_is_reason(lua_State *L) {
 int32 scriptlib::card_is_summon_type(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 ttype = lua_tointeger(L, 2);
 	if(((pcard->summon_info & 0xff00ffff) & ttype) == ttype)
 		lua_pushboolean(L, 1);
@@ -1441,7 +1441,7 @@ int32 scriptlib::card_check_activate_effect(lua_State *L) {
 int32 scriptlib::card_get_tuner_limit(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	effect* peffect = pcard->is_affected_by_effect(EFFECT_TUNER_MATERIAL_LIMIT);
 	if(peffect) {
 		interpreter::effect2value(L, peffect);
@@ -1468,7 +1468,7 @@ int32 scriptlib::card_get_tuner_limit(lua_State *L) {
 int32 scriptlib::card_get_hand_synchro(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	effect* peffect = pcard->is_affected_by_effect(EFFECT_HAND_SYNCHRO);
 	if(peffect) {
 		interpreter::effect2value(L, peffect);
@@ -1757,7 +1757,7 @@ int32 scriptlib::card_copy_effect(lua_State *L) {
 int32 scriptlib::card_replace_effect(lua_State * L) {
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 code = lua_tointeger(L, 2);
 	uint32 reset = lua_tointeger(L, 3);
 	uint32 count = lua_tointeger(L, 4);
@@ -1859,7 +1859,7 @@ int32 scriptlib::card_is_msetable(lua_State *L) {
 	effect* peffect = 0;
 	if(!lua_isnil(L, 3)) {
 		check_param(L, PARAM_TYPE_EFFECT, 3);
-		peffect = *(effect**)lua_touserdata(L, 3);
+		peffect = *(effect**) lua_touserdata(L, 3);
 	}
 	uint32 minc = 0;
 	if(lua_gettop(L) >= 4)
@@ -1949,7 +1949,7 @@ int32 scriptlib::card_is_can_be_summoned(lua_State *L) {
 	effect* peffect = 0;
 	if(!lua_isnil(L, 3)) {
 		check_param(L, PARAM_TYPE_EFFECT, 3);
-		peffect = *(effect**)lua_touserdata(L, 3);
+		peffect = *(effect**) lua_touserdata(L, 3);
 	}
 	uint32 minc = 0;
 	if(lua_gettop(L) >= 4)
@@ -2530,7 +2530,7 @@ int32 scriptlib::card_set_counter_limit(lua_State *L) {
 int32 scriptlib::card_is_can_change_position(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	lua_pushboolean(L, pcard->is_capable_change_position_by_effect(pcard->pduel->game_field->core.reason_player));
 	return 1;
 }
@@ -2576,7 +2576,7 @@ int32 scriptlib::card_is_can_be_fusion_material(lua_State *L) {
 	card* fcard = 0;
 	if(lua_gettop(L) >= 2 && !lua_isnil(L, 2)) {
 		check_param(L, PARAM_TYPE_CARD, 2);
-		fcard = *(card**)lua_touserdata(L, 2);
+		fcard = *(card**) lua_touserdata(L, 2);
 	}
 	lua_pushboolean(L, pcard->is_can_be_fusion_material(fcard));
 	return 1;
@@ -2895,7 +2895,7 @@ int32 scriptlib::card_check_unique_onfield(lua_State *L) {
 	card* icard = 0;
 	if(lua_gettop(L) > 3) {
 		if(check_param(L, PARAM_TYPE_CARD, 4, TRUE))
-			icard = *(card**)lua_touserdata(L, 4);
+			icard = *(card**) lua_touserdata(L, 4);
 	}
 	lua_pushboolean(L, pcard->pduel->game_field->check_unique_onfield(pcard, check_player, check_location, icard) ? 0 : 1);
 	return 1;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -72,7 +72,7 @@ int32 scriptlib::duel_get_draw_count(lua_State *L) {
 int32 scriptlib::duel_register_effect(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
-	effect* peffect = *(effect**)lua_touserdata(L, 1);
+	effect* peffect = *(effect**) lua_touserdata(L, 1);
 	uint32 playerid = lua_tointeger(L, 2);
 	if(playerid != 0 && playerid != 1)
 		return 0;
@@ -253,12 +253,12 @@ int32 scriptlib::duel_summon(lua_State *L) {
 	effect* peffect = 0;
 	if(!lua_isnil(L, 4)) {
 		check_param(L, PARAM_TYPE_EFFECT, 4);
-		peffect = *(effect**)lua_touserdata(L, 4);
+		peffect = *(effect**) lua_touserdata(L, 4);
 	}
 	uint32 playerid = lua_tointeger(L, 1);
 	if(playerid != 0 && playerid != 1)
 		return 0;
-	card* pcard = *(card**)lua_touserdata(L, 2);
+	card* pcard = *(card**) lua_touserdata(L, 2);
 	uint32 ignore_count = lua_toboolean(L, 3);
 	uint32 min_tribute = 0;
 	if(lua_gettop(L) >= 5)
@@ -278,7 +278,7 @@ int32 scriptlib::duel_special_summon_rule(lua_State *L) {
 	uint32 playerid = lua_tointeger(L, 1);
 	if(playerid != 0 && playerid != 1)
 		return 0;
-	card* pcard = *(card**)lua_touserdata(L, 2);
+	card* pcard = *(card**) lua_touserdata(L, 2);
 	duel* pduel = pcard->pduel;
 	uint32 sumtype = 0;
 	if(lua_gettop(L) >= 3)
@@ -294,11 +294,11 @@ int32 scriptlib::duel_synchro_summon(lua_State *L) {
 	uint32 playerid = lua_tointeger(L, 1);
 	if(playerid != 0 && playerid != 1)
 		return 0;
-	card* pcard = *(card**)lua_touserdata(L, 2);
+	card* pcard = *(card**) lua_touserdata(L, 2);
 	card* tuner = 0;
 	if(!lua_isnil(L, 3)) {
 		check_param(L, PARAM_TYPE_CARD, 3);
-		tuner = *(card**)lua_touserdata(L, 3);
+		tuner = *(card**) lua_touserdata(L, 3);
 	}
 	group* mg = 0;
 	if(lua_gettop(L) >= 4) {
@@ -321,11 +321,11 @@ int32 scriptlib::duel_xyz_summon(lua_State *L) {
 	uint32 playerid = lua_tointeger(L, 1);
 	if(playerid != 0 && playerid != 1)
 		return 0;
-	card* pcard = *(card**)lua_touserdata(L, 2);
+	card* pcard = *(card**) lua_touserdata(L, 2);
 	group* materials = 0;
 	if(!lua_isnil(L, 3)) {
 		check_param(L, PARAM_TYPE_GROUP, 3);
-		materials = *(group**)lua_touserdata(L, 3);
+		materials = *(group**) lua_touserdata(L, 3);
 	}
 	int32 minc = 0;
 	if(lua_gettop(L) >= 4)
@@ -348,12 +348,12 @@ int32 scriptlib::duel_setm(lua_State *L) {
 	effect* peffect = 0;
 	if(!lua_isnil(L, 4)) {
 		check_param(L, PARAM_TYPE_EFFECT, 4);
-		peffect = *(effect**)lua_touserdata(L, 4);
+		peffect = *(effect**) lua_touserdata(L, 4);
 	}
 	uint32 playerid = lua_tointeger(L, 1);
 	if(playerid != 0 && playerid != 1)
 		return 0;
-	card* pcard = *(card**)lua_touserdata(L, 2);
+	card* pcard = *(card**) lua_touserdata(L, 2);
 	uint32 ignore_count = lua_toboolean(L, 3);
 	uint32 min_tribute = 0;
 	if(lua_gettop(L) >= 5)
@@ -566,7 +566,7 @@ int32 scriptlib::duel_is_can_add_counter(lua_State *L) {
 	int32 countertype = lua_tointeger(L, 2);
 	int32 count = lua_tointeger(L, 3);
 	check_param(L, PARAM_TYPE_CARD, 4);
-	card* pcard = *(card**)lua_touserdata(L, 4);
+	card* pcard = *(card**) lua_touserdata(L, 4);
 	if(playerid != 0 && playerid != 1) {
 		lua_pushboolean(L, 0);
 		return 1;
@@ -764,7 +764,7 @@ int32 scriptlib::duel_activate_effect(lua_State *L) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
-	effect* peffect = *(effect**)lua_touserdata(L, 1);
+	effect* peffect = *(effect**) lua_touserdata(L, 1);
 	duel* pduel = peffect->pduel;
 	pduel->game_field->add_process(PROCESSOR_ACTIVATE_EFFECT, 0, peffect, 0, 0, 0);
 	return 0;
@@ -953,7 +953,7 @@ int32 scriptlib::duel_raise_event(lua_State *L) {
 	effect* peffect = 0;
 	if(!lua_isnil(L, 3)) {
 		check_param(L, PARAM_TYPE_EFFECT, 3);
-		peffect = *(effect**)lua_touserdata(L, 3);
+		peffect = *(effect**) lua_touserdata(L, 3);
 	}
 	uint32 r = lua_tointeger(L, 4);
 	uint32 rp = lua_tointeger(L, 5);
@@ -975,7 +975,7 @@ int32 scriptlib::duel_raise_single_event(lua_State *L) {
 	effect* peffect = 0;
 	if(!lua_isnil(L, 3)) {
 		check_param(L, PARAM_TYPE_EFFECT, 3);
-		peffect = *(effect**)lua_touserdata(L, 3);
+		peffect = *(effect**) lua_touserdata(L, 3);
 	}
 	uint32 r = lua_tointeger(L, 4);
 	uint32 rp = lua_tointeger(L, 5);
@@ -1354,7 +1354,7 @@ int32 scriptlib::duel_shuffle_hand(lua_State *L) {
 int32 scriptlib::duel_shuffle_setcard(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_GROUP, 1);
-	group* pgroup = *(group**)lua_touserdata(L, 1);
+	group* pgroup = *(group**) lua_touserdata(L, 1);
 	if(pgroup->container.size() <= 1)
 		return 0;
 	duel* pduel = pgroup->pduel;
@@ -1436,7 +1436,7 @@ int32 scriptlib::duel_change_attack_target(lua_State *L) {
 		target = 0;
 	} else {
 		check_param(L, PARAM_TYPE_CARD, 1);
-		target = *(card**)lua_touserdata(L, 1);
+		target = *(card**) lua_touserdata(L, 1);
 		pduel = target->pduel;
 	}
 	card* attacker = pduel->game_field->core.attacker;
@@ -1477,13 +1477,13 @@ int32 scriptlib::duel_calculate_damage(lua_State *L) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* attacker = *(card**)lua_touserdata(L, 1);
+	card* attacker = *(card**) lua_touserdata(L, 1);
 	card* attack_target;
 	if(lua_isnil(L, 2))
 		attack_target = 0;
 	else {
 		check_param(L, PARAM_TYPE_CARD, 2);
-		attack_target = *(card**)lua_touserdata(L, 2);
+		attack_target = *(card**) lua_touserdata(L, 2);
 	}
 	int32 new_attack = FALSE;
 	if(lua_gettop(L) >= 3)
@@ -1521,7 +1521,7 @@ int32 scriptlib::duel_change_target(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_GROUP, 2);
 	uint32 count = lua_tointeger(L, 1);
-	group* pgroup = *(group**)lua_touserdata(L, 2);
+	group* pgroup = *(group**) lua_touserdata(L, 2);
 	duel* pduel = interpreter::get_duel_info(L);
 	pduel->game_field->change_target(count, pgroup);
 	return 0;
@@ -1576,7 +1576,7 @@ int32 scriptlib::duel_negate_effect(lua_State *L) {
 int32 scriptlib::duel_negate_related_chain(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_CARD, 1);
-	card* pcard = *(card**)lua_touserdata(L, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 reset_flag = lua_tointeger(L, 2);
 	duel* pduel = pcard->pduel;
 	if(pduel->game_field->core.current_chain.size() < 2)
@@ -1602,10 +1602,10 @@ int32 scriptlib::duel_disable_summon(lua_State *L) {
 	group* pgroup = 0;
 	duel* pduel = 0;
 	if(check_param(L, PARAM_TYPE_CARD, 1, TRUE)) {
-		pcard = *(card**)lua_touserdata(L, 1);
+		pcard = *(card**) lua_touserdata(L, 1);
 		pduel = pcard->pduel;
 	} else if(check_param(L, PARAM_TYPE_GROUP, 1, TRUE)) {
-		pgroup = *(group**)lua_touserdata(L, 1);
+		pgroup = *(group**) lua_touserdata(L, 1);
 		pduel = pgroup->pduel;
 	} else
 		luaL_error(L, "Parameter %d should be \"Card\" or \"Group\".", 1);
@@ -1680,7 +1680,7 @@ int32 scriptlib::duel_get_location_count(lua_State *L) {
 	duel* pduel = interpreter::get_duel_info(L);
 	uint32 uplayer = pduel->game_field->core.reason_player;
 	uint32 reason = LOCATION_REASON_TOFIELD;
-	if(lua_gettop(L) >= 3 && !lua_isnil(L,3))
+	if(lua_gettop(L) >= 3 && !lua_isnil(L, 3))
 		uplayer = lua_tointeger(L, 3);
 	if(lua_gettop(L) >= 4)
 		reason = lua_tointeger(L, 4);
@@ -1705,9 +1705,9 @@ int32 scriptlib::duel_get_mzone_count(lua_State *L) {
 	player_info::card_vector list_mzone[2];
 	if(lua_gettop(L) >= 2 && !lua_isnil(L, 2)) {
 		if(check_param(L, PARAM_TYPE_CARD, 2, TRUE)) {
-			mcard = *(card**)lua_touserdata(L, 2);
+			mcard = *(card**) lua_touserdata(L, 2);
 		} else if(check_param(L, PARAM_TYPE_GROUP, 2, TRUE)) {
-			mgroup = *(group**)lua_touserdata(L, 2);
+			mgroup = *(group**) lua_touserdata(L, 2);
 		} else
 			luaL_error(L, "Parameter %d should be \"Card\" or \"Group\".", 2);
 		for(int32 p = 0; p < 2; p++) {
@@ -1786,7 +1786,7 @@ int32 scriptlib::duel_get_location_count_fromex(lua_State *L) {
 	card* scard = 0;
 	if(lua_gettop(L) >= 4) {
 		check_param(L, PARAM_TYPE_CARD, 4);
-		scard = *(card**)lua_touserdata(L, 4);
+		scard = *(card**) lua_touserdata(L, 4);
 	}
 	uint32 zone = 0xff;
 	if(lua_gettop(L) >= 5)
@@ -2464,7 +2464,7 @@ int32 scriptlib::duel_check_tribute(lua_State *L) {
 	group* mg = 0;
 	if(lua_gettop(L) >= 4 && !lua_isnil(L, 4)) {
 		check_param(L, PARAM_TYPE_GROUP, 4);
-		mg = *(group**)lua_touserdata(L, 4);
+		mg = *(group**) lua_touserdata(L, 4);
 	}
 	uint8 toplayer = target->current.controler;
 	if(lua_gettop(L) >= 5 && !lua_isnil(L, 5))

--- a/libeffect.cpp
+++ b/libeffect.cpp
@@ -188,13 +188,13 @@ int32 scriptlib::effect_set_label_object(lua_State *L) {
 		return 0;
 	}
 	if(check_param(L, PARAM_TYPE_CARD, 2, TRUE)) {
-		card* p = *(card**)lua_touserdata(L, 2);
+		card* p = *(card**) lua_touserdata(L, 2);
 		peffect->label_object = p->ref_handle;
 	} else if(check_param(L, PARAM_TYPE_EFFECT, 2, TRUE)) {
-		effect* p = *(effect**)lua_touserdata(L, 2);
+		effect* p = *(effect**) lua_touserdata(L, 2);
 		peffect->label_object = p->ref_handle;
 	} else if(check_param(L, PARAM_TYPE_GROUP, 2, TRUE)) {
-		group* p = *(group**)lua_touserdata(L, 2);
+		group* p = *(group**) lua_touserdata(L, 2);
 		peffect->label_object = p->ref_handle;
 	} else
 		luaL_error(L, "Parameter 2 should be \"Card\" or \"Effect\" or \"Group\".");

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -252,8 +252,8 @@ int32 scriptlib::group_select_unselect(lua_State *L) {
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_GROUP, 1);
 	check_param(L, PARAM_TYPE_GROUP, 2);
-	group* pgroup1 = *(group**)lua_touserdata(L, 1);
-	group* pgroup2 = *(group**)lua_touserdata(L, 2);
+	group* pgroup1 = *(group**) lua_touserdata(L, 1);
+	group* pgroup2 = *(group**) lua_touserdata(L, 2);
 	duel* pduel = pgroup1->pduel;
 	uint32 playerid = lua_tointeger(L, 3);
 	if(playerid != 0 && playerid != 1)


### PR DESCRIPTION
I am working on [a project](https://github.com/ZisIsNotZis/ygoDocGen) that generates Lua Documentation by automatically inspecting CPP files in `ygopro-core` . The current program kind of strongly relies on spacing. While debugging I found some part of the `ygopro-core` source code forgot to add space when type casting. I figure it is better to directly fixing the upstream rather than creating another branch or doing complicated checking in the script. Therefore here is the fix.

It basically changes all 

    *(xxx**)lua_touserdata

to

    *(xxx**) lua_touserdata

(with a space in the middle). Most part of the code already have space. Some don't.

And another fix is changing from a `L,3` to `L, 3`