### PR TITLE
don't trigger EVENT_ADJUST recursively

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -5009,8 +5009,10 @@ int32 field::adjust_step(uint16 step) {
 		return FALSE;
 	}
 	case 15: {
-		raise_event((card*)0, EVENT_ADJUST, 0, 0, PLAYER_NONE, PLAYER_NONE, 0);
-		process_instant_event();
+		if(!check_event(EVENT_ADJUST)) {
+			raise_event((card*)0, EVENT_ADJUST, 0, 0, PLAYER_NONE, PLAYER_NONE, 0);
+			process_instant_event();
+		}
 		return FALSE;
 	}
 	case 16: {


### PR DESCRIPTION
The script will use `Duel.Readjust()` if something need to trigger `EVENT_ADJUST` again when processing `EVENT_ADJUST`.

replay: [recursive event trigger detected.zip](https://github.com/Fluorohydride/ygopro-core/files/6799662/recursive.event.trigger.detected.zip)

