### PR TITLE
fix&update remove

### DIFF
--- a/card.h
+++ b/card.h
@@ -320,8 +320,8 @@ public:
 	int32 is_destructable_by_battle(card* pcard);
 	effect* check_indestructable_by_effect(effect* peffect, uint8 playerid);
 	int32 is_destructable_by_effect(effect* peffect, uint8 playerid);
-	int32 is_removeable(uint8 playerid);
-	int32 is_removeable_as_cost(uint8 playerid);
+	int32 is_removeable(uint8 playerid, uint8 pos, uint32 reason);
+	int32 is_removeable_as_cost(uint8 playerid, uint8 pos);
 	int32 is_releasable_by_summon(uint8 playerid, card* pcard);
 	int32 is_releasable_by_nonsummon(uint8 playerid);
 	int32 is_releasable_by_effect(uint8 playerid, effect* peffect);

--- a/field.cpp
+++ b/field.cpp
@@ -3145,7 +3145,7 @@ int32 field::is_player_can_remove(uint8 playerid, card * pcard, uint32 reason) {
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		pduel->lua->add_param(reason, PARAM_TYPE_INT);
 		pduel->lua->add_param(core.reason_effect, PARAM_TYPE_EFFECT);
-		if (pduel->lua->check_condition(eset[i]->target, 5))
+		if(pduel->lua->check_condition(eset[i]->target, 5))
 			return FALSE;
 	}
 	return TRUE;

--- a/field.cpp
+++ b/field.cpp
@@ -1801,7 +1801,7 @@ void field::get_ritual_material(uint8 playerid, effect* peffect, card_set* mater
 		if((pcard->data.type & TYPE_MONSTER) && pcard->is_releasable_by_nonsummon(playerid))
 			material->insert(pcard);
 	for(auto& pcard : player[playerid].list_grave)
-		if((pcard->data.type & TYPE_MONSTER) && pcard->is_affected_by_effect(EFFECT_EXTRA_RITUAL_MATERIAL) && pcard->is_removeable(playerid))
+		if((pcard->data.type & TYPE_MONSTER) && pcard->is_affected_by_effect(EFFECT_EXTRA_RITUAL_MATERIAL) && pcard->is_removeable(playerid, POS_FACEUP, REASON_EFFECT))
 			material->insert(pcard);
 }
 void field::get_fusion_material(uint8 playerid, card_set* material) {
@@ -3134,7 +3134,7 @@ int32 field::is_player_can_send_to_deck(uint8 playerid, card * pcard) {
 	}
 	return TRUE;
 }
-int32 field::is_player_can_remove(uint8 playerid, card * pcard) {
+int32 field::is_player_can_remove(uint8 playerid, card * pcard, uint32 reason) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_REMOVE, &eset);
 	for(int32 i = 0; i < eset.size(); ++i) {
@@ -3143,7 +3143,9 @@ int32 field::is_player_can_remove(uint8 playerid, card * pcard) {
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
-		if (pduel->lua->check_condition(eset[i]->target, 3))
+		pduel->lua->add_param(reason, PARAM_TYPE_INT);
+		pduel->lua->add_param(core.reason_effect, PARAM_TYPE_EFFECT);
+		if (pduel->lua->check_condition(eset[i]->target, 5))
 			return FALSE;
 	}
 	return TRUE;

--- a/field.h
+++ b/field.h
@@ -472,7 +472,7 @@ public:
 	int32 is_player_can_send_to_grave(uint8 playerid, card* pcard);
 	int32 is_player_can_send_to_hand(uint8 playerid, card* pcard);
 	int32 is_player_can_send_to_deck(uint8 playerid, card* pcard);
-	int32 is_player_can_remove(uint8 playerid, card* pcard);
+	int32 is_player_can_remove(uint8 playerid, card* pcard, uint32 reason);
 	int32 is_chain_negatable(uint8 chaincount);
 	int32 is_chain_disablable(uint8 chaincount);
 	int32 is_chain_disabled(uint8 chaincount);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2174,7 +2174,13 @@ int32 scriptlib::card_is_able_to_remove(lua_State *L) {
 	uint32 p = pcard->pduel->game_field->core.reason_player;
 	if(lua_gettop(L) >= 2)
 		p = lua_tointeger(L, 2);
-	if(pcard->is_removeable(p))
+	uint8 pos = POS_FACEUP;
+	if(lua_gettop(L) >= 3)
+		pos = lua_tointeger(L, 3);
+	uint32 reason = REASON_EFFECT;
+	if(lua_gettop(L) >= 4)
+		reason = lua_tointeger(L, 4);
+	if(pcard->is_removeable(p, pos, reason))
 		lua_pushboolean(L, 1);
 	else
 		lua_pushboolean(L, 0);
@@ -2241,7 +2247,10 @@ int32 scriptlib::card_is_able_to_remove_as_cost(lua_State *L) {
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 p = pcard->pduel->game_field->core.reason_player;
-	if(pcard->is_removeable_as_cost(p))
+	uint8 pos = POS_FACEUP;
+	if(lua_gettop(L) >= 2)
+		pos = lua_tointeger(L, 2);
+	if(pcard->is_removeable_as_cost(p, pos))
 		lua_pushboolean(L, 1);
 	else
 		lua_pushboolean(L, 0);

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3947,7 +3947,10 @@ int32 scriptlib::duel_is_player_can_remove(lua_State * L) {
 		check_param_count(L, 2);
 		check_param(L, PARAM_TYPE_CARD, 2);
 		card* pcard = *(card**) lua_touserdata(L, 2);
-		lua_pushboolean(L, pduel->game_field->is_player_can_remove(playerid, pcard));
+		uint32 reason = REASON_EFFECT;
+		if(lua_gettop(L) >= 3)
+			reason = lua_tointeger(L, 3);
+		lua_pushboolean(L, pduel->game_field->is_player_can_remove(playerid, pcard, reason));
 	}
 	return 1;
 }

--- a/operations.cpp
+++ b/operations.cpp
@@ -3396,7 +3396,7 @@ int32 field::destroy(uint16 step, group * targets, effect * reason_effect, uint3
 				dest = LOCATION_GRAVE;
 			if((dest == LOCATION_HAND && !pcard->is_capable_send_to_hand(reason_player))
 			        || (dest == LOCATION_DECK && !pcard->is_capable_send_to_deck(reason_player))
-			        || (dest == LOCATION_REMOVED && !pcard->is_removeable(reason_player)))
+			        || (dest == LOCATION_REMOVED && !pcard->is_removeable(reason_player, pcard->sendto_param.position, reason)))
 				dest = LOCATION_GRAVE;
 			pcard->sendto_param.location = dest;
 		}
@@ -3674,7 +3674,7 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 			         || (!(pcard->current.reason & REASON_COST) && !pcard->is_affect_by_effect(pcard->current.reason_effect))
 			         || (dest == LOCATION_HAND && !pcard->is_capable_send_to_hand(core.reason_player))
 			         || (dest == LOCATION_DECK && !pcard->is_capable_send_to_deck(core.reason_player))
-			         || (dest == LOCATION_REMOVED && !pcard->is_removeable(core.reason_player))
+			         || (dest == LOCATION_REMOVED && !pcard->is_removeable(core.reason_player, pcard->sendto_param.position, reason))
 			         || (dest == LOCATION_GRAVE && !pcard->is_capable_send_to_grave(core.reason_player))
 			         || (dest == LOCATION_EXTRA && !pcard->is_capable_send_to_extra(core.reason_player)))) {
 				pcard->current.reason = pcard->temp.reason;


### PR DESCRIPTION
Fix https://github.com/Fluorohydride/ygopro/issues/2102 and this.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22582
> リンクモンスターである「デリンジャラス・ドラゴン」は通常召喚できないモンスターとして扱われますが、自身のモンスター効果によって墓地から特殊召喚されている「デリンジャラス・ドラゴン」はフィールドを離れる際には表側表示で除外され、裏側表示で除外する事ができませんので、「極超辰醒」を発動する際のコストとして裏側表示で除外するモンスターに、自身のモンスター効果によって墓地から特殊召喚されている「デリンジャラス・ドラゴン」を含める事自体ができません。