### PR TITLE
equip process: send equip card to grave if unable to equip

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -1402,9 +1402,14 @@ int32 field::equip(uint16 step, uint8 equip_player, card * equip_card, card * ta
 			return TRUE;
 		if(equip_card == target)
 			return TRUE;
+		bool to_grave = false;
+		if(target->current.location != LOCATION_MZONE || (target->current.position & POS_FACEDOWN))
+			to_grave = true;
 		refresh_location_info_instant();
-		if(target->current.location != LOCATION_MZONE || (target->current.position & POS_FACEDOWN)
-			|| get_useable_count(equip_card, equip_player, LOCATION_SZONE, equip_player, LOCATION_REASON_TOFIELD) <= 0) {
+		if(get_useable_count(equip_card, equip_player, LOCATION_SZONE, equip_player, LOCATION_REASON_TOFIELD) <= 0
+			&& equip_card->current.location != LOCATION_SZONE)
+			to_grave = true;
+		if(to_grave) {
 			if(equip_card->current.location != LOCATION_GRAVE)
 				send_to(equip_card, 0, REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
 			core.units.begin()->step = 2;

--- a/operations.cpp
+++ b/operations.cpp
@@ -1405,10 +1405,15 @@ int32 field::equip(uint16 step, uint8 equip_player, card * equip_card, card * ta
 		bool to_grave = false;
 		if(target->current.location != LOCATION_MZONE || (target->current.position & POS_FACEDOWN))
 			to_grave = true;
-		refresh_location_info_instant();
-		if(get_useable_count(equip_card, equip_player, LOCATION_SZONE, equip_player, LOCATION_REASON_TOFIELD) <= 0
-			&& equip_card->current.location != LOCATION_SZONE)
-			to_grave = true;
+		if(equip_card->current.location != LOCATION_SZONE) {
+			refresh_location_info_instant();
+			if(get_useable_count(equip_card, equip_player, LOCATION_SZONE, equip_player, LOCATION_REASON_TOFIELD) <= 0)
+				to_grave = true;
+		}
+		if(chain* ch = get_chain(0)) {
+			if(ch->target_cards && ch->target_cards->has_card(target) && !target->is_has_relation(*ch))
+				to_grave = true;
+		}
 		if(to_grave) {
 			if(equip_card->current.location != LOCATION_GRAVE)
 				send_to(equip_card, 0, REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);

--- a/processor.cpp
+++ b/processor.cpp
@@ -4279,9 +4279,6 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 			for(auto& ptarget : cait->target_cards->container)
 				ptarget->release_relation(*cait);
 		}
-		if((pcard->data.type & TYPE_EQUIP) && (peffect->type & EFFECT_TYPE_ACTIVATE)
-		        && !pcard->equiping_target && pcard->is_has_relation(*cait))
-			destroy(pcard, 0, REASON_RULE, PLAYER_NONE);
 		if(core.duel_rule <= 2) {
 			if((pcard->data.type & TYPE_FIELD) && (peffect->type & EFFECT_TYPE_ACTIVATE)
 					&& !pcard->is_status(STATUS_LEAVE_CONFIRMED) && pcard->is_has_relation(*cait)) {

--- a/processor.cpp
+++ b/processor.cpp
@@ -4279,6 +4279,9 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 			for(auto& ptarget : cait->target_cards->container)
 				ptarget->release_relation(*cait);
 		}
+		if((pcard->data.type & TYPE_EQUIP) && (peffect->type & EFFECT_TYPE_ACTIVATE)
+			&& !pcard->equiping_target && pcard->is_has_relation(*cait))
+			pcard->set_status(STATUS_LEAVE_CONFIRMED, TRUE);
 		if(core.duel_rule <= 2) {
 			if((pcard->data.type & TYPE_FIELD) && (peffect->type & EFFECT_TYPE_ACTIVATE)
 					&& !pcard->is_status(STATUS_LEAVE_CONFIRMED) && pcard->is_has_relation(*cait)) {


### PR DESCRIPTION
Similar to special summoning monsters, if the target become not on field or face down, or there is no enough s/t zones, the equipping card should be sent to grave

related: Fluorohydride/ygopro-scripts#1273