### PR TITLE
update Card.GetAttack and so on

### DIFF
--- a/libcard.cpp
+++ b/libcard.cpp
@@ -584,14 +584,20 @@ int32 scriptlib::card_get_attack(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	lua_pushinteger(L, pcard->get_attack());
+	int32 atk = pcard->get_attack();
+	if(atk < 0)
+		atk = 0;
+	lua_pushinteger(L, atk);
 	return 1;
 }
 int32 scriptlib::card_get_origin_attack(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	lua_pushinteger(L, pcard->get_base_attack());
+	int32 atk = pcard->get_base_attack();
+	if(atk < 0)
+		atk = 0;
+	lua_pushinteger(L, atk);
 	return 1;
 }
 int32 scriptlib::card_get_text_attack(lua_State *L) {
@@ -608,14 +614,20 @@ int32 scriptlib::card_get_defense(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	lua_pushinteger(L, pcard->get_defense());
+	int32 def = pcard->get_defense();
+	if(def < 0)
+		def = 0;
+	lua_pushinteger(L, def);
 	return 1;
 }
 int32 scriptlib::card_get_origin_defense(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	lua_pushinteger(L, pcard->get_base_defense());
+	int32 def = pcard->get_base_defense();
+	if(def < 0)
+		def = 0;
+	lua_pushinteger(L, def);
 	return 1;
 }
 int32 scriptlib::card_get_text_defense(lua_State *L) {


### PR DESCRIPTION
Them shouldn't return `-2` on card with "?" ATK/DEF in deck. For cards which need to check the "?" ATK/DEF, use `GetTextAttack` instead.