### PR TITLE
fix Duel.ChangeChainOperation

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -59,7 +59,11 @@ void field::change_chain_effect(uint8 chaincount, int32 rep_op) {
 		return;
 	if(chaincount > core.current_chain.size() || chaincount < 1)
 		chaincount = core.current_chain.size();
-	core.current_chain[chaincount - 1].replace_op = rep_op;
+	chain& pchain = core.current_chain[chaincount - 1];
+	pchain.replace_op = rep_op;
+	if((pchain.triggering_effect->type & EFFECT_TYPE_ACTIVATE) && (pchain.triggering_effect->handler->current.location == LOCATION_SZONE)) {
+		pchain.triggering_effect->handler->set_status(STATUS_LEAVE_CONFIRMED, TRUE);
+	}
 }
 void field::change_target(uint8 chaincount, group* targets) {
 	if(core.current_chain.size() == 0)


### PR DESCRIPTION
Fix this: If _Vanity's Emptiness_'s effect replaced by _Generaider Territory_, _Vanity's Emptiness_ don't send to grave.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22792
> この一連の処理後、「虚無空間」は処理が完了したカードとして、**通常罠カードなどのように、墓地へ送られる事になります**。
> （これによって墓地へ送られた永続罠カードは、カードの効果によって墓地へ送られた扱いにはなりません。）