### PR TITLE
Update spell counter

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2181,30 +2181,21 @@ int32 card::remove_counter(uint16 countertype, uint16 count) {
 	pduel->write_buffer16(count);
 	return TRUE;
 }
+// return: the player can put a counter on this or not
 int32 card::is_can_add_counter(uint8 playerid, uint16 countertype, uint16 count, uint8 singly, uint32 loc) {
 	effect_set eset;
-	if(count > 0) {
-		if(!pduel->game_field->is_player_can_place_counter(playerid, this, countertype, count))
-			return FALSE;
-		if(!loc && (!(current.location & LOCATION_ONFIELD) || !is_position(POS_FACEUP)))
-			return FALSE;
-	}
+	if (!pduel->game_field->is_player_can_place_counter(playerid, this, countertype, count))
+		return FALSE;
+	if (!loc && (!(current.location & LOCATION_ONFIELD) || !is_position(POS_FACEUP)))
+		return FALSE;
 	uint32 check = countertype & COUNTER_WITHOUT_PERMIT;
 	if(!check) {
 		filter_effect(EFFECT_COUNTER_PERMIT + (countertype & 0xffff), &eset);
 		for(int32 i = 0; i < eset.size(); ++i) {
-			uint32 prange = eset[i]->get_value();
+			uint32 prange = eset[i]->range;
 			if(loc)
 				check = loc & prange;
-			else if(current.location & LOCATION_ONFIELD) {
-				uint32 filter = TRUE;
-				if(eset[i]->target) {
-					pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
-					pduel->lua->add_param(this, PARAM_TYPE_CARD);
-					filter = pduel->lua->check_condition(eset[i]->target, 2);
-				}
-				check = current.is_location(prange) && is_position(POS_FACEUP) && filter;
-			} else
+			else
 				check = TRUE;
 			if(check)
 				break;
@@ -2225,6 +2216,27 @@ int32 card::is_can_add_counter(uint8 playerid, uint16 countertype, uint16 count,
 	if(limit > 0 && (cur + (singly ? 1 : count) > limit))
 		return FALSE;
 	return TRUE;
+}
+// return: this have a EFFECT_COUNTER_PERMIT of countertype or not
+int32 card::is_can_have_counter(uint16 countertype) {
+	effect_set eset;
+	if (countertype & COUNTER_WITHOUT_PERMIT)
+		return FALSE;
+	else {
+		filter_self_effect(EFFECT_COUNTER_PERMIT + (countertype & 0xffff), &eset);
+		if (current.is_location(LOCATION_ONFIELD)) {
+			for (int32 i = 0; i < eset.size(); ++i) {
+				if (eset[i]->is_ready())
+					return TRUE;
+			}
+			return FALSE;
+		}
+		else if (eset.size())
+			return TRUE;
+		else
+			return FALSE;
+	}
+	return FALSE;
 }
 int32 card::get_counter(uint16 countertype) {
 	auto cmit = counters.find(countertype);
@@ -2376,6 +2388,25 @@ void card::filter_single_continuous_effect(int32 code, effect_set* eset, uint8 s
 		}
 	}
 	if(sort)
+		eset->sort();
+}
+void card::filter_self_effect(int32 code, effect_set* eset, uint8 sort) {
+	auto rg = single_effect.equal_range(code);
+	for (; rg.first != rg.second; ++rg.first) {
+		effect* peffect = rg.first->second;
+		if(peffect->is_flag(EFFECT_FLAG_SINGLE_RANGE))
+			eset->add_item(rg.first->second);
+	}
+	for (auto& pcard : xyz_materials) {
+		rg = pcard->xmaterial_effect.equal_range(code);
+		for (; rg.first != rg.second; ++rg.first) {
+			effect* peffect = rg.first->second;
+			if (peffect->type & EFFECT_TYPE_FIELD)
+				continue;
+			eset->add_item(peffect);
+		}
+	}
+	if (sort)
 		eset->sort();
 }
 // refresh this->immune_effect

--- a/card.cpp
+++ b/card.cpp
@@ -2226,7 +2226,7 @@ int32 card::is_can_have_counter(uint16 countertype) {
 		filter_self_effect(EFFECT_COUNTER_PERMIT + (countertype & 0xffff), &eset);
 		if (current.is_location(LOCATION_ONFIELD)) {
 			for (int32 i = 0; i < eset.size(); ++i) {
-				if (eset[i]->is_ready())
+				if (eset[i]->is_single_ready())
 					return TRUE;
 			}
 			return FALSE;

--- a/card.h
+++ b/card.h
@@ -277,6 +277,7 @@ public:
 	int32 add_counter(uint8 playerid, uint16 countertype, uint16 count, uint8 singly);
 	int32 remove_counter(uint16 countertype, uint16 count);
 	int32 is_can_add_counter(uint8 playerid, uint16 countertype, uint16 count, uint8 singly, uint32 loc);
+	int32 is_can_have_counter(uint16 countertype);
 	int32 get_counter(uint16 countertype);
 	void set_material(card_set* materials);
 	void add_card_target(card* pcard);
@@ -286,6 +287,7 @@ public:
 	void filter_effect(int32 code, effect_set* eset, uint8 sort = TRUE);
 	void filter_single_effect(int32 code, effect_set* eset, uint8 sort = TRUE);
 	void filter_single_continuous_effect(int32 code, effect_set* eset, uint8 sort = TRUE);
+	void filter_self_effect(int32 code, effect_set* eset, uint8 sort = TRUE);
 	void filter_immune_effect();
 	void filter_disable_related_cards();
 	int32 filter_summon_procedure(uint8 playerid, effect_set* eset, uint8 ignore_count, uint8 min_tribute, uint32 zone);

--- a/effect.cpp
+++ b/effect.cpp
@@ -150,7 +150,7 @@ int32 effect::is_available() {
 	return res;
 }
 // check if a single effect is ready
-int32 effect::is_ready() {
+int32 effect::is_single_ready() {
 	if(type & EFFECT_TYPE_ACTIONS)
 		return FALSE;
 	if((type & (EFFECT_TYPE_SINGLE | EFFECT_TYPE_XMATERIAL)) && !(type & EFFECT_TYPE_FIELD)) {

--- a/effect.cpp
+++ b/effect.cpp
@@ -149,7 +149,8 @@ int32 effect::is_available() {
 		status &= ~EFFECT_STATUS_AVAILABLE;
 	return res;
 }
-// check if a single effect is ready
+// check if a effect is EFFECT_TYPE_SINGLE and is ready
+// check: range, enabled, condition
 int32 effect::is_single_ready() {
 	if(type & EFFECT_TYPE_ACTIONS)
 		return FALSE;

--- a/effect.h
+++ b/effect.h
@@ -69,6 +69,7 @@ public:
 	int32 is_self_destroy_related();
 	int32 is_can_be_forbidden();
 	int32 is_available();
+	int32 is_ready();
 	int32 check_count_limit(uint8 playerid);
 	int32 is_activateable(uint8 playerid, const tevent& e, int32 neglect_cond = FALSE, int32 neglect_cost = FALSE, int32 neglect_target = FALSE, int32 neglect_loc = FALSE, int32 neglect_faceup = FALSE);
 	int32 is_action_check(uint8 playerid);

--- a/effect.h
+++ b/effect.h
@@ -69,7 +69,7 @@ public:
 	int32 is_self_destroy_related();
 	int32 is_can_be_forbidden();
 	int32 is_available();
-	int32 is_ready();
+	int32 is_single_ready();
 	int32 check_count_limit(uint8 playerid);
 	int32 is_activateable(uint8 playerid, const tevent& e, int32 neglect_cond = FALSE, int32 neglect_cost = FALSE, int32 neglect_target = FALSE, int32 neglect_loc = FALSE, int32 neglect_faceup = FALSE);
 	int32 is_action_check(uint8 playerid);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2747,9 +2747,10 @@ int32 scriptlib::card_enable_counter_permit(lua_State *L) {
 	peffect->owner = pcard;
 	peffect->type = EFFECT_TYPE_SINGLE;
 	peffect->code = EFFECT_COUNTER_PERMIT | countertype;
-	peffect->value = prange;
+	peffect->flag[0] = EFFECT_FLAG_SINGLE_RANGE;
+	peffect->range = prange;
 	if(lua_gettop(L) > 3 && lua_isfunction(L, 4))
-		peffect->target = interpreter::get_function_handle(L, 4);
+		peffect->condition = interpreter::get_function_handle(L, 4);
 	pcard->add_effect(peffect);
 	return 0;
 }

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2782,13 +2782,11 @@ int32 scriptlib::card_is_can_turn_set(lua_State *L) {
 	return 1;
 }
 int32 scriptlib::card_is_can_add_counter(lua_State *L) {
-	check_param_count(L, 2);
+	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 countertype = (uint32)lua_tointeger(L, 2);
-	uint32 count = 0;
-	if(lua_gettop(L) > 2)
-		count = (uint32)lua_tointeger(L, 3);
+	uint32 count = (uint32)lua_tointeger(L, 3);
 	uint8 singly = FALSE;
 	if(lua_gettop(L) > 3)
 		singly = lua_toboolean(L, 4);
@@ -2809,6 +2807,14 @@ int32 scriptlib::card_is_can_remove_counter(lua_State *L) {
 	uint32 count = (uint32)lua_tointeger(L, 4);
 	uint32 reason = (uint32)lua_tointeger(L, 5);
 	lua_pushboolean(L, pcard->pduel->game_field->is_player_can_remove_counter(playerid, pcard, 0, 0, countertype, count, reason));
+	return 1;
+}
+int32 scriptlib::card_is_can_have_counter(lua_State* L) {
+	check_param_count(L, 2);
+	check_param(L, PARAM_TYPE_CARD, 1);
+	card* pcard = *(card**)lua_touserdata(L, 1);
+	uint32 countertype = (uint32)lua_tointeger(L, 2);
+	lua_pushboolean(L, pcard->is_can_have_counter(countertype));
 	return 1;
 }
 int32 scriptlib::card_is_can_overlay(lua_State *L) {
@@ -3418,6 +3424,7 @@ static const struct luaL_Reg cardlib[] = {
 	{ "IsCanTurnSet", scriptlib::card_is_can_turn_set },
 	{ "IsCanAddCounter", scriptlib::card_is_can_add_counter },
 	{ "IsCanRemoveCounter", scriptlib::card_is_can_remove_counter },
+	{ "IsCanHaveCounter", scriptlib::card_is_can_have_counter },
 	{ "IsCanOverlay", scriptlib::card_is_can_overlay },
 	{ "IsCanBeFusionMaterial", scriptlib::card_is_can_be_fusion_material },
 	{ "IsCanBeSynchroMaterial", scriptlib::card_is_can_be_synchro_material },

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -251,6 +251,7 @@ public:
 	static int32 card_is_can_turn_set(lua_State *L);
 	static int32 card_is_can_add_counter(lua_State *L);
 	static int32 card_is_can_remove_counter(lua_State *L);
+	static int32 card_is_can_have_counter(lua_State* L);
 	static int32 card_is_can_overlay(lua_State *L);
 	static int32 card_is_can_be_fusion_material(lua_State *L);
 	static int32 card_is_can_be_synchro_material(lua_State *L);


### PR DESCRIPTION
@mercury233 

Problem
I. EFFECT_COUNTER_PERMIT should be a continuous effect
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14130&keyword=&tag=-1
The cards with EFFECT_COUNTER_PERMIT can accept Spell Counter after it is resolved.
The player cannot do:
Chain 1: 魔導変換
Chain 2: 魔導加速
This behavior is incorrect, see ddd.

II. 魔力カウンターを置く事ができるカード(cards that can have a Spell Counter)
The term has multiple definitions.
For effects that only put a counter, it means "cards where you can actually put a counter now".
It does NOT contain cards which are disabled or reach their maximum. 

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22526&keyword=&tag=-1
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14213&keyword=&tag=-1
For other effects, it means "cards with EFFECT_COUNTER_PERMIT".
Ex. 創聖魔導王 エンディミオン/Endymion, the Mighty Master of Magic
It contains cards which are disabled or reach their maximum.

III.
https://ocg-rule.readthedocs.io/zh_CN/latest/c06/2019.html#id10
8/16
裁定变更：
「念动力防卫士」的效果宣言了放置有魔力指示物的卡不能使用的场合，放置的魔力指示物全部取除，也不当作可以放置魔力指示物的卡，不能对其发动「魔力掌握」。


Solution
Card.EnableCounterPermit(Card c, int countertype[, int location])
Now the card will have a EFFECT_COUNTER_PERMIT with EFFECT_FLAG_SINGLE_RANGE.


Card.IsCanAddCounter(int countertype, int count[, int singly, int location])
card::is_can_add_counter()
Check if the player can put counters on this card.
Now Card.IsCanAddCounter() must have the argument `count`.
Usage:
The card effects which only put counters.
card::add_counter()


Card.IsCanHaveCounter(countertype)
card::is_can_have_counter()
Check if this card has a EFFECT_COUNTER_PERMIT of countertype.

For cards on the field, it must have a EFFECT_COUNTER_PERMIT in the current location.
It does not contain ダーク・ヴァルキリア/Dark Valkyria which is not in the Dual state.

For other cards, possessing a EFFECT_COUNTER_PERMIT is enough.


Usage:
The property "cards that can have a Spell Counter".
Ex. 創聖魔導王 エンディミオン/Endymion, the Mighty Master of Magic



effect::is_can_be_forbidden()
Now EFFECT_COUNTER_PERMIT and EFFECT_COUNTER_LIMIT can be forbidden.


Test replays:
[replay.zip](https://github.com/Fluorohydride/ygopro-core/files/6166289/replay.zip)
bug_spell_counter1.yrp
Chain 1: 魔導変換
Chain 2: 魔導加速
It is incorrect.

correct_spell_counter1.yrp
The Pendulum Effect of 創聖魔導王 エンディミオン/Endymion, the Mighty Master of Magic should count disabled cards.
