### PR TITLE
fix TIMING_SPSUMMON of Duel.SpecialSummonStep

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -194,6 +194,7 @@ void field::special_summon_complete(effect* reason_effect, uint8 reason_player) 
 	group* ng = pduel->new_group();
 	ng->container.swap(core.special_summoning);
 	ng->is_readonly = TRUE;
+	core.hint_timing[reason_player] |= TIMING_SPSUMMON;
 	add_process(PROCESSOR_SPSUMMON, 1, reason_effect, ng, reason_player, 0);
 }
 void field::destroy(card_set* targets, effect* reason_effect, uint32 reason, uint32 reason_player, uint32 playerid, uint32 destination, uint32 sequence) {


### PR DESCRIPTION
the step 0 of `PROCESSOR_SPSUMMON`, which add the timing hint, was skipped in `Duel.SpecialSummonComplete`