### PR TITLE
update Duel.SwapControl

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -1039,13 +1039,16 @@ int32 field::swap_control(uint16 step, effect* reason_effect, uint8 reason_playe
 		uint8 s1 = pcard1->current.sequence;
 		uint32 flag;
 		get_useable_count(NULL, p1, LOCATION_MZONE, reason_player, LOCATION_REASON_CONTROL, 0xff, &flag);
-		flag = (flag & ~(1 << s1) & 0xff) | ~0x1f;
+		if(reason_player == p1)
+			flag = (flag & ~(1 << s1) & 0xff) | ~0x1f;
+		else
+			flag = ((flag & ~(1 << s1)) << 16 & 0xff0000) | ~0x1f0000;
 		card* pcard2 = *targets2->it;
 		pduel->write_buffer8(MSG_HINT);
 		pduel->write_buffer8(HINT_SELECTMSG);
-		pduel->write_buffer8(p1);
+		pduel->write_buffer8(reason_player);
 		pduel->write_buffer32(pcard2->data.code);
-		add_process(PROCESSOR_SELECT_PLACE, 0, 0, 0, p1, flag, 1);
+		add_process(PROCESSOR_SELECT_PLACE, 0, 0, 0, reason_player, flag, 1);
 		return FALSE;
 	}
 	case 2: {
@@ -1055,13 +1058,16 @@ int32 field::swap_control(uint16 step, effect* reason_effect, uint8 reason_playe
 		uint8 s2 = pcard2->current.sequence;
 		uint32 flag;
 		get_useable_count(NULL, p2, LOCATION_MZONE, reason_player, LOCATION_REASON_CONTROL, 0xff, &flag);
-		flag = (flag & ~(1 << s2) & 0xff) | ~0x1f;
+		if(reason_player == p2)
+			flag = (flag & ~(1 << s2) & 0xff) | ~0x1f;
+		else
+			flag = ((flag & ~(1 << s2)) << 16 & 0xff0000) | ~0x1f0000;
 		card* pcard1 = *targets1->it;
 		pduel->write_buffer8(MSG_HINT);
 		pduel->write_buffer8(HINT_SELECTMSG);
-		pduel->write_buffer8(p2);
+		pduel->write_buffer8(reason_player);
 		pduel->write_buffer32(pcard1->data.code);
-		add_process(PROCESSOR_SELECT_PLACE, 0, 0, 0, p2, flag, 1);
+		add_process(PROCESSOR_SELECT_PLACE, 0, 0, 0, reason_player, flag, 1);
 		return FALSE;
 	}
 	case 3: {


### PR DESCRIPTION
> Question
「Evil★Twin プレゼント」の『●自分フィールドの「キスキル」モンスターまたは「リィラ」モンスター１体と、相手フィールドの表側表示モンスター１体を対象として発動できる。そのモンスター２体のコントロールを入れ替える』効果の処理時に、それぞれのモンスターを置く位置は、どちらのプレイヤーが決定しますか？
Answer
コントロールを入れ替える２体のモンスターの位置は、いずれも「Evil★Twin プレゼント」の効果を発動したプレイヤーが決めます。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23069&keyword=&tag=-1

There was a ruling about _Creature Swap_ saying the both player who get control of the monster select the place, but it is deleted in the official db, so the ruling should be considered as changed to the player who use the swap effect select places for both player.