### PR TITLE
update Duel.IsEnvironment

### DIFF
--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1168,7 +1168,7 @@ int32 scriptlib::duel_is_environment(lua_State *L) {
 		return 0;
 	duel* pduel = interpreter::get_duel_info(L);
 	int32 ret = 0, fc = 0;
-	if(loc & (LOCATION_FZONE + LOCATION_ONFIELD)) {
+	if(loc & (LOCATION_FZONE + LOCATION_SZONE)) {
 		card* pcard = pduel->game_field->player[0].list_szone[5];
 		if(pcard && pcard->is_position(POS_FACEUP) && pcard->get_status(STATUS_EFFECT_ENABLED)) {
 			fc = 1;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1161,7 +1161,7 @@ int32 scriptlib::duel_is_environment(lua_State *L) {
 	uint32 playerid = PLAYER_ALL;
 	if(lua_gettop(L) >= 2)
 		playerid = (uint32)lua_tointeger(L, 2);
-	uint32 loc = LOCATION_FZONE + LOCATION_ONFIELD;
+	uint32 loc = LOCATION_ONFIELD;
 	if(lua_gettop(L) >= 3)
 		loc = (uint32)lua_tointeger(L, 3);
 	if(playerid != 0 && playerid != 1 && playerid != PLAYER_ALL)

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1168,7 +1168,7 @@ int32 scriptlib::duel_is_environment(lua_State *L) {
 		return 0;
 	duel* pduel = interpreter::get_duel_info(L);
 	int32 ret = 0, fc = 0;
-	if(loc & LOCATION_FZONE) {
+	if(loc & (LOCATION_FZONE + LOCATION_ONFIELD)) {
 		card* pcard = pduel->game_field->player[0].list_szone[5];
 		if(pcard && pcard->is_position(POS_FACEUP) && pcard->get_status(STATUS_EFFECT_ENABLED)) {
 			fc = 1;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1210,6 +1210,20 @@ int32 scriptlib::duel_is_environment(lua_State *L) {
 			}
 		}
 	}
+	if(!ret && (loc & LOCATION_GRAVE)) {
+		if(playerid == 0 || playerid == PLAYER_ALL) {
+			for(auto& pcard : pduel->game_field->player[0].list_grave) {
+				if(code == pcard->get_code())
+					ret = 1;
+			}
+		}
+		if(playerid == 1 || playerid == PLAYER_ALL) {
+			for(auto& pcard : pduel->game_field->player[1].list_grave) {
+				if(code == pcard->get_code())
+					ret = 1;
+			}
+		}
+	}
 	if(!fc) {
 		effect_set eset;
 		pduel->game_field->filter_field_effect(EFFECT_CHANGE_ENVIRONMENT, &eset);


### PR DESCRIPTION
The agents in SR12 can use
```lua
Duel.IsEnvironment(56433456,PLAYER_ALL,LOCATION_ONFIELD+LOCATION_GRAVE)
```
instead of
```lua
Duel.IsEnvironment(56433456) or Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil,56433456)
```