### PR TITLE
Make 2nd parameter in GetLocationCountFromEx optional

### DIFF
--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1869,7 +1869,7 @@ int32 scriptlib::duel_get_location_count_fromex(lua_State *L) {
 		return 0;
 	duel* pduel = interpreter::get_duel_info(L);
 	uint32 uplayer = pduel->game_field->core.reason_player;
-	if(lua_gettop(L) >= 2)
+	if(lua_gettop(L) >= 2 && !lua_isnil(L, 2))
 		uplayer = lua_tointeger(L, 2);
 	bool swapped = false;
 	card* mcard = 0;


### PR DESCRIPTION
It wasn't even really used in scripts, and the only times it was, tp was set as parameter, even of that isn't really the same as reason player on some cases, thus adding also the possibility of wrong interactions in the long run. Since there's no way to retrieve the reason effect (and even if there was it would have been kinda wasting to call a function to pass it as default parameter) it's better to make it optional