### PR TITLE
change the default duel_rule to 5

### DIFF
--- a/libdebug.cpp
+++ b/libdebug.cpp
@@ -152,7 +152,7 @@ int32 scriptlib::debug_reload_field_begin(lua_State *L) {
 	else if (flag & DUEL_OBSOLETE_RULING)
 		pduel->game_field->core.duel_rule = 1;
 	else
-		pduel->game_field->core.duel_rule = 3;
+		pduel->game_field->core.duel_rule = 5;
 	return 0;
 }
 int32 scriptlib::debug_reload_field_end(lua_State *L) {

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -72,7 +72,7 @@ extern "C" DECL_DLLEXPORT void start_duel(ptr pduel, int32 options) {
 	else if(options & DUEL_OBSOLETE_RULING)		//provide backward compatibility with replay
 		pd->game_field->core.duel_rule = 1;
 	else if(!pd->game_field->core.duel_rule)
-		pd->game_field->core.duel_rule = 3;
+		pd->game_field->core.duel_rule = 5;
 	pd->game_field->core.shuffle_hand_check[0] = FALSE;
 	pd->game_field->core.shuffle_hand_check[1] = FALSE;
 	pd->game_field->core.shuffle_deck_check[0] = FALSE;


### PR DESCRIPTION
@mercury233 
It has been 4 years since New Master Rule came out and 1 year since Master Rule 2020 came out.
In my opinion, the default rule should be set to the current rule.