### PR TITLE
fix Duel.SpecialSummon(group,...)

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -2964,6 +2964,8 @@ int32 field::special_summon_step(uint16 step, group* targets, card* target, uint
 			int32 ct1 = get_tofield_count(target, playerid, LOCATION_MZONE, target->summon_player, LOCATION_REASON_TOFIELD, zone, &flag1);
 			int32 ct2 = get_spsummonable_count_fromex(target, playerid, target->summon_player, zone, &flag2);
 			for(auto& pcard : targets->container) {
+				if(pcard->current.location == LOCATION_MZONE)
+					continue;
 				if(pcard->current.location != LOCATION_EXTRA)
 					ct1--;
 				else


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13391795/53739081-da1b0d80-3ecb-11e9-8e86-22d09c6049a0.png)
`ct1` had been wrongly decreased, so in this situation, the last 2 monsters from extra deck will fail to select zone.