### PR TITLE
fix EFFECT_DISABLE_FIELD

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1899,8 +1899,10 @@ void card::reset(uint32 id, uint32 reset_type) {
 			battled_cards.clear();
 			reset_effect_count();
 			auto pr = field_effect.equal_range(EFFECT_DISABLE_FIELD);
-			for(; pr.first != pr.second; ++pr.first)
-				pr.first->second->value = 0;
+			for(; pr.first != pr.second; ++pr.first){
+				if(!pr.first->second->is_flag(EFFECT_FLAG_FUNC_VALUE))
+					pr.first->second->value = 0;
+			}
 		}
 		if(id & (RESET_TODECK | RESET_TOHAND | RESET_TOGRAVE | RESET_REMOVE | RESET_TEMP_REMOVE
 			| RESET_OVERLAY | RESET_MSCHANGE | RESET_TOFIELD  | RESET_TURN_SET)) {

--- a/processor.cpp
+++ b/processor.cpp
@@ -4538,7 +4538,7 @@ int32 field::refresh_location_info(uint16 step) {
 		filter_field_effect(EFFECT_DISABLE_FIELD, &eset);
 		for (int32 i = 0; i < eset.size(); ++i) {
 			uint32 value = eset[i]->get_value();
-			if(value && !eset[i]->is_flag(EFFECT_FLAG_REPEAT)) {
+			if(value) {
 				player[0].disabled_location |= value & 0x1f7f;
 				player[1].disabled_location |= (value >> 16) & 0x1f7f;
 			} else


### PR DESCRIPTION
@mercury233 @purerosefallen 
Problem
Continuous effects with code EFFECT_DISABLE_FIELD does not support normal value function.

Reason
card::reset() will set "value" property to 0 when the card enters the field even if "value" is a function.
Since EFFECT_FLAG_FUNC_VALUE is still alive, it becomes a function with reference 0.
It may cause script error when the script tries to call the original value function.

Solution
Now card::reset() will set "value" property to 0 if "value" is a constant.
Therefore, we can use value function in EFFECT_DISABLE_FIELD, just like other effects.

EFFECT_DISABLE_FIELD has 3 types:
1. The player chooses the location
Now:
The script has an operation function but no value function.
The temp value will be set in operation, and it will be reset in card::reset().

2. Certain location related to the card
Now:
The script has a value function.
It will not be reset in card::reset().

3. Fixed location
Now:
The script sets the value as a constant.
The temp value will be reset in card::reset().

See  Fluorohydride/ygopro-scripts#1520

Replay
[replay.zip](https://github.com/Fluorohydride/ygopro-core/files/5749088/replay.zip)
