### PR TITLE
fix self-destroy & activation of the card

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -194,7 +194,6 @@ void field::special_summon_complete(effect* reason_effect, uint8 reason_player) 
 	group* ng = pduel->new_group();
 	ng->container.swap(core.special_summoning);
 	ng->is_readonly = TRUE;
-	//core.special_summoning.clear();
 	add_process(PROCESSOR_SPSUMMON, 1, reason_effect, ng, reason_player, 0);
 }
 void field::destroy(card_set* targets, effect* reason_effect, uint32 reason, uint32 reason_player, uint32 playerid, uint32 destination, uint32 sequence) {


### PR DESCRIPTION
@mercury233 @pyrQ
According to
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=14155&keyword=&tag=-1
The self-destruction effect will be applied before effect resolution, and this card is sent to grave.
For a continuous card not on the field, the effect resolution will do nothing.

Problem
In this situation, the operation function is still executed.

Reason
`if((peffect->type & EFFECT_TYPE_ACTIVATE) && pcard->is_has_relation(*cait) && !cait->replace_op) {
    pcard->enable_field_effect(true);
    ......
`

`add_process(PROCESSOR_EXECUTE_OPERATION, 0, cait->triggering_effect, 0, cait->triggering_player, 0);`

These lines are executed in the same step.
Even if the self-destruction condition is satisfied, PROCESSOR_EXECUTE_OPERATION will still be executed since it is already in the queue.

Solution
Step 2:
If a continuous card is not on the field, the resolution will do nothing and go to step 4 (clean up).
The self-destruction effect is applied, it will be handled in the next cycle.
If the effect is disabled, the resolution will do nothing and go to step 4 (clean up).

Step 3:
The self-destruction effect (if any) is done.
If a continuous card is not on the field, the resolution will do nothing and go to step 4 (clean up).

Step 4:
Clean up

All PROCESSOR_SOLVE_CHAIN calls starts from step 0, so the behaviors of other functions are unchanged.
This one fixes Fluorohydride/ygopro#2339

Reference
[test_self_destroy.zip](https://github.com/Fluorohydride/ygopro-core/files/6389473/test_self_destroy.zip)
test_self_destroy.yrp
T3
Add
`Debug.Message('test')` in c20426907.disop1
Before:
It will print the text, which indicates that the operation function is executed.
After:
It will not print the text.

Test_self_destroy.lua
The single mode script suggested by @pyrQ.
