### PR TITLE
fix unique check

### DIFF
--- a/card.h
+++ b/card.h
@@ -288,9 +288,9 @@ public:
 	void filter_single_continuous_effect(int32 code, effect_set* eset, uint8 sort = TRUE);
 	void filter_immune_effect();
 	void filter_disable_related_cards();
-	int32 filter_summon_procedure(uint8 playerid, effect_set* eset, uint8 ignore_count, uint8 min_tribute, uint32 zone);
+	int32 filter_summon_procedure(uint8 playerid, effect_set* eset, uint8 ignore_count, uint8 min_tribute, uint32 zone, uint8 ignore_tribute = FALSE, uint32 sumtype = 0);
 	int32 check_summon_procedure(effect* proc, uint8 playerid, uint8 ignore_count, uint8 min_tribute, uint32 zone);
-	int32 filter_set_procedure(uint8 playerid, effect_set* eset, uint8 ignore_count, uint8 min_tribute, uint32 zone);
+	int32 filter_set_procedure(uint8 playerid, effect_set* eset, uint8 ignore_count, uint8 min_tribute, uint32 zone, uint8 ignore_tribute = FALSE, uint32 sumtype = 0);
 	int32 check_set_procedure(effect* proc, uint8 playerid, uint8 ignore_count, uint8 min_tribute, uint32 zone);
 	void filter_spsummon_procedure(uint8 playerid, effect_set* eset, uint32 summon_type);
 	void filter_spsummon_procedure_g(uint8 playerid, effect_set* eset);

--- a/operations.cpp
+++ b/operations.cpp
@@ -3123,7 +3123,7 @@ int32 field::special_summon_step(uint16 step, group* targets, card* target, uint
 			}
 		}
 		if((target->current.location == LOCATION_MZONE)
-				|| check_unique_onfield(target, playerid, LOCATION_MZONE)
+				|| (positions & POS_FACEUP) && check_unique_onfield(target, playerid, LOCATION_MZONE)
 		        || !is_player_can_spsummon(core.reason_effect, target->summon_info & 0xff00ffff, positions, target->summon_player, playerid, target)
 		        || (!nocheck && !(target->data.type & TYPE_MONSTER))) {
 			core.units.begin()->step = 4;
@@ -4469,7 +4469,7 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 			uint32 flag;
 			uint32 lreason = (target->current.location == LOCATION_MZONE) ? LOCATION_REASON_CONTROL : LOCATION_REASON_TOFIELD;
 			int32 ct = get_useable_count(target, playerid, location, move_player, lreason, zone, &flag);
-			if((ret == 1) && (ct <= 0 || target->is_status(STATUS_FORBIDDEN) || check_unique_onfield(target, playerid, location))) {
+			if((ret == 1) && (ct <= 0 || target->is_status(STATUS_FORBIDDEN) || (positions & POS_FACEUP) && check_unique_onfield(target, playerid, location))) {
 				core.units.begin()->step = 3;
 				send_to(target, core.reason_effect, REASON_RULE, core.reason_player, PLAYER_NONE, LOCATION_GRAVE, 0, 0);
 				return FALSE;


### PR DESCRIPTION
@DailyShana @mercury233 
Problem
[unique.zip](https://github.com/Fluorohydride/ygopro-core/files/4807459/unique.zip)
unique1.yrp
Turn 4
Now: マジカルシルクハット cannot special summon 宮廷のしきたり if another one is on the field.
Correct: マジカルシルクハット can special summon 宮廷のしきたり if another one is on the field.

unique2.yrp
Now: Face-down 炎の王 ナグルファー cannot return to field if another one is on the field.
Correct: Face-down 炎の王 ナグルファー can return to field if another one is on the field.

unique3.yrp
Now: If there is a  炎の王 ナグルファー on the filed, the player can still choose summon when activating the effect of 死皇帝の陵墓.
The summon will not work, but the player can activate its effect again.
Correct: If there is a  炎の王 ナグルファー on the filed, the player can only choose monster set.

Reason
unique1.yrp
unique2.yrp
It should check uniqueness only when monsters enter the field in face-up position.

unique3.yrp
The result of  card::is_can_be_summoned() is wrong.
Current version: 
filter_set_procedure() returns 0, but is_can_be_summoned() returns true.
filter_set_procedure() will return 0 if check_tribute() fails, so is_can_be_summoned() will ignore res=0 if  peffec is set.

Modified version: 
1. For effects like 死皇帝の陵墓 which does not need tributes, filter_summon_procedure() should ignore tribute check and return the real checking result.
That is, filter_set_procedure() returns 0 means it really cannot be summoned for effects like 死皇帝の陵墓, and is_can_be_summoned() will return false.

2. is_player_can_summon() check is moved to filter_summon_procedure().

Correct version
[unique_correct.zip](https://github.com/Fluorohydride/ygopro-core/files/4807488/unique_correct.zip)
