### PR TITLE
fix refresh control status

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1975,12 +1975,14 @@ uint8 card::refresh_control_status() {
 		effect* peffect = eset.get_last();
 		if(peffect->id >= last_id) {
 			card* pcard = peffect->get_handler();
-			pduel->game_field->core.readjust_map[pcard]++;
-			if(pduel->game_field->core.readjust_map[pcard] > 3) {
+			uint8 val = (uint8)peffect->get_value(this);
+			if(val != current.controler)
+				pduel->game_field->core.readjust_map[pcard]++;
+			if(pduel->game_field->core.readjust_map[pcard] > 5) {
 				pduel->game_field->send_to(pcard, 0, REASON_RULE, peffect->get_handler_player(), PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
 				return final;
 			}
-			final = (uint8)peffect->get_value(this);
+			final = val;
 		}
 	}
 	return final;


### PR DESCRIPTION
_Mass Hypnosis_ will call `refresh_control_status()` twice for each card, so it shouldn't fail this check: https://github.com/Fluorohydride/ygopro-core/pull/205