### PR TITLE
check lua stack before pushing

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -47,6 +47,8 @@ interpreter::~interpreter() {
 }
 int32 interpreter::register_card(card *pcard) {
 	//create a card in by userdata
+	luaL_checkstack(lua_state, 1, NULL);
+	luaL_checkstack(current_state, 1, NULL);
 	card ** ppcard = (card**) lua_newuserdata(lua_state, sizeof(card*));
 	*ppcard = pcard;
 	pcard->ref_handle = luaL_ref(lua_state, LUA_REGISTRYINDEX);
@@ -74,6 +76,7 @@ void interpreter::register_effect(effect *peffect) {
 	if (!peffect)
 		return;
 	//create a effect in by userdata
+	luaL_checkstack(lua_state, 3, NULL);
 	effect ** ppeffect = (effect**) lua_newuserdata(lua_state, sizeof(effect*));
 	*ppeffect = peffect;
 	peffect->ref_handle = luaL_ref(lua_state, LUA_REGISTRYINDEX);
@@ -103,6 +106,7 @@ void interpreter::register_group(group *pgroup) {
 	if (!pgroup)
 		return;
 	//create a group in by userdata
+	luaL_checkstack(lua_state, 3, NULL);
 	group ** ppgroup = (group**) lua_newuserdata(lua_state, sizeof(group*));
 	*ppgroup = pgroup;
 	pgroup->ref_handle = luaL_ref(lua_state, LUA_REGISTRYINDEX);
@@ -138,9 +142,11 @@ int32 interpreter::load_script(const char* script_name) {
 int32 interpreter::load_card_script(uint32 code) {
 	char class_name[20];
 	sprintf(class_name, "c%d", code);
+	luaL_checkstack(current_state, 1, NULL);
 	lua_getglobal(current_state, class_name);
 	//if script is not loaded, create and load it
 	if (lua_isnil(current_state, -1)) {
+		luaL_checkstack(current_state, 5, NULL);
 		lua_pop(current_state, 1);
 		//create a table & set metatable
 		lua_createtable(current_state, 0, 0);
@@ -174,6 +180,7 @@ void interpreter::add_param(ptr param, int32 type, bool front) {
 void interpreter::push_param(lua_State* L, bool is_coroutine) {
 	int32 pushed = 0;
 	for (const auto& it : params) {
+		luaL_checkstack(L, 1, NULL);
 		uint32 type = it.second;
 		switch(type) {
 		case PARAM_TYPE_INT:
@@ -283,6 +290,7 @@ int32 interpreter::call_card_function(card* pcard, const char* f, uint32 param_c
 		return OPERATION_FAIL;
 	}
 	card2value(current_state, pcard);
+	luaL_checkstack(current_state, 1, NULL);
 	lua_getfield(current_state, -1, f);
 	if (!lua_isfunction(current_state, -1)) {
 		sprintf(pduel->strbuffer, "\"CallCardFunction\"(c%d.%s): attempt to call an error function", pcard->data.code, f);
@@ -323,6 +331,7 @@ int32 interpreter::call_code_function(uint32 code, const char* f, uint32 param_c
 		return OPERATION_FAIL;
 	}
 	load_card_script(code);
+	luaL_checkstack(current_state, 1, NULL);
 	lua_getfield(current_state, -1, f);
 	if (!lua_isfunction(current_state, -1)) {
 		sprintf(pduel->strbuffer, "\"CallCodeFunction\": attempt to call an error function");
@@ -386,6 +395,7 @@ int32 interpreter::check_matching(card* pcard, int32 findex, int32 extraargs) {
 		return TRUE;
 	no_action++;
 	call_depth++;
+	luaL_checkstack(current_state, 1 + extraargs, NULL);
 	lua_pushvalue(current_state, findex);
 	interpreter::card2value(current_state, pcard);
 	for(int32 i = 0; i < extraargs; ++i)
@@ -417,6 +427,7 @@ int32 interpreter::get_operation_value(card* pcard, int32 findex, int32 extraarg
 		return 0;
 	no_action++;
 	call_depth++;
+	luaL_checkstack(current_state, 1 + extraargs, NULL);
 	lua_pushvalue(current_state, findex);
 	interpreter::card2value(current_state, pcard);
 	for(int32 i = 0; i < extraargs; ++i)
@@ -579,6 +590,7 @@ int32 interpreter::call_coroutine(int32 f, uint32 param_count, uint32 * yield_va
 	}
 }
 int32 interpreter::clone_function_ref(int32 func_ref) {
+	luaL_checkstack(current_state, 1, NULL);
 	lua_rawgeti(current_state, LUA_REGISTRYINDEX, func_ref);
 	int32 ref = luaL_ref(current_state, LUA_REGISTRYINDEX);
 	return ref;
@@ -586,6 +598,7 @@ int32 interpreter::clone_function_ref(int32 func_ref) {
 void* interpreter::get_ref_object(int32 ref_handler) {
 	if(ref_handler == 0)
 		return nullptr;
+	luaL_checkstack(current_state, 1, NULL);
 	lua_rawgeti(current_state, LUA_REGISTRYINDEX, ref_handler);
 	void* p = *(void**)lua_touserdata(current_state, -1);
 	lua_pop(current_state, 1);
@@ -593,30 +606,35 @@ void* interpreter::get_ref_object(int32 ref_handler) {
 }
 //Convert a pointer to a lua value, +1 -0
 void interpreter::card2value(lua_State* L, card* pcard) {
+	luaL_checkstack(L, 1, NULL);
 	if (!pcard || pcard->ref_handle == 0)
 		lua_pushnil(L);
 	else
 		lua_rawgeti(L, LUA_REGISTRYINDEX, pcard->ref_handle);
 }
 void interpreter::group2value(lua_State* L, group* pgroup) {
+	luaL_checkstack(L, 1, NULL);
 	if (!pgroup || pgroup->ref_handle == 0)
 		lua_pushnil(L);
 	else
 		lua_rawgeti(L, LUA_REGISTRYINDEX, pgroup->ref_handle);
 }
 void interpreter::effect2value(lua_State* L, effect* peffect) {
+	luaL_checkstack(L, 1, NULL);
 	if (!peffect || peffect->ref_handle == 0)
 		lua_pushnil(L);
 	else
 		lua_rawgeti(L, LUA_REGISTRYINDEX, peffect->ref_handle);
 }
 void interpreter::function2value(lua_State* L, int32 func_ref) {
+	luaL_checkstack(L, 1, NULL);
 	if (!func_ref)
 		lua_pushnil(L);
 	else
 		lua_rawgeti(L, LUA_REGISTRYINDEX, func_ref);
 }
 int32 interpreter::get_function_handle(lua_State* L, int32 index) {
+	luaL_checkstack(L, 1, NULL);
 	lua_pushvalue(L, index);
 	int32 ref = luaL_ref(L, LUA_REGISTRYINDEX);
 	return ref;
@@ -626,6 +644,7 @@ void interpreter::set_duel_info(lua_State* L, duel* pduel) {
 	luaL_ref(L, LUA_REGISTRYINDEX);
 }
 duel* interpreter::get_duel_info(lua_State * L) {
+	luaL_checkstack(L, 1, NULL);
 	lua_rawgeti(L, LUA_REGISTRYINDEX, 3);
 	duel* pduel = (duel*)lua_topointer(L, -1);
 	lua_pop(L, 1);


### PR DESCRIPTION
>When you interact with the Lua API, you are responsible for ensuring consistency. In particular, you are responsible for controlling stack overflow. You can use the function lua_checkstack to ensure that the stack has enough space for pushing new elements.
https://www.lua.org/manual/5.3/manual.html#4.2
-----
Replay: [corrupted stack.zip](https://github.com/Fluorohydride/ygopro-core/files/6434220/corrupted.stack.zip)

![image](https://user-images.githubusercontent.com/13391795/117297127-6d836b00-aea8-11eb-8bf0-0eda69935ea2.png)

In the dueling of this replay, turn 5, the player got `[string "./script/c83764718.lua"]:21: Action is not allowed here.` for _Monster Reborn_, and he activated the first avail card in hand: _Harpie's Feather Duster_.

If you open the replay directly, you may see the player activated _Monster Reborn_ and got MSG_RETRY, but this didn't happened in the duel.

Or sometimes your ygopro will crash with some error related to memory allocating.
If it didn't happen, let us corrupt the stack.

![image](https://user-images.githubusercontent.com/13391795/117296640-ddddbc80-aea7-11eb-9306-7bd0d3192a2a.png)
Add tons of `local rg=g:Filter(Card.IsRace,nil,race)` to the loop in the script, let it create many groups.

Then you may find `c83764718.target` is called with nil as all parameters, that is why _Monster Reborn_ can't be activated so _Harpie's Feather Duster_ become the first avail card and the replay can go on.
![image](https://user-images.githubusercontent.com/13391795/117297329-aae7f880-aea8-11eb-978c-9e2919a7f247.png)

-----

The reason may be some operations to the lua stack make it overflowed. So we should check the stack before pushing anything to it.