### PR TITLE
refresh disable status after reset effect in send_to

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -4160,6 +4160,7 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 				else
 					pcard->reset(RESET_REMOVE, RESET_EVENT);
 			}
+			pcard->refresh_disable_status();
 		}
 		for(auto& pcard : param->leave)
 			raise_single_event(pcard, 0, EVENT_LEAVE_FIELD, pcard->current.reason_effect, pcard->current.reason, pcard->current.reason_player, 0, 0);


### PR DESCRIPTION
Fix: If _Cyber Dragon_ is destroyed by _Ancient Gear Beast_, and is sent back to hand by other card, it can't special summon,  because it still have `STATUS_DISABLED`