### PR TITLE
clear core.limit_syn etc. on summon fail

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -2616,8 +2616,20 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		core.limit_link_card = lcard;
 		core.limit_link_minc = lminc;
 		core.limit_link_maxc = lmaxc;
-		if(!eset.size())
+		if(!eset.size()) {
+			core.limit_tuner = 0;
+			core.limit_syn = 0;
+			core.limit_syn_minc = 0;
+			core.limit_syn_maxc = 0;
+			core.limit_xyz = 0;
+			core.limit_xyz_minc = 0;
+			core.limit_xyz_maxc = 0;
+			core.limit_link = 0;
+			core.limit_link_card = 0;
+			core.limit_link_minc = 0;
+			core.limit_link_maxc = 0;
 			return TRUE;
+		}
 		core.select_effects.clear();
 		core.select_options.clear();
 		for(int32 i = 0; i < eset.size(); ++i) {


### PR DESCRIPTION
[2021-09-06 12-58-31 Knight of Hanoi VS Knight of Hanoi.zip](https://github.com/Fluorohydride/ygopro-core/files/7127647/2021-09-06.12-58-31.Knight.of.Hanoi.VS.Knight.of.Hanoi.zip)
Turn 6, the synchro effect of _Shooting Riser Dragon_ failed, but `core.limit_tuner` was not reset, and caused the following link summon failed.