### PR TITLE
Fixed spsummon counters being resetted on monster swap

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1515,8 +1515,10 @@ void card::apply_field_effect() {
 	}
 	if(unique_code && (current.location & unique_location))
 		pduel->game_field->add_unique_card(this);
-	spsummon_counter[0] = spsummon_counter[1] = 0;
-	spsummon_counter_rst[0] = spsummon_counter_rst[1] = 0;
+	if(current.location != previous.location) {
+		spsummon_counter[0] = spsummon_counter[1] = 0;
+		spsummon_counter_rst[0] = spsummon_counter_rst[1] = 0;
+	}
 }
 void card::cancel_field_effect() {
 	if (current.controler == PLAYER_NONE)


### PR DESCRIPTION
Actually, if you use swapControl with a card like winda, its flags to track special summons will be resetted.
Sample puzzle:
```
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_TEST_MODE,4)
Debug.SetAIName("ai name")
Debug.SetPlayerInfo(0,6000,0,0)
Debug.SetPlayerInfo(1,6000,0,0)

Debug.AddCard(31036355,0,0,LOCATION_HAND,1,POS_FACEDOWN)
Debug.AddCard(83764718,0,0,LOCATION_HAND,1,POS_FACEDOWN)
Debug.AddCard(83764718,0,0,LOCATION_HAND,1,POS_FACEDOWN)

Debug.AddCard(89631139,0,0,LOCATION_GRAVE,1,POS_FACEDOWN)
Debug.AddCard(89631139,0,0,LOCATION_GRAVE,1,POS_FACEDOWN)

Debug.AddCard(94977269,1,1,LOCATION_MZONE,0,POS_FACEUP_ATTACK)

Debug.ReloadFieldEnd()
```

![image](https://user-images.githubusercontent.com/18705342/71930221-89370e00-319b-11ea-88ca-b9b187e56a00.png)
Use the first monster reborn, then creature swap with winda, and you'll be able to activate the other monster reborn.