### PR TITLE
Add Group.GetHash

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -358,6 +358,7 @@ static const struct luaL_Reg grouplib[] = {
 	{ "IsContains", scriptlib::group_is_contains },
 	{ "SearchCard", scriptlib::group_search_card },
 	{ "GetBinClassCount", scriptlib::group_get_bin_class_count },
+	{ "GetHash", scriptlib::group_get_hash },
 	{ "__add", scriptlib::group_meta_add },
 	{ "__bor", scriptlib::group_meta_add },
 	{ "__sub", scriptlib::group_meta_sub },

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -654,7 +654,6 @@ int32 scriptlib::group_get_bin_class_count(lua_State *L) {
 int32 scriptlib::group_get_hash(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_GROUP, 1);
-	check_param(L, PARAM_TYPE_FUNCTION, 1);
 	group* pgroup = *(group**) lua_touserdata(L, 1);
 	uint32 hash = pgroup->container.size();
 	for (auto &pcard : pgroup->container)

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -660,7 +660,7 @@ int32 scriptlib::group_get_hash(lua_State *L) {
 	hash |= (hash << 8);
 	for (auto &pcard : pgroup->container)
 	{
-		hash ^= ((uint64)pcard ^ pcard->fieldid_r ^ (pcard->fieldid << 16) ^ (pcard->get_info_location() << 32));
+		hash ^= (pcard->fieldid_r ^ (pcard->fieldid << 16) ^ (pcard->get_info_location() << 32));
 	}
 	lua_pushinteger(L, hash);
 	return 1;

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -656,10 +656,11 @@ int32 scriptlib::group_get_hash(lua_State *L) {
 	check_param(L, PARAM_TYPE_GROUP, 1);
 	group* pgroup = *(group**) lua_touserdata(L, 1);
 	uint8 len = (uint8)pgroup->container.size();
-	uint32 hash = len | ((0xff - len) << 16) | (0xff ^ len << 8) | ((~len & 0xff) << 24);
+	uint64 hash = len | ((0xff - len) << 32) | (0xff ^ len << 16) | ((~len & 0xff) << 48);
+	hash |= (hash << 8);
 	for (auto &pcard : pgroup->container)
 	{
-		hash ^= ((unsigned long)pcard ^ ((unsigned long)pcard >> 32) ^ pcard->fieldid_r ^ (pcard->fieldid << 16));
+		hash ^= (uint64)pcard ^ pcard->fieldid_r ^ (pcard->fieldid << 32));
 	}
 	lua_pushinteger(L, hash);
 	return 1;

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -651,6 +651,19 @@ int32 scriptlib::group_get_bin_class_count(lua_State *L) {
 	lua_pushinteger(L, ans);
 	return 1;
 }
+int32 scriptlib::group_get_hash(lua_State *L) {
+	check_param_count(L, 1);
+	check_param(L, PARAM_TYPE_GROUP, 1);
+	check_param(L, PARAM_TYPE_FUNCTION, 1);
+	group* pgroup = *(group**) lua_touserdata(L, 1);
+	uint32 hash = pgroup->container.size();
+	for (auto &pcard : pgroup->container)
+	{
+		hash ^= (((unsigned long)pcard & (unsigned long)pcard >> 32) ^ pcard->fieldid);
+	}
+	lua_pushinteger(L, hash);
+	return 1;
+}
 int32 scriptlib::group_meta_add(lua_State* L) {
 	check_param_count(L, 2);
 	if(!check_param(L, PARAM_TYPE_CARD, 1, TRUE) && !check_param(L, PARAM_TYPE_GROUP, 1, TRUE))

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -655,10 +655,11 @@ int32 scriptlib::group_get_hash(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_GROUP, 1);
 	group* pgroup = *(group**) lua_touserdata(L, 1);
-	uint32 hash = pgroup->container.size();
+	uint8 len = (uint8)pgroup->container.size();
+	uint32 hash = len | ((0xff - len) << 16) | (0xff ^ len << 8) | ((~len & 0xff) << 24);
 	for (auto &pcard : pgroup->container)
 	{
-		hash ^= (((unsigned long)pcard & (unsigned long)pcard >> 32) ^ pcard->fieldid);
+		hash ^= ((unsigned long)pcard ^ ((unsigned long)pcard >> 32) ^ pcard->fieldid_r ^ (pcard->fieldid << 16));
 	}
 	lua_pushinteger(L, hash);
 	return 1;

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -655,12 +655,13 @@ int32 scriptlib::group_get_hash(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_GROUP, 1);
 	group* pgroup = *(group**) lua_touserdata(L, 1);
-	uint8 len = (uint8)pgroup->container.size();
+	uint64 len = (uint64)pgroup->container.size();
 	uint64 hash = len | ((0xff - len) << 32) | (0xff ^ len << 16) | ((~len & 0xff) << 48);
 	hash |= (hash << 8);
 	for (auto &pcard : pgroup->container)
 	{
-		hash ^= (pcard->fieldid_r ^ (pcard->fieldid << 16) ^ (pcard->get_info_location() << 32));
+		uint64 loc = (uint64)pcard->get_info_location();
+		hash ^= (pcard->fieldid_r ^ (pcard->fieldid << 16) ^ (loc << 32));
 	}
 	lua_pushinteger(L, hash);
 	return 1;

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -660,7 +660,7 @@ int32 scriptlib::group_get_hash(lua_State *L) {
 	hash |= (hash << 8);
 	for (auto &pcard : pgroup->container)
 	{
-		hash ^= ((uint64)pcard ^ pcard->fieldid_r ^ (pcard->fieldid << 32));
+		hash ^= ((uint64)pcard ^ pcard->fieldid_r ^ (pcard->fieldid << 16) ^ (pcard->get_info_location() << 32));
 	}
 	lua_pushinteger(L, hash);
 	return 1;

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -660,7 +660,7 @@ int32 scriptlib::group_get_hash(lua_State *L) {
 	hash |= (hash << 8);
 	for (auto &pcard : pgroup->container)
 	{
-		hash ^= (uint64)pcard ^ pcard->fieldid_r ^ (pcard->fieldid << 32));
+		hash ^= ((uint64)pcard ^ pcard->fieldid_r ^ (pcard->fieldid << 32));
 	}
 	lua_pushinteger(L, hash);
 	return 1;

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -357,6 +357,7 @@ public:
 	static int32 group_is_contains(lua_State *L);
 	static int32 group_search_card(lua_State *L);
 	static int32 group_get_bin_class_count(lua_State *L);
+	static int32 group_get_hash(lua_State *L);
 
 	//Duel functions
 	static int32 duel_enable_global_flag(lua_State *L);


### PR DESCRIPTION
Group.GetHash(g)
Will return a hash of a group. Groups containing same cards would return the same value.
Used in Group.SelectSubGroup.