### PR TITLE
Don't put extra deck monsters above faceup pendulums in swap_deck_and_grave

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -1048,6 +1048,7 @@ void field::swap_deck_and_grave(uint8 playerid) {
 			++clit;
 	}
 	for(auto& pcard : player[playerid].list_grave) {
+		pcard->current.position = POS_FACEUP;
 		pcard->current.location = LOCATION_GRAVE;
 		pcard->current.reason = REASON_EFFECT;
 		pcard->current.reason_effect = core.reason_effect;
@@ -1057,6 +1058,7 @@ void field::swap_deck_and_grave(uint8 playerid) {
 		pcard->reset(RESET_TOGRAVE, RESET_EVENT);
 	}
 	for(auto& pcard : player[playerid].list_main) {
+		pcard->current.position = POS_FACEDOWN_DEFENSE;
 		pcard->current.location = LOCATION_DECK;
 		pcard->current.reason = REASON_EFFECT;
 		pcard->current.reason_effect = core.reason_effect;
@@ -1066,6 +1068,7 @@ void field::swap_deck_and_grave(uint8 playerid) {
 		pcard->reset(RESET_TODECK, RESET_EVENT);
 	}
 	for(auto& pcard : ex) {
+		pcard->current.position = POS_FACEDOWN_DEFENSE;
 		pcard->current.location = LOCATION_EXTRA;
 		pcard->current.reason = REASON_EFFECT;
 		pcard->current.reason_effect = core.reason_effect;
@@ -1074,7 +1077,7 @@ void field::swap_deck_and_grave(uint8 playerid) {
 		pcard->enable_field_effect(true);
 		pcard->reset(RESET_TODECK, RESET_EVENT);
 	}
-	player[playerid].list_extra.insert(player[playerid].list_extra.end(), ex.begin(), ex.end());
+	player[playerid].list_extra.insert(player[playerid].list_extra.end() - player[playerid].extra_p_count, ex.begin(), ex.end());
 	reset_sequence(playerid, LOCATION_GRAVE);
 	reset_sequence(playerid, LOCATION_EXTRA);
 	pduel->write_buffer8(MSG_SWAP_GRAVE_DECK);


### PR DESCRIPTION
Currently extra decks monsters would be put at the end of the extra deck list, thus putting them on top of faceup pendulums that are present in the extra deck, also causing a desync with the client, where the cards will instead be put right below those faceup pendulums. With this the core will have the same behaviour as the client putting the extra deck mosnters below faceup pendulums. Also set cards positions properly to faceup/facedown.
To get this behaviour, use a modified Exchange of the Spirit that calls Debug.ReloadFieldEnd so that the client will get the current internal state from the core, and you'll notice that the top card of the extra deck will be one of the returned extra deck monsters.
```lua
function s.activate(e,tp,eg,ep,ev,re,r,rp)
	Duel.SwapDeckAndGrave(tp)
	Duel.SwapDeckAndGrave(1-tp)
	Debug.ReloadFieldEnd()
end
```
Test Puzzle
```lua
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,5)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

--Main Deck (yours)
Debug.AddCard(18716735,0,0,LOCATION_DECK,0,POS_FACEDOWN)

--Extra Deck (yours)
Debug.AddCard(18716735,0,0,LOCATION_EXTRA,0,POS_FACEUP)
Debug.AddCard(24094258,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)

--GY (yours)
for i=1,8 do
	Debug.AddCard(72064891,0,0,LOCATION_GRAVE,0,POS_FACEUP)
	Debug.AddCard(22862454,0,0,LOCATION_GRAVE,0,POS_FACEUP)
	Debug.AddCard(72064891,1,1,LOCATION_GRAVE,0,POS_FACEUP)
	Debug.AddCard(22862454,1,1,LOCATION_GRAVE,0,POS_FACEUP)
end

--Spell & Trap Zones (yours)
Debug.AddCard(17484499,0,0,LOCATION_SZONE,1,POS_FACEDOWN)

Debug.ReloadFieldEnd()
```