### PR TITLE
update act in hand/set turn

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -246,8 +246,18 @@ int32 effect::is_activateable(uint8 playerid, const tevent& e, int32 neglect_con
 				handler->filter_effect(ecode, &eset);
 				for(int32 i = 0; i < eset.size(); ++i) {
 					if(eset[i]->check_count_limit(playerid)) {
-						available = true;
-						break;
+						if(eset[i]->cost) {
+							pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
+							pduel->lua->add_param(handler, PARAM_TYPE_CARD);
+							pduel->lua->add_param(playerid, PARAM_TYPE_INT);
+							if(pduel->lua->check_condition(eset[i]->cost, 3)) {
+								available = true;
+								break;
+							}
+						} else {
+							available = true;
+							break;
+						}
 					}
 				}
 				if(!available)
@@ -270,7 +280,7 @@ int32 effect::is_activateable(uint8 playerid, const tevent& e, int32 neglect_con
 				if(phandler->is_position(POS_FACEUP) && !phandler->is_status(STATUS_EFFECT_ENABLED))
 					return FALSE;
 			}
-			if(!(type & (EFFECT_TYPE_FLIP | EFFECT_TYPE_TRIGGER_F)) 
+			if(!(type & (EFFECT_TYPE_FLIP | EFFECT_TYPE_TRIGGER_F))
 					&& !((type & EFFECT_TYPE_SINGLE) && (code == EVENT_TO_GRAVE || code == EVENT_DESTROYED || code == EVENT_SPSUMMON_SUCCESS || code == EVENT_TO_HAND || code == EVENT_REMOVE || code == EVENT_FLIP))) {
 				if((code < 1132 || code > 1149) && pduel->game_field->infos.phase == PHASE_DAMAGE && !is_flag(EFFECT_FLAG_DAMAGE_STEP))
 					return FALSE;
@@ -572,7 +582,7 @@ int32 effect::reset(uint32 reset_level, uint32 reset_type) {
 			return FALSE;
 		uint8 pid = get_handler_player();
 		uint8 tp = handler->pduel->game_field->infos.turn_player;
-		if((((reset_flag & RESET_SELF_TURN) && pid == tp) || ((reset_flag & RESET_OPPO_TURN) && pid != tp)) 
+		if((((reset_flag & RESET_SELF_TURN) && pid == tp) || ((reset_flag & RESET_OPPO_TURN) && pid != tp))
 				&& (reset_level & 0x3ff & reset_flag))
 			reset_count--;
 		if(reset_count == 0)


### PR DESCRIPTION
If activating card has multiple `EFFECT_TRAP_ACT_IN_HAND`, `EFFECT_TRAP_ACT_IN_SET_TURN`, `EFFECT_QP_ACT_IN_NTPHAND` or `EFFECT_QP_ACT_IN_SET_TURN`, activating player cannot select applying effect.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14554
> 質問の状況の場合、そのターンにセットされた「ディメンション・スライド」をどちらの効果によって発動するかを選ぶ事ができます。
> 
> 自身の『その特殊召喚がエクシーズ召喚だった場合、このカードはセットしたターンに発動できる』効果によって発動する事とした場合、「王家の神殿」の『①：自分は罠カード１枚をセットしたターンに発動できる』効果によって、他の罠カードをもう１枚発動する事ができます。
> 
> 逆に、「王家の神殿」の『①：自分は罠カード１枚をセットしたターンに発動できる』効果によって「ディメンション・スライド」を発動した場合には、このターンにセットされた他の罠カードを発動する事はできません。

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=18869
> 「タイフーン」を、カードによって決められた『相手フィールドに魔法・罠カードが２枚以上存在し、自分フィールドに魔法・罠カードが存在しない場合、このカードの発動は手札からもできる』方法によって手札から発動する場合には、「虚空の黒魔導師」のエクシーズ素材を取り除く必要はありません。
> 
> 「タイフーン」を『①：X素材を持ったこのカードがモンスターゾーンに存在する限り、自分は相手ターンに速攻魔法カード及び罠カードを手札から発動できる。その発動の際にこのカードのX素材を１つ取り除く』モンスター効果によって手札から発動する場合には、「虚空の黒魔導師」のエクシーズ素材を取り除く必要があります。