### PR TITLE
fix trap monsters disabling under duel rule<=4

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -1365,6 +1365,10 @@ int32 field::self_destroy(uint16 step, card* ucard, int32 p) {
 int32 field::trap_monster_adjust(uint16 step) {
 	switch(step) {
 	case 0: {
+		if(core.duel_rule <= 4) {
+			core.units.begin()->step = 3;
+			return FALSE;
+		}
 		card_set* to_grave_set = new card_set;
 		core.units.begin()->ptr1 = to_grave_set;
 		return FALSE;
@@ -1419,14 +1423,17 @@ int32 field::trap_monster_adjust(uint16 step) {
 		for(uint8 p = 0; p < 2; ++p) {
 			for(auto& pcard : core.trap_monster_adjust_set[tp]) {
 				pcard->reset(RESET_TURN_SET, RESET_EVENT);
+				if(core.duel_rule <= 4)
+					refresh_location_info_instant();
 				move_to_field(pcard, tp, tp, LOCATION_SZONE, pcard->current.position, FALSE, 2);
 			}
 			tp = 1 - tp;
 		}
-		card_set* to_grave_set = (card_set*)core.units.begin()->ptr1;
-		if(to_grave_set->size())
-			send_to(to_grave_set, 0, REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
-		delete to_grave_set;
+		if(to_grave_set) {
+			if(to_grave_set->size())
+				send_to(to_grave_set, 0, REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
+			delete to_grave_set;
+		}
 		return TRUE;
 	}
 	}

--- a/operations.cpp
+++ b/operations.cpp
@@ -1429,7 +1429,7 @@ int32 field::trap_monster_adjust(uint16 step) {
 			}
 			tp = 1 - tp;
 		}
-		if(to_grave_set) {
+		if(card_set* to_grave_set = (card_set*)core.units.begin()->ptr1) {
 			if(to_grave_set->size())
 				send_to(to_grave_set, 0, REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
 			delete to_grave_set;


### PR DESCRIPTION
If under mr4 or lower a trap monster is disabled (via jinzo for example), the monster won't be able to return to its previous location, and will remain stuck in the monster zone, that because the zone locking effect is being reset on RESET_TURN_SET, but the adjust operation isn't refreshing the locations after the effects are reset (like it was doing before the mr5 update). Also, almost all the steps in trap_monster_adjust can be skipped if the duel isn't mr5 as there will always be a free location due to trap monster mechanics in previous master rules.