### PR TITLE
update chain::chain_operation_sort() 

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -15,7 +15,10 @@
 int32 field::field_used_count[32] = {0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5};
 
 bool chain::chain_operation_sort(const chain& c1, const chain& c2) {
-	return c1.triggering_effect->id < c2.triggering_effect->id;
+	if (c1.triggering_effect && c2.triggering_effect && c1.triggering_effect->id != c2.triggering_effect->id)
+		return c1.triggering_effect->id < c2.triggering_effect->id;
+	else
+		return c1.chain_id < c2.chain_id;
 }
 void chain::set_triggering_state(card* pcard) {
 	triggering_controler = pcard->current.controler;


### PR DESCRIPTION
@mercury233 
Problem
Suppose that a trigger effect X is triggered multiple times in one chain.
When select_chain() is called, there will be multiple chain object with the same effect id.

Since std::sort() is not guaranteed to be stable, we should update chain::chain_operation_sort() when effect id is tied.

Solution
Require #369 
Compare chain_id when tied.
