### PR TITLE
remove COUNTER_NEED_ENABLE

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2125,7 +2125,7 @@ int32 card::destination_redirect(uint8 destination, uint32 reason) {
 int32 card::add_counter(uint8 playerid, uint16 countertype, uint16 count, uint8 singly) {
 	if(!is_can_add_counter(playerid, countertype, count, singly, 0))
 		return FALSE;
-	uint16 cttype = countertype & ~COUNTER_NEED_ENABLE;
+	uint16 cttype = countertype;
 	auto pr = counters.emplace(cttype, counter_map::mapped_type());
 	auto cmit = pr.first;
 	if(pr.second) {
@@ -2145,7 +2145,7 @@ int32 card::add_counter(uint8 playerid, uint16 countertype, uint16 count, uint8 
 				pcount = mcount;
 		}
 	}
-	if((countertype & COUNTER_WITHOUT_PERMIT) && !(countertype & COUNTER_NEED_ENABLE))
+	if(countertype & COUNTER_WITHOUT_PERMIT)
 		cmit->second[0] += pcount;
 	else
 		cmit->second[1] += pcount;
@@ -2188,8 +2188,6 @@ int32 card::is_can_add_counter(uint8 playerid, uint16 countertype, uint16 count,
 			return FALSE;
 		if(!loc && (!(current.location & LOCATION_ONFIELD) || !is_position(POS_FACEUP)))
 			return FALSE;
-		if((countertype & COUNTER_NEED_ENABLE) && is_status(STATUS_DISABLED))
-			return FALSE;
 	}
 	uint32 check = countertype & COUNTER_WITHOUT_PERMIT;
 	if(!check) {
@@ -2215,7 +2213,7 @@ int32 card::is_can_add_counter(uint8 playerid, uint16 countertype, uint16 count,
 	}
 	if(!check)
 		return FALSE;
-	uint16 cttype = countertype & ~COUNTER_NEED_ENABLE;
+	uint16 cttype = countertype;
 	int32 limit = -1;
 	int32 cur = 0;
 	auto cmit = counters.find(cttype);

--- a/card.h
+++ b/card.h
@@ -366,7 +366,7 @@ public:
 #define SUMMON_TYPE_LINK		0x4c000000
 //Counter
 #define COUNTER_WITHOUT_PERMIT	0x1000
-#define COUNTER_NEED_ENABLE		0x2000
+//#define COUNTER_NEED_ENABLE		0x2000
 
 #define ASSUME_CODE			1
 #define ASSUME_TYPE			2

--- a/libdebug.cpp
+++ b/libdebug.cpp
@@ -127,14 +127,14 @@ int32 scriptlib::debug_pre_add_counter(lua_State *L) {
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 countertype = (uint32)lua_tointeger(L, 2);
 	uint32 count = (uint32)lua_tointeger(L, 3);
-	uint16 cttype = countertype & ~COUNTER_NEED_ENABLE;
+	uint16 cttype = countertype;
 	auto pr = pcard->counters.emplace(cttype, card::counter_map::mapped_type());
 	auto cmit = pr.first;
 	if(pr.second) {
 		cmit->second[0] = 0;
 		cmit->second[1] = 0;
 	}
-	if((countertype & COUNTER_WITHOUT_PERMIT) && !(countertype & COUNTER_NEED_ENABLE))
+	if(countertype & COUNTER_WITHOUT_PERMIT)
 		cmit->second[0] += count;
 	else
 		cmit->second[1] += count;


### PR DESCRIPTION
Mail in 2019/1/19

Counters with COUNTER_WITHOUT_PERMIT can be put on any monster.
Before:
A card put counters of this type on X:
The counters will not be removed when X is disabled.

A card put counters of this type on itself:
The counters will be removed when the card itself is disabled, the counters put on itself is denoted by COUNTER_NEED_ENABLE.

Now:
A card put counters of this type on itself:
The counters will not be removed when the card itself is disabled.
