### PR TITLE
fix equipped monster activated effect

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -4151,7 +4151,7 @@ int32 field::add_chain(uint16 step) {
 				phandler->set_status(STATUS_LEAVE_CONFIRMED, TRUE);
 		}
 		if((phandler->get_type() & (TYPE_SPELL | TYPE_TRAP))
-				&& (phandler->data.type & (TYPE_CONTINUOUS | TYPE_FIELD | TYPE_EQUIP | TYPE_PENDULUM))
+				&& (phandler->get_type() & (TYPE_CONTINUOUS | TYPE_FIELD | TYPE_EQUIP | TYPE_PENDULUM))
 				&& phandler->is_has_relation(clit) && phandler->current.location == LOCATION_SZONE
 				&& !peffect->is_flag(EFFECT_FLAG_FIELD_ONLY))
 			clit.flag |= CHAIN_CONTINUOUS_CARD;


### PR DESCRIPTION
should also don't process if the monster leave field when the effect resolve

addition to https://github.com/Fluorohydride/ygopro-core/commit/462d1314f5bfa959d042448078dd5394a585b904