### PR TITLE
define REASON_LOST_OVERLAY

### DIFF
--- a/common.h
+++ b/common.h
@@ -155,7 +155,7 @@ struct card_sort {
 #define REASON_REPLACE		0x1000000	//
 #define REASON_DRAW			0x2000000	//
 #define REASON_REDIRECT		0x4000000	//
-//#define REASON_REVEAL			0x8000000	//
+#define REASON_LOST_OVERLAY	0x8000000	//
 #define REASON_LINK			0x10000000	//
 
 //Status

--- a/operations.cpp
+++ b/operations.cpp
@@ -4270,7 +4270,7 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 		if(equipings.size())
 			destroy(&equipings, 0, REASON_RULE + REASON_LOST_TARGET, PLAYER_NONE);
 		if(overlays.size())
-			send_to(&overlays, 0, REASON_RULE + REASON_LOST_TARGET, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
+			send_to(&overlays, 0, REASON_RULE + REASON_LOST_OVERLAY, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
 		adjust_instant();
 		return FALSE;
 	}
@@ -4580,7 +4580,7 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 			if(target->xyz_materials.size()) {
 				card_set overlays;
 				overlays.insert(target->xyz_materials.begin(), target->xyz_materials.end());
-				send_to(&overlays, 0, REASON_LOST_TARGET + REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
+				send_to(&overlays, 0, REASON_LOST_OVERLAY + REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
 			}
 		}
 		if((target->previous.location == LOCATION_SZONE) && target->equiping_target)


### PR DESCRIPTION
`REASON_LOST_TARGET` is widely used for equip cards but never used for xyz material.