### PR TITLE
Pass extra parameter when retrieving the value of EFFECT_CHANGE_BATTL…

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -3433,9 +3433,12 @@ void field::calculate_battle_damage(effect** pdamchange, card** preason_card, ui
 							int32 val = -1;
 							if(!eset[i]->is_flag(EFFECT_FLAG_PLAYER_TARGET)) {
 								pduel->lua->add_param(p, PARAM_TYPE_INT);
+								pduel->lua->add_param(eset[i]->get_handler() == core.attacker, PARAM_TYPE_BOOLEAN);
+								val = eset[i]->get_value(2);
+							} else if(eset[i]->is_target_player(p)) {
+								pduel->lua->add_param(eset[i]->get_handler() == core.attacker, PARAM_TYPE_BOOLEAN);
 								val = eset[i]->get_value(1);
-							} else if(eset[i]->is_target_player(p))
-								val = eset[i]->get_value();
+							}
 							if(val == 0) {
 								dam_value = 0;
 								break;
@@ -3553,9 +3556,12 @@ void field::calculate_battle_damage(effect** pdamchange, card** preason_card, ui
 				int32 val = -1;
 				if(!eset[i]->is_flag(EFFECT_FLAG_PLAYER_TARGET)) {
 					pduel->lua->add_param(p, PARAM_TYPE_INT);
+					pduel->lua->add_param(eset[i]->get_handler() == reason_card, PARAM_TYPE_BOOLEAN);
+					val = eset[i]->get_value(2);
+				} else if(eset[i]->is_target_player(p)) {
+					pduel->lua->add_param(eset[i]->get_handler() == reason_card, PARAM_TYPE_BOOLEAN);
 					val = eset[i]->get_value(1);
-				} else if(eset[i]->is_target_player(p))
-					val = eset[i]->get_value();
+				}
 				if(val == 0) {
 					dam_value = 0;
 					break;

--- a/processor.cpp
+++ b/processor.cpp
@@ -3433,10 +3433,10 @@ void field::calculate_battle_damage(effect** pdamchange, card** preason_card, ui
 							int32 val = -1;
 							if(!eset[i]->is_flag(EFFECT_FLAG_PLAYER_TARGET)) {
 								pduel->lua->add_param(p, PARAM_TYPE_INT);
-								pduel->lua->add_param(eset[i]->get_handler() == core.attacker, PARAM_TYPE_BOOLEAN);
+								pduel->lua->add_param(core.attacker, PARAM_TYPE_CARD);
 								val = eset[i]->get_value(2);
 							} else if(eset[i]->is_target_player(p)) {
-								pduel->lua->add_param(eset[i]->get_handler() == core.attacker, PARAM_TYPE_BOOLEAN);
+								pduel->lua->add_param(core.attacker, PARAM_TYPE_CARD);
 								val = eset[i]->get_value(1);
 							}
 							if(val == 0) {
@@ -3556,10 +3556,10 @@ void field::calculate_battle_damage(effect** pdamchange, card** preason_card, ui
 				int32 val = -1;
 				if(!eset[i]->is_flag(EFFECT_FLAG_PLAYER_TARGET)) {
 					pduel->lua->add_param(p, PARAM_TYPE_INT);
-					pduel->lua->add_param(eset[i]->get_handler() == reason_card, PARAM_TYPE_BOOLEAN);
+					pduel->lua->add_param(reason_card, PARAM_TYPE_CARD);
 					val = eset[i]->get_value(2);
 				} else if(eset[i]->is_target_player(p)) {
-					pduel->lua->add_param(eset[i]->get_handler() == reason_card, PARAM_TYPE_BOOLEAN);
+					pduel->lua->add_param(reason_card, PARAM_TYPE_CARD);
 					val = eset[i]->get_value(1);
 				}
 				if(val == 0) {


### PR DESCRIPTION
…E_DAMAGE

This is needed mostly for Ghostrick Mansion, that card halves the battle damage only when a non ghostrick monster is inflicting it. The current script instead will halve the battle damage whenever a non ghostrick monster battles. The extra parameter, will be a boolean indicating if the handler of that effect is the card actually inflicting the damage. This will also require changing mansion's script from using a field effect to using grant effect, so that the handler will be properly set.

```

	local e5=Effect.CreateEffect(c)
	e5:SetType(EFFECT_TYPE_SINGLE)
	e5:SetCode(EFFECT_CHANGE_BATTLE_DAMAGE)
	e5:SetValue(s.damval)
	local e6=Effect.CreateEffect(c)
	e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_GRANT)
	e6:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_SET_AVAILABLE)
	e6:SetRange(LOCATION_FZONE)
	e6:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
	e6:SetTarget(s.rdtg)
	e6:SetLabelObject(e5)
	c:RegisterEffect(e6)

function s.rdtg(e,c)
	return not c:IsSetCard(0x8d)
end
function s.damval(e,damp,isres)
	if isres then return HALF_DAMAGE
	else return -1 end
end
```