### PR TITLE
update EFFECT_SET_CONTROL

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1988,8 +1988,7 @@ void card::reset(uint32 id, uint32 reset_type) {
 			}
 		}
 		if(id & RESET_TURN_SET) {
-			effect* peffect = check_control_effect();
-			if(peffect) {
+			if(effect* peffect = check_control_effect()) {
 				effect* new_effect = pduel->new_effect();
 				new_effect->id = peffect->id;
 				new_effect->owner = this;
@@ -2755,7 +2754,6 @@ effect* card::is_affected_by_effect(int32 code, card* target) {
 	}
 	return 0;
 }
-// return the last control-changing continuous effect
 effect* card::check_control_effect() {
 	effect* ret_effect = 0;
 	for (auto& pcard : equiping_cards) {
@@ -2779,11 +2777,21 @@ effect* card::check_control_effect() {
 	auto rg = single_effect.equal_range(EFFECT_SET_CONTROL);
 	for (; rg.first != rg.second; ++rg.first) {
 		effect* peffect = rg.first->second;
-		if(!peffect->is_flag(EFFECT_FLAG_OWNER_RELATE))
+		if(!peffect->condition)
 			continue;
 		if(!ret_effect || peffect->id > ret_effect->id)
 			ret_effect = peffect;
 	}
+	/*
+	rg = pduel->game_field->effects.aura_effect.equal_range(EFFECT_SET_CONTROL);
+	for(; rg.first != rg.second; ++rg.first) {
+		effect* peffect = rg.first->second;
+		if(peffect->is_flag(EFFECT_FLAG_PLAYER_TARGET) || !peffect->is_target(this))
+			continue;
+		if(!ret_effect || peffect->id > ret_effect->id)
+			ret_effect = peffect;
+	}
+	*/
 	return ret_effect;
 }
 int32 card::fusion_check(group* fusion_m, card* cg, uint32 chkf) {

--- a/effect.cpp
+++ b/effect.cpp
@@ -545,7 +545,6 @@ int32 effect::is_chainable(uint8 tp) {
 	return TRUE;
 }
 //return: this can be reset by reset_level or not
-//RESET_CODE can only reset single effects without EFFECT_FLAG_SINGLE_RANGE, EFFECT_FLAG_OWNER_RELATE
 //RESET_DISABLE is valid only when owner == handler
 int32 effect::reset(uint32 reset_level, uint32 reset_type) {
 	switch (reset_type) {
@@ -577,8 +576,7 @@ int32 effect::reset(uint32 reset_level, uint32 reset_type) {
 		break;
 	}
 	case RESET_CODE: {
-		return (code == reset_level) && (type & EFFECT_TYPE_SINGLE) && !(type & EFFECT_TYPE_ACTIONS) 
-			&& !is_flag(EFFECT_FLAG_SINGLE_RANGE) && !is_flag(EFFECT_FLAG_OWNER_RELATE);
+		return (code == reset_level) && (type & EFFECT_TYPE_SINGLE) && !(type & EFFECT_TYPE_ACTIONS);
 		break;
 	}
 	case RESET_COPY: {

--- a/field.cpp
+++ b/field.cpp
@@ -442,7 +442,6 @@ void field::swap_card(card* pcard1, card* pcard2) {
 	pduel->write_buffer32(pcard2->data.code);
 	pduel->write_buffer32(pcard1->get_info_location());
 }
-// add EFFECT_SET_CONTROL
 void field::set_control(card* pcard, uint8 playerid, uint16 reset_phase, uint8 reset_count) {
 	if((core.remove_brainwashing && pcard->is_affected_by_effect(EFFECT_REMOVE_BRAINWASHING)) || pcard->refresh_control_status() == playerid)
 		return;

--- a/processor.cpp
+++ b/processor.cpp
@@ -4691,7 +4691,14 @@ int32 field::adjust_step(uint16 step) {
 				for(uint8 p = 0; p < 2; ++p) {
 					for(auto& pcard : player[p].list_mzone) {
 						if(pcard && pcard->is_affected_by_effect(EFFECT_REMOVE_BRAINWASHING)) {
-							pcard->reset(EFFECT_SET_CONTROL, RESET_CODE);
+							//the opposite of pcard->check_control_effect()
+							auto pr = pcard->single_effect.equal_range(EFFECT_SET_CONTROL);
+							for(auto eit = pr.first; eit != pr.second;) {
+								effect* peffect = eit->second;
+								++eit;
+								if(!peffect->condition)
+									peffect->handler->remove_effect(peffect);
+							}
 							if(p != pcard->owner && pcard->is_capable_change_control())
 								core.control_adjust_set[p].insert(pcard);
 						}


### PR DESCRIPTION
when monster affected by `EFFECT_SET_CONTROL` of `EFFECT_TYPE_SINGLE` with `condition` become face down, the controller will take control permanently
and `EFFECT_REMOVE_BRAINWASHING` only reset `EFFECT_SET_CONTROL` of `EFFECT_TYPE_SINGLE` without `condition`