### PR TITLE
Don't let trigger effects trigger if their condition is met at the same time as them changing location

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1508,6 +1508,8 @@ void card::xyz_remove(card* mat) {
 	if(mat->overlay_target != this)
 		return;
 	xyz_materials.erase(xyz_materials.begin() + mat->current.sequence);
+	if(pduel->game_field->core.current_chain.size() > 0)
+		pduel->game_field->core.just_sent_cards.insert(mat);
 	mat->previous.controler = mat->current.controler;
 	mat->previous.location = mat->current.location;
 	mat->previous.sequence = mat->current.sequence;

--- a/effect.cpp
+++ b/effect.cpp
@@ -267,6 +267,8 @@ int32 effect::is_activateable(uint8 playerid, const tevent& e, int32 neglect_con
 				if(phandler->is_position(POS_FACEUP) && !phandler->is_status(STATUS_EFFECT_ENABLED))
 					return FALSE;
 			}
+			if(pduel->game_field->core.just_sent_cards.find(phandler) != pduel->game_field->core.just_sent_cards.end())
+				return FALSE;
 			if(!(type & (EFFECT_TYPE_FLIP | EFFECT_TYPE_TRIGGER_F)) && !((type & EFFECT_TYPE_TRIGGER_O) && (type & EFFECT_TYPE_SINGLE))) {
 				if((code < 1132 || code > 1149) && pduel->game_field->infos.phase == PHASE_DAMAGE && !is_flag(EFFECT_FLAG_DAMAGE_STEP))
 					return FALSE;

--- a/field.cpp
+++ b/field.cpp
@@ -283,6 +283,8 @@ void field::remove_card(card* pcard) {
 		player[playerid].used_location &= ~(1 << pcard->current.sequence);
 	if (pcard->current.location == LOCATION_SZONE)
 		player[playerid].used_location &= ~(256 << pcard->current.sequence);
+	if(core.current_chain.size() > 0)
+		core.just_sent_cards.insert(pcard);
 	pcard->previous.controler = pcard->current.controler;
 	pcard->previous.location = pcard->current.location;
 	pcard->previous.sequence = pcard->current.sequence;
@@ -341,6 +343,8 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 					pduel->write_buffer32(pcard->data.code);
 					pduel->write_buffer32(pcard->get_info_location());
 				}
+				if(core.current_chain.size() > 0)
+					core.just_sent_cards.insert(pcard);
 				pcard->previous.controler = pcard->current.controler;
 				pcard->previous.location = pcard->current.location;
 				pcard->previous.sequence = pcard->current.sequence;
@@ -1014,12 +1018,16 @@ void field::reset_sequence(uint8 playerid, uint8 location) {
 }
 void field::swap_deck_and_grave(uint8 playerid) {
 	for(auto& pcard : player[playerid].list_grave) {
+		if(core.current_chain.size() > 0)
+			core.just_sent_cards.insert(pcard);
 		pcard->previous.location = LOCATION_GRAVE;
 		pcard->previous.sequence = pcard->current.sequence;
 		pcard->enable_field_effect(false);
 		pcard->cancel_field_effect();
 	}
 	for(auto& pcard : player[playerid].list_main) {
+		if(core.current_chain.size() > 0)
+			core.just_sent_cards.insert(pcard);
 		pcard->previous.location = LOCATION_DECK;
 		pcard->previous.sequence = pcard->current.sequence;
 		pcard->enable_field_effect(false);

--- a/field.h
+++ b/field.h
@@ -171,6 +171,7 @@ struct processor {
 	processor_list units;
 	processor_list subunits;
 	processor_unit reserved;
+	card_set just_sent_cards;
 	card_vector select_cards;
 	card_vector unselect_cards;
 	card_vector summonable_cards;

--- a/operations.cpp
+++ b/operations.cpp
@@ -356,6 +356,8 @@ int32 field::draw(uint16 step, effect* reason_effect, uint32 reason, uint8 reaso
 			pcard->enable_field_effect(false);
 			pcard->cancel_field_effect();
 			player[playerid].list_main.pop_back();
+			if(core.current_chain.size() > 0)
+				core.just_sent_cards.insert(pcard);
 			pcard->previous.controler = pcard->current.controler;
 			pcard->previous.location = pcard->current.location;
 			pcard->previous.sequence = pcard->current.sequence;
@@ -3994,6 +3996,8 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 			pduel->write_buffer8(0);
 			pduel->write_buffer8(0);
 			pduel->write_buffer32(pcard->current.reason);
+			if(core.current_chain.size() > 0)
+				core.just_sent_cards.insert(pcard);
 			pcard->previous.controler = pcard->current.controler;
 			pcard->previous.location = pcard->current.location;
 			pcard->previous.sequence = pcard->current.sequence;
@@ -4344,6 +4348,8 @@ int32 field::discard_deck(uint16 step, uint8 playerid, uint8 count, uint32 reaso
 			pcard->enable_field_effect(false);
 			pcard->cancel_field_effect();
 			player[playerid].list_main.pop_back();
+			if(core.current_chain.size() > 0)
+				core.just_sent_cards.insert(pcard);
 			pcard->previous.controler = pcard->current.controler;
 			pcard->previous.location = pcard->current.location;
 			pcard->previous.sequence = pcard->current.sequence;

--- a/processor.cpp
+++ b/processor.cpp
@@ -4440,6 +4440,7 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 		return FALSE;
 	}
 	case 13: {
+		core.just_sent_cards.clear();
 		raise_event((card*)0, EVENT_CHAIN_END, 0, 0, 0, 0, 0);
 		process_instant_event();
 		adjust_all();
@@ -4455,6 +4456,7 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 	return TRUE;
 }
 int32 field::break_effect() {
+	core.just_sent_cards.clear();
 	core.hint_timing[0] &= TIMING_DAMAGE_STEP | TIMING_DAMAGE_CAL;
 	core.hint_timing[1] &= TIMING_DAMAGE_STEP | TIMING_DAMAGE_CAL;
 	for (auto chit = core.new_ochain.begin(); chit != core.new_ochain.end();) {


### PR DESCRIPTION
This aims to be a proper solution for the workarounds used [here](https://github.com/Fluorohydride/ygopro-scripts/pull/1481) and [here](https://github.com/Fluorohydride/ygopro-scripts/pull/1486).
When a card is moved, it's put in the just_sent_cards set, if this happens during a chain, and in the activation validity check, it'll return false if the card is present in this set. This requires no script change, as it will all be handled internally.