### PR TITLE
update Card.CheckActivateEffect

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -352,49 +352,52 @@ int32 effect::is_action_check(uint8 playerid) {
 	return TRUE;
 }
 // check functions: condition, cost(chk=0), target(chk=0)
-int32 effect::is_activate_ready(uint8 playerid, const tevent& e, int32 neglect_cond, int32 neglect_cost, int32 neglect_target) {
-	if (!neglect_cond && condition) {
-		pduel->lua->add_param(this, PARAM_TYPE_EFFECT);
+int32 effect::is_activate_ready(effect* reason_effect, uint8 playerid, const tevent& e, int32 neglect_cond, int32 neglect_cost, int32 neglect_target) {
+	if(!neglect_cond && condition) {
+		pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
-		pduel->lua->add_param(e.event_cards , PARAM_TYPE_GROUP);
+		pduel->lua->add_param(e.event_cards, PARAM_TYPE_GROUP);
 		pduel->lua->add_param(e.event_player, PARAM_TYPE_INT);
 		pduel->lua->add_param(e.event_value, PARAM_TYPE_INT);
-		pduel->lua->add_param(e.reason_effect , PARAM_TYPE_EFFECT);
+		pduel->lua->add_param(e.reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(e.reason, PARAM_TYPE_INT);
 		pduel->lua->add_param(e.reason_player, PARAM_TYPE_INT);
-		if (!pduel->lua->check_condition(condition, 8)) {
+		if(!pduel->lua->check_condition(condition, 8)) {
 			return FALSE;
 		}
 	}
 	if(!neglect_cost && cost && !(type & EFFECT_TYPE_CONTINUOUS)) {
-		pduel->lua->add_param(this, PARAM_TYPE_EFFECT);
+		pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
-		pduel->lua->add_param(e.event_cards , PARAM_TYPE_GROUP);
+		pduel->lua->add_param(e.event_cards, PARAM_TYPE_GROUP);
 		pduel->lua->add_param(e.event_player, PARAM_TYPE_INT);
 		pduel->lua->add_param(e.event_value, PARAM_TYPE_INT);
-		pduel->lua->add_param(e.reason_effect , PARAM_TYPE_EFFECT);
+		pduel->lua->add_param(e.reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(e.reason, PARAM_TYPE_INT);
 		pduel->lua->add_param(e.reason_player, PARAM_TYPE_INT);
 		pduel->lua->add_param((ptr)0, PARAM_TYPE_INT);
-		if (!pduel->lua->check_condition(cost, 9)) {
+		if(!pduel->lua->check_condition(cost, 9)) {
 			return FALSE;
 		}
 	}
 	if(!neglect_target && target) {
-		pduel->lua->add_param(this, PARAM_TYPE_EFFECT);
+		pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
-		pduel->lua->add_param(e.event_cards , PARAM_TYPE_GROUP);
+		pduel->lua->add_param(e.event_cards, PARAM_TYPE_GROUP);
 		pduel->lua->add_param(e.event_player, PARAM_TYPE_INT);
 		pduel->lua->add_param(e.event_value, PARAM_TYPE_INT);
-		pduel->lua->add_param(e.reason_effect , PARAM_TYPE_EFFECT);
+		pduel->lua->add_param(e.reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(e.reason, PARAM_TYPE_INT);
 		pduel->lua->add_param(e.reason_player, PARAM_TYPE_INT);
 		pduel->lua->add_param((ptr)0, PARAM_TYPE_INT);
-		if (!pduel->lua->check_condition(target, 9)) {
+		if(!pduel->lua->check_condition(target, 9)) {
 			return FALSE;
 		}
 	}
 	return TRUE;
+}
+int32 effect::is_activate_ready(uint8 playerid, const tevent& e, int32 neglect_cond, int32 neglect_cost, int32 neglect_target) {
+	return is_activate_ready(this, playerid, e, neglect_cond, neglect_cost, neglect_target);
 }
 // check functions: condition
 int32 effect::is_condition_check(uint8 playerid, const tevent& e) {

--- a/effect.h
+++ b/effect.h
@@ -72,6 +72,7 @@ public:
 	int32 check_count_limit(uint8 playerid);
 	int32 is_activateable(uint8 playerid, const tevent& e, int32 neglect_cond = FALSE, int32 neglect_cost = FALSE, int32 neglect_target = FALSE, int32 neglect_loc = FALSE, int32 neglect_faceup = FALSE);
 	int32 is_action_check(uint8 playerid);
+	int32 is_activate_ready(effect* reason_effect, uint8 playerid, const tevent& e, int32 neglect_cond = FALSE, int32 neglect_cost = FALSE, int32 neglect_target = FALSE);
 	int32 is_activate_ready(uint8 playerid, const tevent& e, int32 neglect_cond = FALSE, int32 neglect_cost = FALSE, int32 neglect_target = FALSE);
 	int32 is_condition_check(uint8 playerid, const tevent& e);
 	int32 is_activate_check(uint8 playerid, const tevent& e, int32 neglect_cond = FALSE, int32 neglect_cost = FALSE, int32 neglect_target = FALSE);

--- a/processor.cpp
+++ b/processor.cpp
@@ -957,11 +957,11 @@ int32 field::check_event(uint32 code, tevent * pe) {
 }
 int32 field::check_event_c(effect* peffect, uint8 playerid, int32 neglect_con, int32 neglect_cost, int32 copy_info, tevent* pe) {
 	if(peffect->code == EVENT_FREE_CHAIN) {
-		return peffect->is_activate_ready(playerid, nil_event, neglect_con, neglect_cost, FALSE);
+		return peffect->is_activate_ready(core.reason_effect, playerid, nil_event, neglect_con, neglect_cost, FALSE);
 	}
 	for(const auto& ev : core.point_event) {
 		if(ev.event_code == peffect->code &&
-		        peffect->is_activate_ready(playerid, ev, neglect_con, neglect_cost, FALSE)) {
+		        peffect->is_activate_ready(core.reason_effect, playerid, ev, neglect_con, neglect_cost, FALSE)) {
 			if(pe)
 				*pe = ev;
 			if(copy_info && !pduel->lua->no_action && core.current_chain.size()) {
@@ -972,7 +972,7 @@ int32 field::check_event_c(effect* peffect, uint8 playerid, int32 neglect_con, i
 	}
 	for(const auto& ev : core.instant_event) {
 		if(ev.event_code == peffect->code &&
-		        peffect->is_activate_ready(playerid, ev, neglect_con, neglect_cost, FALSE)) {
+		        peffect->is_activate_ready(core.reason_effect, playerid, ev, neglect_con, neglect_cost, FALSE)) {
 			if(pe)
 				*pe = ev;
 			if(copy_info && !pduel->lua->no_action && core.current_chain.size()) {


### PR DESCRIPTION
when activating effect that copying another effect, when performing `target`, we use the `e,tp` of the copying effect but not the original effect:
```lua
function cxxx.cptg(e,tp,eg,ep,ev,re,r,rp,chk)
    --...
    local te,ceg,cep,cev,cre,cr,crp=tc:CheckActivateEffect(false,true,true)
    local tg=te:GetTarget()
    if tg then tg(e,tp,ceg,cep,cev,cre,cr,crp,1) end
    --...
end
```
but when filtering what cards can be copied, checking `target` is using `e,tp` of the original effect inside the `c:CheckActivateEffect(false,true,false)`.
This is inconsistent.

so we should update the `Card.CheckActivateEffect` to checking `condition`, `cost`, `target` using `e,tp` of the copying effect.