### PR TITLE
update immune effects

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1580,7 +1580,6 @@ void card::enable_field_effect(bool enabled) {
 			reset(RESET_DISABLE, RESET_EVENT);
 	} else
 		set_status(STATUS_EFFECT_ENABLED, FALSE);
-	filter_immune_effect();
 	if (get_status(STATUS_DISABLED | STATUS_FORBIDDEN))
 		return;
 	filter_disable_related_cards();
@@ -1966,26 +1965,17 @@ void card::reset_effect_count() {
 // refresh STATUS_DISABLED based on EFFECT_DISABLE and EFFECT_CANNOT_DISABLE
 // refresh STATUS_FORBIDDEN based on EFFECT_FORBIDDEN
 void card::refresh_disable_status() {
-	// forbidden
-	int32 pre_fb = is_status(STATUS_FORBIDDEN);
 	filter_immune_effect();
+	// forbidden
 	if (is_affected_by_effect(EFFECT_FORBIDDEN))
 		set_status(STATUS_FORBIDDEN, TRUE);
 	else
 		set_status(STATUS_FORBIDDEN, FALSE);
-	int32 cur_fb = is_status(STATUS_FORBIDDEN);
-	if(pre_fb != cur_fb)
-		filter_immune_effect();
 	// disabled
-	int32 pre_dis = is_status(STATUS_DISABLED);
-	filter_immune_effect();
 	if (!is_affected_by_effect(EFFECT_CANNOT_DISABLE) && is_affected_by_effect(EFFECT_DISABLE))
 		set_status(STATUS_DISABLED, TRUE);
 	else
 		set_status(STATUS_DISABLED, FALSE);
-	int32 cur_dis = is_status(STATUS_DISABLED);
-	if(pre_dis != cur_dis)
-		filter_immune_effect();
 }
 std::tuple<uint8, effect*> card::refresh_control_status() {
 	uint8 final = owner;
@@ -2373,24 +2363,23 @@ void card::filter_single_continuous_effect(int32 code, effect_set* eset, uint8 s
 }
 // refresh this->immune_effect
 void card::filter_immune_effect() {
-	effect* peffect;
 	immune_effect.clear();
 	auto rg = single_effect.equal_range(EFFECT_IMMUNE_EFFECT);
 	for (; rg.first != rg.second; ++rg.first) {
-		peffect = rg.first->second;
+		effect* peffect = rg.first->second;
 		immune_effect.add_item(peffect);
 	}
 	for (auto& pcard : equiping_cards) {
 		rg = pcard->equip_effect.equal_range(EFFECT_IMMUNE_EFFECT);
 		for (; rg.first != rg.second; ++rg.first) {
-			peffect = rg.first->second;
+			effect* peffect = rg.first->second;
 			immune_effect.add_item(peffect);
 		}
 	}
 	for (auto& pcard : effect_target_owner) {
 		rg = pcard->target_effect.equal_range(EFFECT_IMMUNE_EFFECT);
 		for (; rg.first != rg.second; ++rg.first) {
-			peffect = rg.first->second;
+			effect* peffect = rg.first->second;
 			if(peffect->is_target(this))
 				immune_effect.add_item(peffect);
 		}
@@ -2398,7 +2387,7 @@ void card::filter_immune_effect() {
 	for (auto& pcard : xyz_materials) {
 		rg = pcard->xmaterial_effect.equal_range(EFFECT_IMMUNE_EFFECT);
 		for (; rg.first != rg.second; ++rg.first) {
-			peffect = rg.first->second;
+			effect* peffect = rg.first->second;
 			if (peffect->type & EFFECT_TYPE_FIELD)
 				continue;
 			immune_effect.add_item(peffect);
@@ -2406,7 +2395,7 @@ void card::filter_immune_effect() {
 	}
 	rg = pduel->game_field->effects.aura_effect.equal_range(EFFECT_IMMUNE_EFFECT);
 	for (; rg.first != rg.second; ++rg.first) {
-		peffect = rg.first->second;
+		effect* peffect = rg.first->second;
 		if (peffect->is_target(this))
 			immune_effect.add_item(peffect);
 	}

--- a/card.cpp
+++ b/card.cpp
@@ -2378,22 +2378,20 @@ void card::filter_immune_effect() {
 	auto rg = single_effect.equal_range(EFFECT_IMMUNE_EFFECT);
 	for (; rg.first != rg.second; ++rg.first) {
 		peffect = rg.first->second;
-		if (peffect->is_available())
-			immune_effect.add_item(peffect);
+		immune_effect.add_item(peffect);
 	}
 	for (auto& pcard : equiping_cards) {
 		rg = pcard->equip_effect.equal_range(EFFECT_IMMUNE_EFFECT);
 		for (; rg.first != rg.second; ++rg.first) {
 			peffect = rg.first->second;
-			if (peffect->is_available())
-				immune_effect.add_item(peffect);
+			immune_effect.add_item(peffect);
 		}
 	}
 	for (auto& pcard : effect_target_owner) {
 		rg = pcard->target_effect.equal_range(EFFECT_IMMUNE_EFFECT);
 		for (; rg.first != rg.second; ++rg.first) {
 			peffect = rg.first->second;
-			if(peffect->is_target(this) && peffect->is_available())
+			if(peffect->is_target(this))
 				immune_effect.add_item(peffect);
 		}
 	}
@@ -2403,14 +2401,13 @@ void card::filter_immune_effect() {
 			peffect = rg.first->second;
 			if (peffect->type & EFFECT_TYPE_FIELD)
 				continue;
-			if (peffect->is_available())
-				immune_effect.add_item(peffect);
+			immune_effect.add_item(peffect);
 		}
 	}
 	rg = pduel->game_field->effects.aura_effect.equal_range(EFFECT_IMMUNE_EFFECT);
 	for (; rg.first != rg.second; ++rg.first) {
 		peffect = rg.first->second;
-		if (peffect->is_target(this) && peffect->is_available())
+		if (peffect->is_target(this))
 			immune_effect.add_item(peffect);
 	}
 	immune_effect.sort();

--- a/effect.cpp
+++ b/effect.cpp
@@ -511,9 +511,9 @@ int32 effect::is_player_effect_target(card* pcard) {
 	return TRUE;
 }
 int32 effect::is_immuned(card* pcard) {
-	effect_set_v effects = pcard->immune_effect;
+	const effect_set_v& effects = pcard->immune_effect;
 	for (int32 i = 0; i < effects.size(); ++i) {
-		effect* peffect = effects.at(i);
+		effect* peffect = effects[i];
 		if(peffect->is_available() && peffect->value) {
 			pduel->lua->add_param(this, PARAM_TYPE_EFFECT);
 			pduel->lua->add_param(pcard, PARAM_TYPE_CARD);

--- a/effect.cpp
+++ b/effect.cpp
@@ -514,7 +514,7 @@ int32 effect::is_immuned(card* pcard) {
 	effect_set_v effects = pcard->immune_effect;
 	for (int32 i = 0; i < effects.size(); ++i) {
 		effect* peffect = effects.at(i);
-		if(peffect->value) {
+		if(peffect->is_available() && peffect->value) {
 			pduel->lua->add_param(this, PARAM_TYPE_EFFECT);
 			pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
 			if(peffect->check_value_condition(2))

--- a/effectset.h
+++ b/effectset.h
@@ -92,10 +92,19 @@ struct effect_set_v {
 			return;
 		std::sort(container.begin(), container.begin() + count, effect_sort_id);
 	}
+	effect* const& get_last() const {
+		return container[count - 1];
+	}
 	effect*& get_last() {
 		return container[count - 1];
 	}
+	effect* const& operator[] (int index) const {
+		return container[index];
+	}
 	effect*& operator[] (int index) {
+		return container[index];
+	}
+	effect* const& at(int index) const {
 		return container[index];
 	}
 	effect*& at(int index) {

--- a/field.cpp
+++ b/field.cpp
@@ -1913,38 +1913,35 @@ void field::update_disable_check_list(effect* peffect) {
 		add_to_disable_check_list(pcard);
 }
 void field::add_to_disable_check_list(card* pcard) {
-	auto result=effects.disable_check_set.insert(pcard);
+	auto result = effects.disable_check_set.insert(pcard);
 	if(!result.second)
 		return;
 	effects.disable_check_list.push_back(pcard);
 }
 void field::adjust_disable_check_list() {
-	card* checking;
-	int32 pre_disable, new_disable;
-	if (!effects.disable_check_list.size())
+	if(!effects.disable_check_list.size())
 		return;
-	card_set checked;
 	do {
-		checked.clear();
-		while (effects.disable_check_list.size()) {
-			checking = effects.disable_check_list.front();
+		card_set checked;
+		while(effects.disable_check_list.size()) {
+			card* checking = effects.disable_check_list.front();
 			effects.disable_check_list.pop_front();
 			effects.disable_check_set.erase(checking);
 			checked.insert(checking);
-			if (checking->is_status(STATUS_TO_ENABLE | STATUS_TO_DISABLE))
+			if(checking->is_status(STATUS_TO_ENABLE | STATUS_TO_DISABLE))
 				continue;
-			pre_disable = checking->get_status(STATUS_DISABLED | STATUS_FORBIDDEN);
+			int32 pre_disable = checking->get_status(STATUS_DISABLED | STATUS_FORBIDDEN);
 			checking->refresh_disable_status();
-			new_disable = checking->get_status(STATUS_DISABLED | STATUS_FORBIDDEN);
-			if (pre_disable != new_disable && checking->is_status(STATUS_EFFECT_ENABLED)) {
+			int32 new_disable = checking->get_status(STATUS_DISABLED | STATUS_FORBIDDEN);
+			if(pre_disable != new_disable && checking->is_status(STATUS_EFFECT_ENABLED)) {
 				checking->filter_disable_related_cards();
-				if (pre_disable)
+				if(pre_disable)
 					checking->set_status(STATUS_TO_ENABLE, TRUE);
 				else
 					checking->set_status(STATUS_TO_DISABLE, TRUE);
 			}
 		}
-		for (auto& pcard : checked) {
+		for(auto& pcard : checked) {
 			if(pcard->is_status(STATUS_DISABLED) && pcard->is_status(STATUS_TO_DISABLE) && !pcard->is_status(STATUS_TO_ENABLE))
 				pcard->reset(RESET_DISABLE, RESET_EVENT);
 			pcard->set_status(STATUS_TO_ENABLE | STATUS_TO_DISABLE, FALSE);


### PR DESCRIPTION
@DailyShana  @mercury233 
Problem
[86.zip](https://github.com/Fluorohydride/ygopro-core/files/4776515/86.zip)
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6890&keyword=&tag=-1
エクシーズ・オーバーディレイ(taeget: No.86 H－C ロンゴミアント with 3+ materials)
Now: No. 86 will not return to Extra Deck.
Correst: No. 86 will return to Extra Deck.

Reason
The status of No.86 is not refreshed after losing its materials.
In current version, Duel.AdjustInstantly(tc) does not work since filter_disable_related_cards() does not check the continuous effects of this.
