### PR TITLE
add EFFECT_TYPE_TARGET

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2244,10 +2244,19 @@ void card::cancel_card_target(card* pcard) {
 	}
 }
 void card::clear_card_target() {
-	for(auto& pcard : effect_target_owner)
+	for(auto& pcard : effect_target_owner) {
 		pcard->effect_target_cards.erase(this);
+		for(auto& it : pcard->target_effect) {
+			if(it.second->is_disable_related())
+				pduel->game_field->add_to_disable_check_list(this);
+		}
+	}
 	for(auto& pcard : effect_target_cards) {
 		pcard->effect_target_owner.erase(this);
+		for(auto& it : target_effect) {
+			if(it.second->is_disable_related())
+				pduel->game_field->add_to_disable_check_list(pcard);
+		}
 		for(auto it = pcard->single_effect.begin(); it != pcard->single_effect.end();) {
 			auto rm = it++;
 			effect* peffect = rm->second;

--- a/card.cpp
+++ b/card.cpp
@@ -2368,7 +2368,7 @@ void card::filter_effect(int32 code, effect_set* eset, uint8 sort) {
 		rg = pcard->target_effect.equal_range(code);
 		for(; rg.first != rg.second; ++rg.first) {
 			peffect = rg.first->second;
-			if(peffect->is_available() && is_affect_by_effect(peffect))
+			if(peffect->is_available() && peffect->is_target(this) && is_affect_by_effect(peffect))
 				eset->add_item(peffect);
 		}
 	}
@@ -2414,8 +2414,11 @@ void card::filter_single_continuous_effect(int32 code, effect_set* eset, uint8 s
 	}
 	for(auto& pcard : effect_target_owner) {
 		rg = pcard->target_effect.equal_range(code);
-		for(; rg.first != rg.second; ++rg.first)
-			eset->add_item(rg.first->second);
+		for(; rg.first != rg.second; ++rg.first) {
+			effect* peffect = rg.first->second;
+			if(peffect->is_target(pcard))
+				eset->add_item(peffect);
+		}
 	}
 	for (auto& pcard : xyz_materials) {
 		rg = pcard->xmaterial_effect.equal_range(code);
@@ -2451,7 +2454,7 @@ void card::filter_immune_effect() {
 		rg = pcard->target_effect.equal_range(EFFECT_IMMUNE_EFFECT);
 		for (; rg.first != rg.second; ++rg.first) {
 			peffect = rg.first->second;
-			if(peffect->is_available())
+			if(peffect->is_target(this) && peffect->is_available())
 				immune_effect.add_item(peffect);
 		}
 	}
@@ -2738,7 +2741,7 @@ effect* card::is_affected_by_effect(int32 code) {
 		rg = pcard->target_effect.equal_range(code);
 		for (; rg.first != rg.second; ++rg.first) {
 			peffect = rg.first->second;
-			if (peffect->is_available() && is_affect_by_effect(peffect))
+			if (peffect->is_available() && peffect->is_target(this) && is_affect_by_effect(peffect))
 				return peffect;
 		}
 	}
@@ -2782,7 +2785,7 @@ effect* card::is_affected_by_effect(int32 code, card* target) {
 		rg = pcard->target_effect.equal_range(code);
 		for (; rg.first != rg.second; ++rg.first) {
 			peffect = rg.first->second;
-			if (peffect->is_available() && is_affect_by_effect(peffect) && peffect->get_value(target))
+			if (peffect->is_available() && peffect->is_target(this) && is_affect_by_effect(peffect) && peffect->get_value(target))
 				return peffect;
 		}
 	}
@@ -2819,7 +2822,7 @@ effect* card::check_control_effect() {
 		auto rg = pcard->target_effect.equal_range(EFFECT_SET_CONTROL);
 		for (; rg.first != rg.second; ++rg.first) {
 			effect* peffect = rg.first->second;
-			if(!ret_effect || peffect->id > ret_effect->id)
+			if(!ret_effect || peffect->is_target(pcard) && peffect->id > ret_effect->id)
 				ret_effect = peffect;
 		}
 	}

--- a/card.cpp
+++ b/card.cpp
@@ -2839,6 +2839,8 @@ effect* card::check_control_effect() {
 	auto rg = single_effect.equal_range(EFFECT_SET_CONTROL);
 	for (; rg.first != rg.second; ++rg.first) {
 		effect* peffect = rg.first->second;
+		if(!peffect->is_flag(EFFECT_FLAG_OWNER_RELATE))
+			continue;
 		if(!ret_effect || peffect->id > ret_effect->id)
 			ret_effect = peffect;
 	}

--- a/card.cpp
+++ b/card.cpp
@@ -1808,7 +1808,7 @@ void card::remove_effect(effect* peffect, effect_container::iterator it) {
 			check_target.clear();
 	} else if (peffect->type & EFFECT_TYPE_XMATERIAL) {
 		xmaterial_effect.erase(it);
-		if(overlay_target)
+		if (overlay_target)
 			check_target = { overlay_target };
 		else
 			check_target.clear();

--- a/card.cpp
+++ b/card.cpp
@@ -1654,8 +1654,8 @@ void card::enable_field_effect(bool enabled) {
 			for (auto& it : equip_effect)
 				it.second->id = pduel->game_field->infos.field_id++;
 		}
-		if(current.location & LOCATION_ONFIELD) {
-			for (auto& it : target_effect)
+		for (auto& it : target_effect) {
+			if (it.second->in_range(this))
 				it.second->id = pduel->game_field->infos.field_id++;
 		}
 		if (get_status(STATUS_DISABLED))

--- a/card.h
+++ b/card.h
@@ -180,6 +180,7 @@ public:
 	effect_container single_effect;
 	effect_container field_effect;
 	effect_container equip_effect;
+	effect_container target_effect;
 	effect_container xmaterial_effect;
 	effect_indexer indexer;
 	effect_relation relate_effect;

--- a/effect.cpp
+++ b/effect.cpp
@@ -435,8 +435,14 @@ int32 effect::is_activate_check(uint8 playerid, const tevent& e, int32 neglect_c
 int32 effect::is_target(card* pcard) {
 	if(type & EFFECT_TYPE_ACTIONS)
 		return FALSE;
-	if(type & (EFFECT_TYPE_SINGLE | EFFECT_TYPE_EQUIP | EFFECT_TYPE_TARGET | EFFECT_TYPE_XMATERIAL) && !(type & EFFECT_TYPE_FIELD))
+	if(type & (EFFECT_TYPE_SINGLE | EFFECT_TYPE_EQUIP | EFFECT_TYPE_XMATERIAL) && !(type & EFFECT_TYPE_FIELD))
 		return TRUE;
+	if((type & EFFECT_TYPE_TARGET) && !(type & EFFECT_TYPE_FIELD)) {
+		if(!target)
+			return TRUE;
+		else
+			return is_fit_target_function(pcard);
+	}
 	if(pcard && !is_flag(EFFECT_FLAG_SET_AVAILABLE) && (pcard->current.location & LOCATION_ONFIELD)
 			&& !pcard->is_position(POS_FACEUP))
 		return FALSE;

--- a/effect.cpp
+++ b/effect.cpp
@@ -96,7 +96,7 @@ int32 effect::is_available() {
 		if(powner == phandler && !is_flag(EFFECT_FLAG_CANNOT_DISABLE) && phandler->get_status(STATUS_DISABLED))
 			return FALSE;
 	}
-	if(type & EFFECT_TYPE_EQUIP) {
+	if (type & EFFECT_TYPE_EQUIP) {
 		if(handler->current.controler == PLAYER_NONE)
 			return FALSE;
 		if(is_flag(EFFECT_FLAG_OWNER_RELATE) && is_can_be_forbidden() && owner->is_status(STATUS_FORBIDDEN))

--- a/effect.cpp
+++ b/effect.cpp
@@ -91,7 +91,7 @@ int32 effect::is_available() {
 		if(powner == phandler && !is_flag(EFFECT_FLAG_CANNOT_DISABLE) && phandler->get_status(STATUS_DISABLED))
 			return FALSE;
 	}
-	if (type & EFFECT_TYPE_EQUIP) {
+	if(type & (EFFECT_TYPE_EQUIP | EFFECT_TYPE_TARGET)) {
 		if(handler->current.controler == PLAYER_NONE)
 			return FALSE;
 		if(is_flag(EFFECT_FLAG_OWNER_RELATE) && is_can_be_forbidden() && owner->is_status(STATUS_FORBIDDEN))
@@ -435,7 +435,7 @@ int32 effect::is_activate_check(uint8 playerid, const tevent& e, int32 neglect_c
 int32 effect::is_target(card* pcard) {
 	if(type & EFFECT_TYPE_ACTIONS)
 		return FALSE;
-	if(type & (EFFECT_TYPE_SINGLE | EFFECT_TYPE_EQUIP | EFFECT_TYPE_XMATERIAL) && !(type & EFFECT_TYPE_FIELD))
+	if(type & (EFFECT_TYPE_SINGLE | EFFECT_TYPE_EQUIP | EFFECT_TYPE_TARGET | EFFECT_TYPE_XMATERIAL) && !(type & EFFECT_TYPE_FIELD))
 		return TRUE;
 	if(pcard && !is_flag(EFFECT_FLAG_SET_AVAILABLE) && (pcard->current.location & LOCATION_ONFIELD)
 			&& !pcard->is_position(POS_FACEUP))

--- a/effect.cpp
+++ b/effect.cpp
@@ -91,7 +91,7 @@ int32 effect::is_available() {
 		if(powner == phandler && !is_flag(EFFECT_FLAG_CANNOT_DISABLE) && phandler->get_status(STATUS_DISABLED))
 			return FALSE;
 	}
-	if(type & (EFFECT_TYPE_EQUIP | EFFECT_TYPE_TARGET)) {
+	if(type & EFFECT_TYPE_EQUIP) {
 		if(handler->current.controler == PLAYER_NONE)
 			return FALSE;
 		if(is_flag(EFFECT_FLAG_OWNER_RELATE) && is_can_be_forbidden() && owner->is_status(STATUS_FORBIDDEN))
@@ -109,7 +109,7 @@ int32 effect::is_available() {
 				return FALSE;
 		}
 	}
-	if (type & EFFECT_TYPE_FIELD) {
+	if (type & (EFFECT_TYPE_FIELD | EFFECT_TYPE_TARGET)) {
 		card* phandler = get_handler();
 		card* powner = get_owner();
 		if (!is_flag(EFFECT_FLAG_FIELD_ONLY)) {
@@ -438,10 +438,9 @@ int32 effect::is_target(card* pcard) {
 	if(type & (EFFECT_TYPE_SINGLE | EFFECT_TYPE_EQUIP | EFFECT_TYPE_XMATERIAL) && !(type & EFFECT_TYPE_FIELD))
 		return TRUE;
 	if((type & EFFECT_TYPE_TARGET) && !(type & EFFECT_TYPE_FIELD)) {
-		if(!target)
-			return TRUE;
-		else
-			return is_fit_target_function(pcard);
+		if(pcard->get_status(STATUS_SUMMONING | STATUS_SUMMON_DISABLED | STATUS_ACTIVATE_DISABLED | STATUS_SPSUMMON_STEP))
+			return FALSE;
+		return is_fit_target_function(pcard);
 	}
 	if(pcard && !is_flag(EFFECT_FLAG_SET_AVAILABLE) && (pcard->current.location & LOCATION_ONFIELD)
 			&& !pcard->is_position(POS_FACEUP))

--- a/effect.h
+++ b/effect.h
@@ -156,6 +156,7 @@ public:
 #define EFFECT_TYPE_CONTINUOUS		0x0800	//
 #define EFFECT_TYPE_XMATERIAL		0x1000	//
 #define EFFECT_TYPE_GRANT			0x2000	//
+#define EFFECT_TYPE_TARGET			0x4000	//
 
 //========== Flags ==========
 enum effect_flag : uint32 {

--- a/operations.cpp
+++ b/operations.cpp
@@ -1378,7 +1378,8 @@ int32 field::equip(uint16 step, uint8 equip_player, card * equip_card, card * ta
 		if(equip_card == target || target->current.location != LOCATION_MZONE)
 			return TRUE;
 		if(equip_card->equiping_target) {
-			equip_card->cancel_card_target(equip_card->equiping_target);
+			equip_card->effect_target_cards.erase(equip_card->equiping_target);
+			equip_card->equiping_target->effect_target_owner.erase(equip_card);
 			equip_card->unequip();
 			equip_card->enable_field_effect(false);
 			return FALSE;


### PR DESCRIPTION
for effect affecting continuous targets, parallel to `EFFECT_TYPE_EQUIP`

Note:
`EFFECT_TYPE_TARGET` is only for effects that **affect** continuous targets. The continuous spell/trap taking continuous targets on field when activating is of this kind, which is different from monster effects that taking continuous targets, see Fluorohydride/ygopro-scripts#1203

Sample:
```lua
local e3=Effect.CreateEffect(c)
e3:SetType(EFFECT_TYPE_TARGET)
e3:SetCode(effect_code)
e3:SetRange(location) --where to apply
--[[other settings:
e3:SetCondition
e3:SetTarget --additional condition of affected continuous target
e3:SetProperty
e3:SetValue
...
--]]
c:RegisterEffect(e3)
```