### PR TITLE
add Auxiliary.PreloadUds

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -39,6 +39,7 @@ interpreter::interpreter(duel* pd): coroutines(256) {
 	scriptlib::open_duellib(lua_state);
 	scriptlib::open_debuglib(lua_state);
 	//extra scripts
+	load_script("./script/special.lua");
 	load_script("./script/constant.lua");
 	load_script("./script/utility.lua");
 }
@@ -322,9 +323,16 @@ int32 interpreter::call_code_function(uint32 code, const char* f, uint32 param_c
 		params.clear();
 		return OPERATION_FAIL;
 	}
-	load_card_script(code);
+	if (code)
+		load_card_script(code);
+	else
+		lua_getglobal(current_state, "Auxiliary");
 	lua_getfield(current_state, -1, f);
 	if (!lua_isfunction(current_state, -1)) {
+		if(!code) {
+			params.clear();
+			return OPERATION_FAIL;
+		}
 		sprintf(pduel->strbuffer, "\"CallCodeFunction\": attempt to call an error function");
 		handle_message(pduel, 1);
 		lua_pop(current_state, 2);

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -39,9 +39,9 @@ interpreter::interpreter(duel* pd): coroutines(256) {
 	scriptlib::open_duellib(lua_state);
 	scriptlib::open_debuglib(lua_state);
 	//extra scripts
-	load_script("./script/special.lua");
 	load_script("./script/constant.lua");
 	load_script("./script/utility.lua");
+	load_script("./script/special.lua");
 }
 interpreter::~interpreter() {
 	lua_close(lua_state);

--- a/interpreter.h
+++ b/interpreter.h
@@ -37,6 +37,7 @@ public:
 	coroutine_map coroutines;
 	int32 no_action;
 	int32 call_depth;
+	int32 preloaded;
 
 	explicit interpreter(duel* pd);
 	~interpreter();

--- a/libdebug.cpp
+++ b/libdebug.cpp
@@ -36,6 +36,10 @@ int32 scriptlib::debug_add_card(lua_State *L) {
 		return 0;
 	if(playerid != 0 && playerid != 1)
 		return 0;
+	if(!pduel->lua->preloaded) {
+		pduel->lua->preloaded = TRUE;
+		pduel->lua->call_code_function(0, (char*) "PreloadUds", 0, 0);
+	}
 	if(pduel->game_field->is_location_useable(playerid, location, sequence)) {
 		card* pcard = pduel->new_card(code);
 		pcard->owner = owner;

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -61,6 +61,7 @@ extern "C" DECL_DLLEXPORT ptr create_duel(uint32 seed) {
 	duel* pduel = new duel();
 	duel_set.insert(pduel);
 	pduel->random.reset(seed);
+	pduel->lua->preloaded = FALSE;
 	return (ptr)pduel;
 }
 extern "C" DECL_DLLEXPORT void start_duel(ptr pduel, int32 options) {
@@ -136,6 +137,10 @@ extern "C" DECL_DLLEXPORT int32 process(ptr pduel) {
 }
 extern "C" DECL_DLLEXPORT void new_card(ptr pduel, uint32 code, uint8 owner, uint8 playerid, uint8 location, uint8 sequence, uint8 position) {
 	duel* ptduel = (duel*)pduel;
+	if(!ptduel->lua->preloaded) {
+		ptduel->lua->preloaded = TRUE;
+		ptduel->lua->call_code_function(0, (char*) "PreloadUds", 0, 0);
+	}
 	if(ptduel->game_field->is_location_useable(playerid, location, sequence)) {
 		card* pcard = ptduel->new_card(code);
 		pcard->owner = owner;


### PR DESCRIPTION
the function Auxiliary.PreloadUds would be called after the lua environment was set, but before every cards were loaded.
In this function we can create effects affecting globally. It made chances to create special duel rules with this function.
In addition, `./script/special.lua` would be read for reading special duel rule scripts. Those card packes in `expansions` directory could include this script for special rules.
In addition, I'm making this just ready for Rush Duel. I'm currently participating the project https://github.com/Yuzurisa/ygopro-rd , which is using this mechanic. Contributions are welcomed to this one.
