### PR TITLE
update EFFECT_CANNOT_TO_DECK

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3539,7 +3539,7 @@ int32 card::is_capable_send_to_hand(uint8 playerid) {
 		return FALSE;
 	if(is_affected_by_effect(EFFECT_CANNOT_TO_HAND))
 		return FALSE;
-	if(is_extra_deck_monster() && !is_capable_send_to_deck(playerid))
+	if(is_extra_deck_monster() && !is_capable_send_to_extra(playerid))
 		return FALSE;
 	if(!pduel->game_field->is_player_can_send_to_hand(playerid, this))
 		return FALSE;
@@ -3559,7 +3559,7 @@ int32 card::is_capable_send_to_deck(uint8 playerid) {
 int32 card::is_capable_send_to_extra(uint8 playerid) {
 	if(!is_extra_deck_monster() && !(data.type & TYPE_PENDULUM))
 		return FALSE;
-	if(is_affected_by_effect(EFFECT_CANNOT_TO_DECK))
+	if(is_extra_deck_monster() && is_affected_by_effect(EFFECT_CANNOT_TO_DECK))
 		return FALSE;
 	if(!pduel->game_field->is_player_can_send_to_deck(playerid, this))
 		return FALSE;
@@ -3570,7 +3570,7 @@ int32 card::is_capable_cost_to_grave(uint8 playerid) {
 	uint32 dest = LOCATION_GRAVE;
 	if(data.type & TYPE_TOKEN)
 		return FALSE;
-	if((data.type & TYPE_PENDULUM) && (current.location & LOCATION_ONFIELD) && !is_affected_by_effect(EFFECT_CANNOT_TO_DECK))
+	if((data.type & TYPE_PENDULUM) && (current.location & LOCATION_ONFIELD))
 		return FALSE;
 	if(current.location == LOCATION_GRAVE)
 		return FALSE;


### PR DESCRIPTION
# Problem
9/30
Q.
「G・B・ハンター」はフィールド上に表側表示で存在する場合 
ペンデュラムモンスターはフィールドから墓地へ送る場合はどなるの？
 
A.
ご質問については、フィールドのペンデュラムモンスターが破壊された際には、エクストラデッキに表側で加わります。
また、「G・B・ハンター」の効果が適用されている間は、ペンデュラムモンスターだけに限らず、フィールドのカードをデッキへ戻すことができません。
そのため、フィールドからデッキへ戻す効果を持つカードや効果を発動することはできません。 


9/30
Q.
「G・B・ハンター」はフィールド上に表側表示で存在する場合、ペンデュラムモンスターはフィールドから墓地へ送る場合はどなるの？
 
A.
ペンデュラムモンスターはルール上、フィールドで破壊される等して墓地に送られる際には、エクストラデッキに表側で加わります。
その際に、「G・B・ハンター」の効果は、何も影響はありません。

Now the Pendulum monsters will be sent to Extra Deck even when EFFECT_CANNOT_TO_DECK is applied.
