### PR TITLE
add Card.IsAbleToEquip, fix CardCheckEquipTarget

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3571,10 +3571,10 @@ int32 card::is_control_can_be_changed(int32 ignore_mzone, uint32 zone) {
 		return FALSE;
 	return TRUE;
 }
-int32 card::is_capable_equip(int32 ignore_szone) {
+int32 card::is_capable_equip(uint8 playerid, int32 ignore_szone) {
 	if(is_status(STATUS_FORBIDDEN))
 		return FALSE;
-	if(!ignore_szone && pduel->game_field->get_useable_count(this, current.controler, LOCATION_SZONE, current.controler, LOCATION_REASON_TOFIELD) <= 0)
+	if(!ignore_szone && pduel->game_field->get_useable_count(this, playerid, LOCATION_SZONE, playerid, LOCATION_REASON_TOFIELD) <= 0)
 		return FALSE;
 	if(pduel->game_field->check_unique_onfield(this, current.controler, LOCATION_MZONE))
 		return FALSE;

--- a/card.cpp
+++ b/card.cpp
@@ -3574,6 +3574,8 @@ int32 card::is_control_can_be_changed(int32 ignore_mzone, uint32 zone) {
 int32 card::is_capable_equip(uint8 playerid, int32 ignore_szone) {
 	if(is_status(STATUS_FORBIDDEN))
 		return FALSE;
+	if(current.controler != playerid && is_affected_by_effect(EFFECT_CANNOT_CHANGE_CONTROL))
+		return FALSE;
 	if(!ignore_szone && pduel->game_field->get_useable_count(this, playerid, LOCATION_SZONE, playerid, LOCATION_REASON_TOFIELD) <= 0)
 		return FALSE;
 	if(pduel->game_field->check_unique_onfield(this, current.controler, LOCATION_MZONE))

--- a/card.cpp
+++ b/card.cpp
@@ -3571,6 +3571,15 @@ int32 card::is_control_can_be_changed(int32 ignore_mzone, uint32 zone) {
 		return FALSE;
 	return TRUE;
 }
+int32 card::is_capable_equip(int32 ignore_szone) {
+	if(is_status(STATUS_FORBIDDEN))
+		return FALSE;
+	if(!ignore_szone && pduel->game_field->get_useable_count(this, current.controler, LOCATION_SZONE, current.controler, LOCATION_REASON_TOFIELD) <= 0)
+		return FALSE;
+	if(pduel->game_field->check_unique_onfield(this, current.controler, LOCATION_MZONE))
+		return FALSE;
+	return TRUE;
+}
 int32 card::is_capable_be_battle_target(card* pcard) {
 	if(is_affected_by_effect(EFFECT_CANNOT_BE_BATTLE_TARGET, pcard))
 		return FALSE;

--- a/card.h
+++ b/card.h
@@ -339,6 +339,7 @@ public:
 	int32 is_capable_turn_set(uint8 playerid);
 	int32 is_capable_change_control();
 	int32 is_control_can_be_changed(int32 ignore_mzone, uint32 zone);
+	int32 is_capable_equip(int32 ignore_szone);
 	int32 is_capable_be_battle_target(card* pcard);
 	int32 is_capable_be_effect_target(effect* peffect, uint8 playerid);
 	int32 is_can_be_fusion_material(card* fcard);

--- a/card.h
+++ b/card.h
@@ -339,7 +339,7 @@ public:
 	int32 is_capable_turn_set(uint8 playerid);
 	int32 is_capable_change_control();
 	int32 is_control_can_be_changed(int32 ignore_mzone, uint32 zone);
-	int32 is_capable_equip(int32 ignore_szone);
+	int32 is_capable_equip(uint8 playerid, int32 ignore_szone);
 	int32 is_capable_be_battle_target(card* pcard);
 	int32 is_capable_be_effect_target(effect* peffect, uint8 playerid);
 	int32 is_can_be_fusion_material(card* fcard);

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -232,6 +232,7 @@ static const struct luaL_Reg cardlib[] = {
 	{ "IsForbidden", scriptlib::card_is_forbidden },
 	{ "IsAbleToChangeControler", scriptlib::card_is_able_to_change_controler },
 	{ "IsControlerCanBeChanged", scriptlib::card_is_controler_can_be_changed },
+	{ "IsAbleToEquip", scriptlib::card_is_able_to_equip },
 	{ "AddCounter", scriptlib::card_add_counter },
 	{ "RemoveCounter", scriptlib::card_remove_counter },
 	{ "GetCounter", scriptlib::card_get_counter },

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -1199,7 +1199,10 @@ int32 scriptlib::card_check_equip_target(lua_State *L) {
 	check_param(L, PARAM_TYPE_CARD, 2);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	card* target = *(card**) lua_touserdata(L, 2);
-	if(pcard->is_affected_by_effect(EFFECT_EQUIP_LIMIT, target)
+	int32 ign = FALSE;
+	if(lua_gettop(L) >= 3)
+		ign = lua_toboolean(L, 3);
+	if(pcard->is_capable_equip(ign) && pcard->is_affected_by_effect(EFFECT_EQUIP_LIMIT, target)
 		&& ((!pcard->is_affected_by_effect(EFFECT_OLDUNION_STATUS) || target->get_union_count() == 0)
 			&& (!pcard->is_affected_by_effect(EFFECT_UNION_STATUS) || target->get_old_union_count() == 0)))
 		lua_pushboolean(L, 1);
@@ -2453,6 +2456,19 @@ int32 scriptlib::card_is_controler_can_be_changed(lua_State *L) {
 	if(lua_gettop(L) >= 3)
 		zone = lua_tointeger(L, 3);
 	if(pcard->is_control_can_be_changed(ign, zone))
+		lua_pushboolean(L, 1);
+	else
+		lua_pushboolean(L, 0);
+	return 1;
+}
+int32 scriptlib::card_is_able_to_equip(lua_State *L) {
+	check_param_count(L, 1);
+	check_param(L, PARAM_TYPE_CARD, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
+	int32 ign = FALSE;
+	if(lua_gettop(L) >= 2)
+		ign = lua_toboolean(L, 2);
+	if(pcard->is_capable_equip(ign))
 		lua_pushboolean(L, 1);
 	else
 		lua_pushboolean(L, 0);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -1199,10 +1199,13 @@ int32 scriptlib::card_check_equip_target(lua_State *L) {
 	check_param(L, PARAM_TYPE_CARD, 2);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	card* target = *(card**) lua_touserdata(L, 2);
-	int32 ign = FALSE;
+	uint32 playerid = pcard->current.controler;
 	if(lua_gettop(L) >= 3)
-		ign = lua_toboolean(L, 3);
-	if(pcard->is_capable_equip(ign) && pcard->is_affected_by_effect(EFFECT_EQUIP_LIMIT, target)
+		playerid = lua_tointeger(L, 3);
+	int32 ign = FALSE;
+	if(lua_gettop(L) >= 4)
+		ign = lua_toboolean(L, 4);
+	if(pcard->is_capable_equip(playerid, ign) && pcard->is_affected_by_effect(EFFECT_EQUIP_LIMIT, target)
 		&& ((!pcard->is_affected_by_effect(EFFECT_OLDUNION_STATUS) || target->get_union_count() == 0)
 			&& (!pcard->is_affected_by_effect(EFFECT_UNION_STATUS) || target->get_old_union_count() == 0)))
 		lua_pushboolean(L, 1);
@@ -2465,10 +2468,13 @@ int32 scriptlib::card_is_able_to_equip(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	int32 ign = FALSE;
+	uint32 playerid = pcard->current.controler;
 	if(lua_gettop(L) >= 2)
-		ign = lua_toboolean(L, 2);
-	if(pcard->is_capable_equip(ign))
+		playerid = lua_tointeger(L, 2);
+	int32 ign = FALSE;
+	if(lua_gettop(L) >= 3)
+		ign = lua_toboolean(L, 3);
+	if(pcard->is_capable_equip(playerid, ign))
 		lua_pushboolean(L, 1);
 	else
 		lua_pushboolean(L, 0);

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -236,6 +236,7 @@ public:
 	static int32 card_is_forbidden(lua_State *L);
 	static int32 card_is_able_to_change_controler(lua_State *L);
 	static int32 card_is_controler_can_be_changed(lua_State *L);
+	static int32 card_is_able_to_equip(lua_State *L);
 	static int32 card_add_counter(lua_State *L);
 	static int32 card_remove_counter(lua_State *L);
 	static int32 card_get_counter(lua_State *L);


### PR DESCRIPTION
Update: add `Card.IsAbleToEquip`.
Fix: `CardCheckEquipTarget` don't check unique.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10828
Q.自分の魔法＆罠ゾーンに「ダストンのモップ」が表側表示で存在し、相手のモンスターゾーンに表側表示で存在するモンスターに装備されています。

この状況で、自分は「妖精伝姫－シンデレラ」の『②：１ターンに１度、手札から魔法カード１枚を捨てて発動できる。自分の手札・デッキ・墓地から装備魔法カード１枚を選んでこのカードに装備する。この効果で装備された装備魔法カードはエンドフェイズに持ち主の手札に戻る』モンスター効果で、2枚目となる「ダストンのモップ」を装備させる事はできますか？
A.「ダストンのモップ」は『自分フィールド上に１枚しか表側表示で存在できない』カードですので、質問の状況のように、既に自分フィールドに「ダストンのモップ」が表側表示で存在している場合には、「妖精伝姫－シンデレラ」の『自分の手札・デッキ・墓地から装備魔法カード１枚を選んでこのカードに装備する』モンスター効果によって、2枚目となる「ダストンのモップ」を選ぶ事はできません。
（自分の手札・デッキ・墓地に存在する装備魔法カードが「ダストンのモップ」のみ、という状況であった場合には、「妖精伝姫－シンデレラ」のモンスター効果を発動する事自体ができません。） 

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13567
Q.自分フィールドに「聖剣ガラティーン」が表側表示で存在する時、墓地の「聖剣ガラティーン」を対象として「旗鼓堂々」を発動できますか？

また、「聖剣ガラティーン」のカードの発動にチェーンして「旗鼓堂々」を発動し、墓地の「聖剣ガラティーン」を対象とする事はできますか？
A.「聖剣ガラティーン」は『自分フィールド上に１枚しか表側表示で存在できない』カードですので、既に自分フィールドに「聖剣ガラティーン」が存在している場合、「旗鼓堂々」の対象として、墓地の「聖剣ガラティーン」を対象に選択する事はできません。

また、「聖剣ガラティーン」のカードの発動にチェーンして、「旗鼓堂々」を発動する場合も同様です。墓地の「聖剣ガラティーン」を対象として「旗鼓堂々」を発動する事はできません。 