### PR TITLE
fix RESET_SELF_TURN RESET_OPPO_TURN

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -580,7 +580,7 @@ int32 effect::reset(uint32 reset_level, uint32 reset_type) {
 	case RESET_PHASE: {
 		if(!(reset_flag & RESET_PHASE))
 			return FALSE;
-		uint8 pid = get_handler_player();
+		uint8 pid = get_owner_player();
 		uint8 tp = handler->pduel->game_field->infos.turn_player;
 		if((((reset_flag & RESET_SELF_TURN) && pid == tp) || ((reset_flag & RESET_OPPO_TURN) && pid != tp)) 
 				&& (reset_level & 0x3ff & reset_flag))

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -1745,6 +1745,7 @@ int32 scriptlib::card_register_flag_effect(lua_State *L) {
 		reset |= (RESET_SELF_TURN | RESET_OPPO_TURN);
 	duel* pduel = pcard->pduel;
 	effect* peffect = pduel->new_effect();
+	peffect->effect_owner = pduel->game_field->core.reason_player;
 	peffect->owner = pcard;
 	peffect->handler = 0;
 	peffect->type = EFFECT_TYPE_SINGLE;


### PR DESCRIPTION
`RESET_SELF_TURN` and `RESET_OPPO_TURN` was using the player who control the card, but at most cases it should be the player who own the effect.

For example, Number 68 used its effect in turn 1 of player A, and its control is got by player B in turn 2, its indes effect should disappear at the end of turn 2, but now it wasn't reset until the turn of the opponent of player B end in turn 3.