### PR TITLE
Refresh disable status for spell activated from hand 

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -328,8 +328,7 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 					return;
 				} else
 					remove_card(pcard);
-			}
-			else if(location & LOCATION_ONFIELD) {
+			} else if(location & LOCATION_ONFIELD) {
 				if (playerid == preplayer && sequence == presequence)
 					return;
 				if(location == LOCATION_MZONE) {
@@ -373,13 +372,11 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 						pcard->unique_fieldid = UINT_MAX;
 				}
 				return;
-			}
-			else if(location == LOCATION_HAND) {
+			} else if(location == LOCATION_HAND) {
 				if(preplayer == playerid)
 					return;
 				remove_card(pcard);
-			}
-			else {
+			} else {
 				if(location == LOCATION_GRAVE) {
 					if(pcard->current.sequence == player[pcard->current.controler].list_grave.size() - 1)
 						return;
@@ -414,8 +411,7 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 				}
 				return;
 			}
-		}
-		else {
+		} else {
 			if((pcard->data.type & TYPE_PENDULUM) && (location == LOCATION_GRAVE)
 			        && pcard->is_capable_send_to_extra(playerid)
 			        && (((pcard->current.location == LOCATION_MZONE) && !pcard->is_status(STATUS_SUMMON_DISABLED))

--- a/field.cpp
+++ b/field.cpp
@@ -328,7 +328,8 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 					return;
 				} else
 					remove_card(pcard);
-			} else if(location & LOCATION_ONFIELD) {
+			}
+			else if(location & LOCATION_ONFIELD) {
 				if (playerid == preplayer && sequence == presequence)
 					return;
 				if(location == LOCATION_MZONE) {
@@ -372,11 +373,13 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 						pcard->unique_fieldid = UINT_MAX;
 				}
 				return;
-			} else if(location == LOCATION_HAND) {
+			}
+			else if(location == LOCATION_HAND) {
 				if(preplayer == playerid)
 					return;
 				remove_card(pcard);
-			} else {
+			}
+			else {
 				if(location == LOCATION_GRAVE) {
 					if(pcard->current.sequence == player[pcard->current.controler].list_grave.size() - 1)
 						return;
@@ -411,7 +414,8 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 				}
 				return;
 			}
-		} else {
+		}
+		else {
 			if((pcard->data.type & TYPE_PENDULUM) && (location == LOCATION_GRAVE)
 			        && pcard->is_capable_send_to_extra(playerid)
 			        && (((pcard->current.location == LOCATION_MZONE) && !pcard->is_status(STATUS_SUMMON_DISABLED))

--- a/processor.cpp
+++ b/processor.cpp
@@ -4007,6 +4007,7 @@ int32 field::add_chain(uint16 step) {
 		auto& clit = core.new_chains.front();
 		effect* peffect = clit.triggering_effect;
 		card* phandler = peffect->get_handler();
+		phandler->refresh_disable_status();
 		if(peffect->type & EFFECT_TYPE_ACTIVATE) {
 			clit.set_triggering_state(phandler);
 		}


### PR DESCRIPTION
@mercury233 
Problem
王宮の勅命 is on the field.

Activating a spell card from the field:
The spell card will have STATUS_DISABLED immediately.

Activating a spell card from the hand:
The spell card will not have STATUS_DISABLED immediately.

It may cause the same card has different behaviors when it is activated from different place.

Reason
The disable status is not refreshed when the spell card is moved to the field from the hand.

Solution
Refresh it in step 1.

Test replay
[replay.zip](https://github.com/Fluorohydride/ygopro-core/files/6117863/replay.zip)

