### PR TITLE
include REASON_FUSION/RITUAL/... in msg_move of special summon

### DIFF
--- a/common.h
+++ b/common.h
@@ -159,6 +159,7 @@ struct card_sort {
 #define REASON_REDIRECT		0x4000000	//
 //#define REASON_REVEAL			0x8000000	//
 #define REASON_LINK			0x10000000	//
+#define REASON_PENDULUM		0x20000000	//
 
 //Status
 #define STATUS_DISABLED				0x0001	//

--- a/operations.cpp
+++ b/operations.cpp
@@ -156,6 +156,25 @@ void field::mset(uint32 setplayer, card* target, effect* proc, uint32 ignore_cou
 void field::special_summon_rule(uint32 sumplayer, card* target, uint32 summon_type) {
 	add_process(PROCESSOR_SPSUMMON_RULE, 0, 0, (group*)target, sumplayer, summon_type);
 }
+static uint32 summon_info2reason(uint32 summon_info) {
+    uint32 summontype = summon_info & 0xff000000;
+    uint32 summonreason = 0;
+
+    if(summontype == SUMMON_TYPE_FUSION)
+        summonreason = REASON_FUSION;
+    else if(summontype == SUMMON_TYPE_RITUAL)
+        summonreason = REASON_RITUAL;
+    else if(summontype == SUMMON_TYPE_SYNCHRO)
+        summonreason = REASON_SYNCHRO;
+    else if(summontype == SUMMON_TYPE_XYZ)
+        summonreason = REASON_XYZ;
+    else if(summontype == SUMMON_TYPE_PENDULUM)
+        summonreason = REASON_PENDULUM;
+    else if(summontype == SUMMON_TYPE_LINK)
+        summonreason = REASON_LINK;
+
+    return summonreason;
+}
 void field::special_summon(card_set* target, uint32 sumtype, uint32 sumplayer, uint32 playerid, uint32 nocheck, uint32 nolimit, uint32 positions, uint32 zone) {
 	if((positions & POS_FACEDOWN) && is_player_affected_by_effect(sumplayer, EFFECT_DEVINE_LIGHT))
 		positions = (positions & POS_FACEUP) | ((positions & POS_FACEDOWN) >> 1);
@@ -165,7 +184,7 @@ void field::special_summon(card_set* target, uint32 sumtype, uint32 sumplayer, u
 		pcard->temp.reason_player = pcard->current.reason_player;
 		pcard->summon_info = (sumtype & 0xf00ffff) | SUMMON_TYPE_SPECIAL | ((uint32)pcard->current.location << 16);
 		pcard->summon_player = sumplayer;
-		pcard->current.reason = REASON_SPSUMMON;
+		pcard->current.reason = REASON_SPSUMMON | summon_info2reason(pcard->summon_info);
 		pcard->current.reason_effect = core.reason_effect;
 		pcard->current.reason_player = core.reason_player;
 		pcard->spsummon_param = (playerid << 24) + (nocheck << 16) + (nolimit << 8) + positions;
@@ -182,7 +201,7 @@ void field::special_summon_step(card* target, uint32 sumtype, uint32 sumplayer, 
 	target->temp.reason_player = target->current.reason_player;
 	target->summon_info = (sumtype & 0xf00ffff) | SUMMON_TYPE_SPECIAL | ((uint32)target->current.location << 16);
 	target->summon_player = sumplayer;
-	target->current.reason = REASON_SPSUMMON;
+	target->current.reason = REASON_SPSUMMON | summon_info2reason(target->summon_info);
 	target->current.reason_effect = core.reason_effect;
 	target->current.reason_player = core.reason_player;
 	target->spsummon_param = (playerid << 24) + (nocheck << 16) + (nolimit << 8) + positions;
@@ -2681,7 +2700,7 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		target->summon_info = (summon_info & 0xf00ffff) | SUMMON_TYPE_SPECIAL | ((uint32)target->current.location << 16);
 		target->enable_field_effect(false);
 		move_to_field(target, sumplayer, targetplayer, LOCATION_MZONE, positions, FALSE, 0, FALSE, zone);
-		target->current.reason = REASON_SPSUMMON;
+		target->current.reason = REASON_SPSUMMON | summon_info2reason(target->summon_info);
 		target->current.reason_effect = peffect;
 		target->current.reason_player = sumplayer;
 		target->summon_player = sumplayer;
@@ -2856,6 +2875,7 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		pcard->current.reason_player = sumplayer;
 		pcard->summon_player = sumplayer;
 		pcard->summon_info = (peffect->get_value(pcard) & 0xff00ffff) | SUMMON_TYPE_SPECIAL | ((uint32)pcard->current.location << 16);
+		pcard->current.reason |= summon_info2reason(pcard->summon_info);
 		uint32 zone = 0xff;
 		uint32 flag1, flag2;
 		int32 ct1 = get_tofield_count(pcard, sumplayer, LOCATION_MZONE, sumplayer, LOCATION_REASON_TOFIELD, zone, &flag1);


### PR DESCRIPTION
Before: the msg_move of pendulum summoned card show REASON_SPSUMMON
After: the msg_move of pendulum summoned card shows REASON_SPSUMMON+REASON_PENDULUM

This PR adds the reason in msg_move for all the six named special summon types.

For issue #282