### PR TITLE
don't enable field effect if effect replaced

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -4311,7 +4311,7 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 	case 2: {
 		effect* peffect = cait->triggering_effect;
 		card* pcard = peffect->get_handler();
-		if((peffect->type & EFFECT_TYPE_ACTIVATE) && pcard->is_has_relation(*cait)) {
+		if((peffect->type & EFFECT_TYPE_ACTIVATE) && pcard->is_has_relation(*cait) && !cait->replace_op) {
 			pcard->enable_field_effect(true);
 			if(core.duel_rule <= 2) {
 				if(pcard->data.type & TYPE_FIELD) {


### PR DESCRIPTION
> 「ジェネレイド」と名のついたカードの効果の発動にチェーンして、永続罠カードのカードの発動が行われた際にも、「王の支配」の効果を発動する事はできます。
質問の状況の場合、チェーン3にて発動した「王の支配」の効果が適用され、チェーン2にて発動した「虚無空間」の処理は、『お互いのプレイヤーは、それぞれデッキから１枚ドローする』処理として行われ、最後にチェーン1にて発動した「死の王 ヘル」のモンスター効果によってモンスターが特殊召喚されます。
この一連の処理後、「虚無空間」は処理が完了したカードとして、通常罠カードなどのように、墓地へ送られる事になります。
（これによって墓地へ送られた永続罠カードは、カードの効果によって墓地へ送られた扱いにはなりません。）
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22792&keyword=&tag=-1&request_locale=ja

Fix: The field effect of card whose activate effect is replaced shouldn't be activated, but now _Vanity's Emptiness_ will still prevent summon before it is sent to grave in chain end.