### PR TITLE
init group.it

### DIFF
--- a/group.cpp
+++ b/group.cpp
@@ -13,15 +13,18 @@ group::group(duel* pd) {
 	ref_handle = 0;
 	pduel = pd;
 	is_readonly = FALSE;
+	it = container.begin();
 }
 group::group(duel* pd, card* pcard) {
 	container.insert(pcard);
 	ref_handle = 0;
 	pduel = pd;
 	is_readonly = FALSE;
+	it = container.begin();
 }
 group::group(duel* pd, const card_set& cset): container(cset) {
 	ref_handle = 0;
 	pduel = pd;
 	is_readonly = FALSE;
+	it = container.begin();
 }


### PR DESCRIPTION
prevent crash when calling `GetNext` without `GetFirst`