### PR TITLE
add TYPE_EFFECT only for monster when copying effect

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1870,7 +1870,7 @@ int32 card::copy_effect(uint32 code, uint32 reset, uint32 count) {
 	for(auto& peffect : pduel->uncopy)
 		pduel->delete_effect(peffect);
 	pduel->uncopy.clear();
-	if(!(data.type & TYPE_EFFECT)) {
+	if((data.type & TYPE_MONSTER) && !(data.type & TYPE_EFFECT)) {
 		effect* peffect = pduel->new_effect();
 		if(pduel->game_field->core.reason_effect)
 			peffect->owner = pduel->game_field->core.reason_effect->get_handler();
@@ -1916,7 +1916,7 @@ int32 card::replace_effect(uint32 code, uint32 reset, uint32 count) {
 	for(auto& peffect : pduel->uncopy)
 		pduel->delete_effect(peffect);
 	pduel->uncopy.clear();
-	if(!(data.type & TYPE_EFFECT)) {
+	if((data.type & TYPE_MONSTER) && !(data.type & TYPE_EFFECT)) {
 		effect* peffect = pduel->new_effect();
 		if(pduel->game_field->core.reason_effect)
 			peffect->owner = pduel->game_field->core.reason_effect->get_handler();


### PR DESCRIPTION
The `copy_effect` and `replace_effect` would always add `TYPE_EFFECT` for non-effect monsters. This will cause problems when copying spells or traps.