### PR TITLE
refine the timing of adjust

### DIFF
--- a/libcard.cpp
+++ b/libcard.cpp
@@ -1347,6 +1347,7 @@ int32 scriptlib::card_remove_overlay_card(lua_State *L) {
 	pduel->game_field->remove_overlay_card(reason, pcard, playerid, 0, 0, min, max);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushboolean(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -1420,6 +1421,7 @@ int32 scriptlib::card_set_card_target(lua_State *L) {
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	card* ocard = *(card**) lua_touserdata(L, 2);
 	pcard->add_card_target(ocard);
+	pcard->pduel->game_field->adjust_all();
 	return 0;
 }
 int32 scriptlib::card_get_card_target(lua_State *L) {
@@ -2593,6 +2595,7 @@ int32 scriptlib::card_remove_counter(lua_State *L) {
 		pduel->game_field->remove_counter(reason, pcard, rplayer, 0, 0, countertype, count);
 		return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 			duel* pduel = (duel*)ctx;
+			pduel->game_field->adjust_all();
 			lua_pushboolean(L, pduel->game_field->returns.ivalue[0]);
 			return 1;
 		});

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -780,7 +780,9 @@ int32 scriptlib::duel_move_to_field(lua_State *L) {
 	pduel->game_field->move_to_field(pcard, move_player, playerid, destination, positions, enable, 0, FALSE, zone);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
-		pduel->game_field->adjust_all();
+		uint32 enable = lua_toboolean(L, 6);
+		if(enable)
+			pduel->game_field->adjust_all();
 		lua_pushboolean(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -1228,7 +1230,11 @@ int32 scriptlib::duel_damage(lua_State *L) {
 	pduel->game_field->damage(pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, 0, playerid, amount, is_step);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
-		pduel->game_field->adjust_all();
+		uint32 is_step = FALSE;
+		if(lua_gettop(L) >= 4)
+			is_step = lua_toboolean(L, 4);
+		if(!is_step)
+			pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -1250,7 +1256,11 @@ int32 scriptlib::duel_recover(lua_State *L) {
 	pduel->game_field->recover(pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, playerid, amount, is_step);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
-		pduel->game_field->adjust_all();
+		uint32 is_step = FALSE;
+		if(lua_gettop(L) >= 4)
+			is_step = lua_toboolean(L, 4);
+		if(!is_step)
+			pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -1258,6 +1268,7 @@ int32 scriptlib::duel_recover(lua_State *L) {
 int32 scriptlib::duel_rd_complete(lua_State *L) {
 	duel* pduel = interpreter::get_duel_info(L);
 	pduel->game_field->core.subunits.splice(pduel->game_field->core.subunits.end(), pduel->game_field->core.recover_damage_reserve);
+	pduel->game_field->adjust_all();
 	return lua_yield(L, 0);
 }
 int32 scriptlib::duel_equip(lua_State *L) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3295,8 +3295,7 @@ int32 scriptlib::duel_overlay(lua_State *L) {
 		target->xyz_overlay(&cset);
 	} else
 		target->xyz_overlay(&pgroup->container);
-	if(target->current.location == LOCATION_MZONE)
-		target->pduel->game_field->adjust_all();
+	target->pduel->game_field->adjust_all();
 	return lua_yield(L, 0);
 }
 int32 scriptlib::duel_get_overlay_group(lua_State *L) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -201,6 +201,7 @@ int32 scriptlib::duel_destroy(lua_State *L) {
 		pduel->game_field->destroy(&(pgroup->container), pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, PLAYER_NONE, dest, 0);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -227,6 +228,7 @@ int32 scriptlib::duel_remove(lua_State *L) {
 		pduel->game_field->send_to(&(pgroup->container), pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, PLAYER_NONE, LOCATION_REMOVED, 0, pos);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -252,6 +254,7 @@ int32 scriptlib::duel_sendto_grave(lua_State *L) {
 		pduel->game_field->send_to(&(pgroup->container), pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -497,6 +500,7 @@ int32 scriptlib::duel_special_summon(lua_State *L) {
 		pduel->game_field->special_summon(&(pgroup->container), sumtype, sumplayer, playerid, nocheck, nolimit, positions, zone);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -529,6 +533,7 @@ int32 scriptlib::duel_special_summon_complete(lua_State *L) {
 	pduel->game_field->special_summon_complete(pduel->game_field->core.reason_effect, pduel->game_field->core.reason_player);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -557,6 +562,7 @@ int32 scriptlib::duel_sendto_hand(lua_State *L) {
 		pduel->game_field->send_to(&(pgroup->container), pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, playerid, LOCATION_HAND, 0, POS_FACEUP);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -586,6 +592,7 @@ int32 scriptlib::duel_sendto_deck(lua_State *L) {
 		pduel->game_field->send_to(&(pgroup->container), pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, playerid, LOCATION_DECK, sequence, POS_FACEUP);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -614,6 +621,7 @@ int32 scriptlib::duel_sendto_extra(lua_State *L) {
 		pduel->game_field->send_to(&(pgroup->container), pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, playerid, LOCATION_EXTRA, 0, POS_FACEUP);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -659,6 +667,7 @@ int32 scriptlib::duel_remove_counter(lua_State *L) {
 	pduel->game_field->remove_counter(reason, 0, rplayer, s, o, countertype, count);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushboolean(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -719,6 +728,7 @@ int32 scriptlib::duel_change_form(lua_State *L) {
 		pduel->game_field->change_position(&(pgroup->container), pduel->game_field->core.reason_effect, pduel->game_field->core.reason_player, au, ad, du, dd, flag, TRUE);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -744,6 +754,7 @@ int32 scriptlib::duel_release(lua_State *L) {
 		pduel->game_field->release(&(pgroup->container), pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -769,6 +780,7 @@ int32 scriptlib::duel_move_to_field(lua_State *L) {
 	pduel->game_field->move_to_field(pcard, move_player, playerid, destination, positions, enable, 0, FALSE, zone);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushboolean(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -793,6 +805,7 @@ int32 scriptlib::duel_return_to_field(lua_State *L) {
 	pduel->game_field->move_to_field(pcard, pcard->previous.controler, pcard->previous.controler, pcard->previous.location, pos, TRUE, 1, 0, zone);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushboolean(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -1193,6 +1206,7 @@ int32 scriptlib::duel_draw(lua_State *L) {
 	pduel->game_field->draw(pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, playerid, count);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -1214,6 +1228,7 @@ int32 scriptlib::duel_damage(lua_State *L) {
 	pduel->game_field->damage(pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, 0, playerid, amount, is_step);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -1235,6 +1250,7 @@ int32 scriptlib::duel_recover(lua_State *L) {
 	pduel->game_field->recover(pduel->game_field->core.reason_effect, reason, pduel->game_field->core.reason_player, playerid, amount, is_step);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -1264,6 +1280,11 @@ int32 scriptlib::duel_equip(lua_State *L) {
 	pduel->game_field->equip(playerid, equip_card, target, up, step);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		uint32 step = FALSE;
+		if(lua_gettop(L) > 4)
+			step = lua_toboolean(L, 5);
+		if(!step)
+			pduel->game_field->adjust_all();
 		lua_pushboolean(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -1286,6 +1307,7 @@ int32 scriptlib::duel_equip_complete(lua_State *L) {
 	pduel->game_field->core.hint_timing[1] |= TIMING_EQUIP;
 	pduel->game_field->process_single_event();
 	pduel->game_field->process_instant_event();
+	pduel->game_field->adjust_all();
 	return lua_yield(L, 0);
 }
 int32 scriptlib::duel_get_control(lua_State *L) {
@@ -1320,6 +1342,7 @@ int32 scriptlib::duel_get_control(lua_State *L) {
 		pduel->game_field->get_control(&pgroup->container, pduel->game_field->core.reason_effect, pduel->game_field->core.reason_player, playerid, reset_phase, reset_count, zone);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -1354,6 +1377,7 @@ int32 scriptlib::duel_swap_control(lua_State *L) {
 		pduel->game_field->swap_control(pduel->game_field->core.reason_effect, pduel->game_field->core.reason_player, &pgroup1->container, &pgroup2->container, reset_phase, reset_count);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushboolean(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -1389,6 +1413,7 @@ int32 scriptlib::duel_discard_deck(lua_State *L) {
 	pduel->game_field->add_process(PROCESSOR_DISCARD_DECK, 0, 0, 0, playerid + (count << 16), reason);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -1423,6 +1448,7 @@ int32 scriptlib::duel_discard_hand(lua_State *L) {
 	pduel->game_field->add_process(PROCESSOR_DISCARD_HAND, 0, NULL, NULL, playerid, min + (max << 16), reason);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushinteger(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});
@@ -3314,6 +3340,7 @@ int32 scriptlib::duel_remove_overlay_card(lua_State *L) {
 	pduel->game_field->remove_overlay_card(reason, 0, playerid, s, o, min, max);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
+		pduel->game_field->adjust_all();
 		lua_pushboolean(L, pduel->game_field->returns.ivalue[0]);
 		return 1;
 	});

--- a/operations.cpp
+++ b/operations.cpp
@@ -1421,7 +1421,7 @@ int32 field::equip(uint16 step, uint8 equip_player, card * equip_card, card * ta
 		if(!is_step) {
 			if(equip_card->is_position(POS_FACEUP))
 				equip_card->enable_field_effect(true);
-			adjust_disable_check_list();
+			adjust_instant();
 			card_set cset;
 			cset.insert(equip_card);
 			raise_single_event(target, &cset, EVENT_EQUIP, core.reason_effect, 0, core.reason_player, PLAYER_NONE, 0);
@@ -1876,6 +1876,7 @@ int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, ui
 		core.summoning_card = 0;
 		raise_event(target, EVENT_SUMMON, proc, 0, sumplayer, sumplayer, 0);
 		process_instant_event();
+		adjust_all();
 		add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, 0x101, TRUE);
 		return FALSE;
 	}
@@ -2725,6 +2726,7 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		target->set_status(STATUS_SUMMON_DISABLED, FALSE);
 		raise_event(target, EVENT_SPSUMMON, core.units.begin()->peffect, 0, sumplayer, sumplayer, 0);
 		process_instant_event();
+		adjust_all();
 		add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, 0x101, TRUE);
 		return FALSE;
 	}
@@ -3730,7 +3732,7 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 		uint32 dest, redirect, redirect_seq, check_cb;
 		for(auto& pcard : targets->container)
 			pcard->enable_field_effect(false);
-		adjust_disable_check_list();
+		adjust_instant();
 		for(auto& pcard : targets->container) {
 			dest = pcard->sendto_param.location;
 			redirect = 0;
@@ -4477,7 +4479,7 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 			process_single_event();
 			process_instant_event();
 		}
-		adjust_disable_check_list();
+		adjust_instant();
 		return FALSE;
 	}
 	case 3: {

--- a/operations.cpp
+++ b/operations.cpp
@@ -1876,7 +1876,6 @@ int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, ui
 		core.summoning_card = 0;
 		raise_event(target, EVENT_SUMMON, proc, 0, sumplayer, sumplayer, 0);
 		process_instant_event();
-		adjust_all();
 		add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, 0x101, TRUE);
 		return FALSE;
 	}
@@ -2726,7 +2725,6 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		target->set_status(STATUS_SUMMON_DISABLED, FALSE);
 		raise_event(target, EVENT_SPSUMMON, core.units.begin()->peffect, 0, sumplayer, sumplayer, 0);
 		process_instant_event();
-		adjust_all();
 		add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, 0x101, TRUE);
 		return FALSE;
 	}

--- a/processor.cpp
+++ b/processor.cpp
@@ -4261,7 +4261,7 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 		pduel->write_buffer8(MSG_CHAIN_SOLVED);
 		pduel->write_buffer8(cait->chain_count);
 		raise_event((card*)0, EVENT_CHAIN_SOLVED, cait->triggering_effect, 0, cait->triggering_player, cait->triggering_player, cait->chain_count);
-		adjust_disable_check_list();
+		adjust_instant();
 		process_instant_event();
 		core.units.begin()->step = 9;
 		return FALSE;
@@ -4373,7 +4373,6 @@ int32 field::break_effect() {
 }
 void field::adjust_instant() {
 	adjust_disable_check_list();
-	adjust_self_destroy_set();
 }
 void field::adjust_all() {
 	core.readjust_map.clear();


### PR DESCRIPTION
call `adjust_all()` after excuting lua operation functions so that the field information can be refreshed each time an operation is done.

https://github.com/Fluorohydride/ygopro/issues/1639
https://github.com/Fluorohydride/ygopro/issues/1695
https://github.com/Fluorohydride/ygopro/issues/1716
https://github.com/Fluorohydride/ygopro/issues/2200