### PR TITLE
port to lua 5.4

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -550,7 +550,8 @@ int32 interpreter::call_coroutine(int32 f, uint32 param_count, uint32 * yield_va
 	}
 	push_param(rthread, true);
 	current_state = rthread;
-	int32 result = lua_resume(rthread, 0, param_count);
+	int32 res;
+	int32 result = lua_resume(rthread, 0, param_count, &res);
 	if (result == 0) {
 		coroutines.erase(f);
 		if(yield_value)
@@ -621,12 +622,13 @@ int32 interpreter::get_function_handle(lua_State* L, int32 index) {
 	int32 ref = luaL_ref(L, LUA_REGISTRYINDEX);
 	return ref;
 }
+static const char key = 'k';
 void interpreter::set_duel_info(lua_State* L, duel* pduel) {
 	lua_pushlightuserdata(L, pduel);
-	luaL_ref(L, LUA_REGISTRYINDEX);
+	lua_rawsetp(L, LUA_REGISTRYINDEX, &key);
 }
 duel* interpreter::get_duel_info(lua_State * L) {
-	lua_rawgeti(L, LUA_REGISTRYINDEX, 3);
+	lua_rawgetp(L, LUA_REGISTRYINDEX, &key);
 	duel* pduel = (duel*)lua_topointer(L, -1);
 	lua_pop(L, 1);
 	return pduel;


### PR DESCRIPTION
lua 5.4 is just released recently, to port to lua 5.4, there are two places to change:

- there is a new parameter for `lua_resume` and no way to backward

- the behavior of initial calling `luaL_ref(L, LUA_REGISTRYINDEX)` is changed
in `interpreter::set_duel_info`, the return value of `luaL_ref(L, LUA_REGISTRYINDEX)` is 4 instead of 3, so in `interpreter::get_duel_info`, the first line should be changed to `lua_rawgeti(L, LUA_REGISTRYINDEX, 4)`.
as the initial count of elements in `LUA_REGISTRYINDEX` is not part of api, so we should use other keys to save `duel*` in `LUA_REGISTRYINDEX`. Here I choose the address of a static varieble as key, which is unique by the nature of c/c++.

there is another issue when using lua 5.4. When calling `c:CheckActivateEffect` during execution of a coroutine (e.g executing `target`), it will cause a "C stack overflow", which do not occur in lua 5.3.
It seem that the stack overflow check is too strict, so we have to wait the upstream to solve this issue before merging this.