### PR TITLE
add struct material_info

### DIFF
--- a/card.h
+++ b/card.h
@@ -91,6 +91,28 @@ struct query_cache {
 	uint32 link_marker;
 };
 
+struct material_info {
+	// Synchron
+	card* limit_tuner;
+	group* limit_syn;
+	int32 limit_syn_minc;
+	int32 limit_syn_maxc;
+	// Xyz
+	group* limit_xyz;
+	int32 limit_xyz_minc;
+	int32 limit_xyz_maxc;
+	// Link
+	group* limit_link;
+	card* limit_link_card;
+	int32 limit_link_minc;
+	int32 limit_link_maxc;
+
+	material_info()
+		: limit_tuner(nullptr), limit_syn(nullptr), limit_syn_minc(0), limit_syn_maxc(0), limit_xyz(nullptr), limit_xyz_minc(0), limit_xyz_maxc(0), 
+		limit_link(nullptr), limit_link_card(nullptr), limit_link_minc(0), limit_link_maxc(0) {}
+};
+const material_info null_info;
+
 class card {
 public:
 	struct effect_relation_hash {
@@ -299,7 +321,7 @@ public:
 	int32 check_summon_procedure(effect* proc, uint8 playerid, uint8 ignore_count, uint8 min_tribute, uint32 zone);
 	int32 filter_set_procedure(uint8 playerid, effect_set* eset, uint8 ignore_count, uint8 min_tribute, uint32 zone);
 	int32 check_set_procedure(effect* proc, uint8 playerid, uint8 ignore_count, uint8 min_tribute, uint32 zone);
-	void filter_spsummon_procedure(uint8 playerid, effect_set* eset, uint32 summon_type);
+	void filter_spsummon_procedure(uint8 playerid, effect_set* eset, uint32 summon_type, material_info info = null_info);
 	void filter_spsummon_procedure_g(uint8 playerid, effect_set* eset);
 	effect* is_affected_by_effect(int32 code);
 	effect* is_affected_by_effect(int32 code, card* target);
@@ -314,13 +336,13 @@ public:
 	int32 check_cost_condition(int32 ecode, int32 playerid, int32 sumtype);
 	int32 is_summonable_card();
 	int32 is_fusion_summonable_card(uint32 summon_type);
-	int32 is_spsummonable(effect* proc);
+	int32 is_spsummonable(effect* proc, material_info info = null_info);
 	int32 is_summonable(effect* proc, uint8 min_tribute, uint32 zone = 0x1f, uint32 releasable = 0xff00ff);
 	int32 is_can_be_summoned(uint8 playerid, uint8 ingore_count, effect* peffect, uint8 min_tribute, uint32 zone = 0x1f);
 	int32 get_summon_tribute_count();
 	int32 get_set_tribute_count();
 	int32 is_can_be_flip_summoned(uint8 playerid);
-	int32 is_special_summonable(uint8 playerid, uint32 summon_type);
+	int32 is_special_summonable(uint8 playerid, uint32 summon_type, material_info info = null_info);
 	int32 is_can_be_special_summoned(effect* reason_effect, uint32 sumtype, uint8 sumpos, uint8 sumplayer, uint8 toplayer, uint8 nocheck, uint8 nolimit, uint32 zone);
 	int32 is_setable_mzone(uint8 playerid, uint8 ignore_count, effect* peffect, uint8 min_tribute, uint32 zone = 0x1f);
 	int32 is_setable_szone(uint8 playerid, uint8 ignore_fd = 0);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2102,15 +2102,12 @@ int32 scriptlib::card_is_synchro_summonable(lua_State *L) {
 	if(lua_gettop(L) >= 5)
 		maxc = (int32)lua_tointeger(L, 5);
 	uint32 p = pcard->pduel->game_field->core.reason_player;
-	pcard->pduel->game_field->core.limit_tuner = tuner;
-	pcard->pduel->game_field->core.limit_syn = mg;
-	pcard->pduel->game_field->core.limit_syn_minc = minc;
-	pcard->pduel->game_field->core.limit_syn_maxc = maxc;
-	int32 res = pcard->is_special_summonable(p, SUMMON_TYPE_SYNCHRO);
-	pcard->pduel->game_field->core.limit_tuner = 0;
-	pcard->pduel->game_field->core.limit_syn = 0;
-	pcard->pduel->game_field->core.limit_syn_minc = 0;
-	pcard->pduel->game_field->core.limit_syn_maxc = 0;
+	material_info info;
+	info.limit_tuner = tuner;
+	info.limit_syn = mg;
+	info.limit_syn_minc = minc;
+	info.limit_syn_maxc = maxc;
+	int32 res = pcard->is_special_summonable(p, SUMMON_TYPE_SYNCHRO, info);
 	lua_pushboolean(L, res);
 	return 1;
 }
@@ -2134,13 +2131,11 @@ int32 scriptlib::card_is_xyz_summonable(lua_State *L) {
 	if(lua_gettop(L) >= 4)
 		maxc = (int32)lua_tointeger(L, 4);
 	uint32 p = pcard->pduel->game_field->core.reason_player;
-	pcard->pduel->game_field->core.limit_xyz = materials;
-	pcard->pduel->game_field->core.limit_xyz_minc = minc;
-	pcard->pduel->game_field->core.limit_xyz_maxc = maxc;
-	int32 res = pcard->is_special_summonable(p, SUMMON_TYPE_XYZ);
-	pcard->pduel->game_field->core.limit_xyz = 0;
-	pcard->pduel->game_field->core.limit_xyz_minc = 0;
-	pcard->pduel->game_field->core.limit_xyz_maxc = 0;
+	material_info info;
+	info.limit_xyz = materials;
+	info.limit_xyz_minc = minc;
+	info.limit_xyz_maxc = maxc;
+	int32 res = pcard->is_special_summonable(p, SUMMON_TYPE_XYZ, info);
 	lua_pushboolean(L, res);
 	return 1;
 }
@@ -2171,15 +2166,12 @@ int32 scriptlib::card_is_link_summonable(lua_State *L) {
 	if(lua_gettop(L) >= 5)
 		maxc = (int32)lua_tointeger(L, 5);
 	uint32 p = pcard->pduel->game_field->core.reason_player;
-	pcard->pduel->game_field->core.limit_link = materials;
-	pcard->pduel->game_field->core.limit_link_card = lcard;
-	pcard->pduel->game_field->core.limit_link_minc = minc;
-	pcard->pduel->game_field->core.limit_link_maxc = maxc;
-	int32 res = pcard->is_special_summonable(p, SUMMON_TYPE_LINK);
-	pcard->pduel->game_field->core.limit_link = 0;
-	pcard->pduel->game_field->core.limit_link_card = 0;
-	pcard->pduel->game_field->core.limit_link_minc = 0;
-	pcard->pduel->game_field->core.limit_link_maxc = 0;
+	material_info info;
+	info.limit_link = materials;
+	info.limit_link_card = lcard;
+	info.limit_link_minc = minc;
+	info.limit_link_maxc = maxc;
+	int32 res = pcard->is_special_summonable(p, SUMMON_TYPE_LINK, info);
 	lua_pushboolean(L, res);
 	return 1;
 }

--- a/operations.cpp
+++ b/operations.cpp
@@ -2592,30 +2592,20 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 	switch(step) {
 	case 0: {
 		effect_set eset;
-		card* tuner = core.limit_tuner;
-		group* syn = core.limit_syn;
-		int32 sminc = core.limit_syn_minc;
-		int32 smaxc = core.limit_syn_maxc;
-		group* xmaterials = core.limit_xyz;
-		int32 xminc = core.limit_xyz_minc;
-		int32 xmaxc = core.limit_xyz_maxc;
-		group* lmaterials = core.limit_link;
-		card* lcard = core.limit_link_card;
-		int32 lminc = core.limit_link_minc;
-		int32 lmaxc = core.limit_link_maxc;
-		target->filter_spsummon_procedure(sumplayer, &eset, summon_type);
+		material_info info;
+		info.limit_tuner = core.limit_tuner;
+		info.limit_syn = core.limit_syn;
+		info.limit_syn_minc = core.limit_syn_minc;
+		info.limit_syn_maxc = core.limit_syn_maxc;
+		info.limit_xyz = core.limit_xyz;
+		info.limit_xyz_minc = core.limit_xyz_minc;
+		info.limit_xyz_maxc = core.limit_xyz_maxc;
+		info.limit_link = core.limit_link;
+		info.limit_link_card = core.limit_link_card;
+		info.limit_link_minc = core.limit_link_minc;
+		info.limit_link_maxc = core.limit_link_maxc;
+		target->filter_spsummon_procedure(sumplayer, &eset, summon_type, info);
 		target->filter_spsummon_procedure_g(sumplayer, &eset);
-		core.limit_tuner = tuner;
-		core.limit_syn = syn;
-		core.limit_syn_minc = sminc;
-		core.limit_syn_maxc = smaxc;
-		core.limit_xyz = xmaterials;
-		core.limit_xyz_minc = xminc;
-		core.limit_xyz_maxc = xmaxc;
-		core.limit_link = lmaterials;
-		core.limit_link_card = lcard;
-		core.limit_link_minc = lminc;
-		core.limit_link_maxc = lmaxc;
 		if(!eset.size())
 			return TRUE;
 		core.select_effects.clear();


### PR DESCRIPTION
# Problem
class card
is_spsummonable(), is_special_summonable(), filter_spsummon_procedure()
They need material info as arguments, but it is passed to those functions by `core.limit_*` now.
Passing the arguments by global variables might cause lots of problems.


# Solution
Now they will use arguments just like normal functions.
