### PR TITLE
Don't register field effect if it has EFFECT_FLAG_SPSUM_PARAM

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1528,7 +1528,7 @@ void card::apply_field_effect() {
 	if (current.controler == PLAYER_NONE)
 		return;
 	for (auto& it : field_effect) {
-		if (it.second->in_range(this)
+		if (!it.second->is_flag(EFFECT_FLAG_SPSUM_PARAM) && it.second->in_range(this)
 				|| ((it.second->range & LOCATION_HAND) && (it.second->type & EFFECT_TYPE_TRIGGER_O) && !(it.second->code & EVENT_PHASE))) {
 			pduel->game_field->add_effect(it.second);
 		}
@@ -1541,7 +1541,7 @@ void card::cancel_field_effect() {
 	if (current.controler == PLAYER_NONE)
 		return;
 	for (auto& it : field_effect) {
-		if (it.second->in_range(this)
+		if (!it.second->is_flag(EFFECT_FLAG_SPSUM_PARAM) && it.second->in_range(this)
 				|| ((it.second->range & LOCATION_HAND) && (it.second->type & EFFECT_TYPE_TRIGGER_O) && !(it.second->code & EVENT_PHASE))) {
 			pduel->game_field->remove_effect(it.second);
 		}
@@ -1565,7 +1565,7 @@ void card::enable_field_effect(bool enabled) {
 				it.second->id = pduel->game_field->infos.field_id++;
 		}
 		for (auto& it : field_effect) {
-			if (it.second->in_range(this))
+			if (!it.second->is_flag(EFFECT_FLAG_SPSUM_PARAM) && it.second->in_range(this))
 				it.second->id = pduel->game_field->infos.field_id++;
 		}
 		if(current.location == LOCATION_SZONE) {
@@ -1573,7 +1573,7 @@ void card::enable_field_effect(bool enabled) {
 				it.second->id = pduel->game_field->infos.field_id++;
 		}
 		for (auto& it : target_effect) {
-			if (it.second->in_range(this))
+			if (!it.second->is_flag(EFFECT_FLAG_SPSUM_PARAM) && it.second->in_range(this))
 				it.second->id = pduel->game_field->infos.field_id++;
 		}
 		if (get_status(STATUS_DISABLED))
@@ -1669,8 +1669,8 @@ int32 card::add_effect(effect* peffect) {
 	indexer.emplace(peffect, eit);
 	peffect->handler = this;
 	if((peffect->type & EFFECT_TYPE_FIELD)) {
-		if(peffect->in_range(this)
-			|| current.controler != PLAYER_NONE && ((peffect->range & LOCATION_HAND) && (peffect->type & EFFECT_TYPE_TRIGGER_O) && !(peffect->code & EVENT_PHASE)))
+		if(!peffect->is_flag(EFFECT_FLAG_SPSUM_PARAM) && (peffect->in_range(this)
+			|| current.controler != PLAYER_NONE && ((peffect->range & LOCATION_HAND) && (peffect->type & EFFECT_TYPE_TRIGGER_O) && !(peffect->code & EVENT_PHASE))))
 			pduel->game_field->add_effect(peffect);
 	}
 	if (current.controler != PLAYER_NONE && !check_target.empty()) {
@@ -1739,8 +1739,8 @@ void card::remove_effect(effect* peffect, effect_container::iterator it) {
 			pduel->game_field->update_disable_check_list(peffect);
 		}
 		field_effect.erase(it);
-		if(peffect->in_range(this)
-			|| current.controler != PLAYER_NONE && ((peffect->range & LOCATION_HAND) && (peffect->type & EFFECT_TYPE_TRIGGER_O) && !(peffect->code & EVENT_PHASE)))
+		if(!peffect->is_flag(EFFECT_FLAG_SPSUM_PARAM) && (peffect->in_range(this)
+			|| current.controler != PLAYER_NONE && ((peffect->range & LOCATION_HAND) && (peffect->type & EFFECT_TYPE_TRIGGER_O) && !(peffect->code & EVENT_PHASE))))
 			pduel->game_field->remove_effect(peffect);
 	}
 	if ((current.controler != PLAYER_NONE) && !get_status(STATUS_DISABLED | STATUS_FORBIDDEN) && !check_target.empty()) {


### PR DESCRIPTION
Cards using a field summon procedure, being it special summon, normal or set, in combination with EFFECT_FLAG_SPSUM_PARAM, were erroneously registered as field effects and put in effects.aura_effect, because unlike the other summon procedure effects that have by default the target range to 0,0, making ``peffect->in_range(this)`` return false, an effect using EFFECT_FLAG_SPSUM_PARAM actually has those 2 values set to the extra parameters for the effect.