### PR TITLE
Set current player to PLAYER_NONE in xyz_remove

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1472,6 +1472,7 @@ void card::xyz_remove(card* mat) {
 	mat->current.location = 0;
 	mat->current.sequence = 0;
 	mat->overlay_target = 0;
+	mat->current.controler = PLAYER_NONE;
 	for(auto clit = xyz_materials.begin(); clit != xyz_materials.end(); ++clit)
 		(*clit)->current.sequence = (uint8)(clit - xyz_materials.begin());
 	for(auto& eit : mat->xmaterial_effect) {


### PR DESCRIPTION
After the previous change (https://github.com/Fluorohydride/ygopro-core/commit/fefb0c47462f3b59217e2460dc63a78db32fbe9d) , xyz_add was returning as a previouslt overlayed material had its controller not set to PLAYER_NONE, making the client crash