### PR TITLE
Don't cancel attack if monster is switched to def but has EFFECT_DEFENSE_ATTACK

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -4560,7 +4560,7 @@ int32 field::change_position(uint16 step, group * targets, effect * reason_effec
 					npos = POS_FACEUP_DEFENSE;
 				pcard->previous.position = opos;
 				pcard->current.position = npos;
-				if(npos & POS_DEFENSE)
+				if((npos & POS_DEFENSE) && !pcard->is_affected_by_effect(EFFECT_DEFENSE_ATTACK))
 					pcard->set_status(STATUS_ATTACK_CANCELED, TRUE);
 				pcard->set_status(STATUS_JUST_POS, TRUE);
 				pduel->write_buffer8(MSG_POS_CHANGE);


### PR DESCRIPTION
fixes https://github.com/Fluorohydride/ygopro-core/issues/289