### PR TITLE
update Card.IsCanAddCounter and Card.EnableCounterPermit

### DIFF
--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2525,6 +2525,8 @@ int32 scriptlib::card_enable_counter_permit(lua_State *L) {
 	peffect->type = EFFECT_TYPE_SINGLE;
 	peffect->code = EFFECT_COUNTER_PERMIT | countertype;
 	peffect->value = prange;
+	if(lua_gettop(L) > 3 && lua_isfunction(L, 4))
+		peffect->target = interpreter::get_function_handle(L, 4);
 	pcard->add_effect(peffect);
 	return 0;
 }
@@ -2556,11 +2558,13 @@ int32 scriptlib::card_is_can_turn_set(lua_State *L) {
 	return 1;
 }
 int32 scriptlib::card_is_can_add_counter(lua_State *L) {
-	check_param_count(L, 3);
+	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 countertype = lua_tointeger(L, 2);
-	uint32 count = lua_tointeger(L, 3);
+	uint32 count = 0;
+	if(lua_gettop(L) > 2)
+		count = lua_tointeger(L, 3);
 	uint8 singly = FALSE;
 	if(lua_gettop(L) > 3)
 		singly = lua_toboolean(L, 4);


### PR DESCRIPTION
Update: missing spell counter's ruing.

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14213
質問の状況の場合、「魔導戦士 ブレイカー」は自身の『①：このカードが召喚に成功した場合に発動する。このカードに魔力カウンターを１つ置く（最大１つまで）』モンスター効果によって、これ以上魔力カウンターを置くことができない状態ですが、魔力カウンターを置く事ができる効果を持つカードですので、自分フィールドの魔力カウンターを置く事ができるカードは、モンスターゾーンの「魔導戦士 ブレイカー」と、特殊召喚された「創聖魔導王 エンディミオン」自身と、フィールドゾーンの「魔法都市エンディミオン」の3枚となりますので、1枚～3枚のカードをフィールドから選んで破壊する事になります。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22526
質問の状況の場合、「魔導獣 ケルベロス」は「禁じられた聖杯」の効果によってモンスター効果が無効化されていますが、魔力カウンターを置く事ができる効果を持つカードですので、自分フィールドの魔力カウンターを置く事ができるカードは、モンスターゾーンの「魔導獣 ケルベロス」と、特殊召喚された「創聖魔導王 エンディミオン」自身と、フィールドゾーンの「魔法都市エンディミオン」の3枚となりますので、1枚～3枚のカードをフィールドから選んで破壊する事になります。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22527
質問の状況の場合、ペンデュラムゾーンの「魔導獣 メデューサ」は、魔力カウンターを置く事ができるカードとしては扱われませんので、自分フィールドの魔力カウンターを置く事ができるカードは、特殊召喚されたモンスターゾーンの「創聖魔導王 エンディミオン」自身と、フィールドゾーンの「魔法都市エンディミオン」の2枚となりますので、1枚または2枚のカードをフィールドから選んで破壊する事になります。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22531
質問の状況の場合、通常モンスター扱いの「ダーク・ヴァルキリア」は、魔力カウンターを置く事ができるカードとしては扱われませんので、自分フィールドの魔力カウンターを置く事ができるカードは、特殊召喚されたモンスターゾーンの「創聖魔導王 エンディミオン」自身のみとなりますので、1枚のカードをフィールドから選んで破壊する事になります。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22532
「サーヴァント・オブ・エンディミオン」の効果によって特殊召喚する『デッキの魔力カウンターを置く事ができる攻撃力１０００以上のモンスター１体』として、「ダーク・ヴァルキリア」を選ぶ事はできます。

「ダーク・ヴァルキリア」はもう1度召喚され効果モンスター扱いとなっていなければ、魔力カウンターを置く事ができませんので、通常の処理は「ダーク・ヴァルキリア」と「サーヴァント・オブ・エンディミオン」が特殊召喚され、「サーヴァント・オブ・エンディミオン」にのみ魔力カウンターが置かれる事になります。

なお、効果処理時に、「超合魔獣ラプテノス」の『①：このカードがモンスターゾーンに存在する限り、フィールドのデュアルモンスターは全て、もう１度召喚された状態として扱う』モンスター効果が適用されており、特殊召喚された「ダーク・ヴァルキリア」がもう1度召喚された状態として扱われる場合には、「ダーク・ヴァルキリア」にも魔力カウンターを置く処理が適用される事になります。

Mail:
遊戯王OCG事務局です。 

いつも遊戯王オフィシャルカードゲームをお楽しみいただきありがとうございます。 
お問い合わせいただいた件、下記のとおりご案内いたします。 

Q. 
「魔導獣 メデューサ」のペンデュラム効果の対象として、「古代の機械獣」との戦闘で破壊された「ダーク・ヴァルキリア」を対象にできますか？ 
A. 
ご質問の「ダーク・ヴァルキリア」を対象に選択できます。

Q. 
「魔導獣 メデューサ」のペンデュラム効果の対象として、「古代の機械獣」との戦闘で破壊された「ゲイシャドウ」を対象にできますか？ 
A. 
ご質問の「ゲイシャドウ」を対象に選択できます。

Q. 
相手フィールドに「ゲート・ブロッカー」が存在する場合、自分は「創聖魔導王 エンディミオン」のペンデュラム効果を発動できますか？ 
A. 
相手の「ゲート・ブロッカー」の効果が適用されている場合、自分は「創聖魔導王 エンディミオン」のペンデュラム効果を発動することができません。

Q. 
相手フィールドに「ゲート・ブロッカー」が存在する場合、自分は「エンプレス・オブ・エンディミオン」のペンデュラム効果を発動できますか？ 
A. 
相手の「ゲート・ブロッカー」のモンスター効果が適用されている場合、自分は「エンプレス・オブ・エンディミオン」のペンデュラム効果を発動することができません。

Q. 
相手フィールドに「ゲート・ブロッカー」が存在する場合、自分は「マギステル・オブ・エンディミオン」の②のモンスター効果を発動できますか？ 
A. 
ご質問の状況の場合でも、「マギステル・オブ・エンディミオン」の『②：相手ターンに１度、自分フィールドの魔力カウンターを３つ取り除いて発動できる。魔力カウンターを置く事ができるモンスター１体をデッキから特殊召喚する』モンスター効果は発動できます。