### PR TITLE
update card::add_effect()

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1647,6 +1647,15 @@ int32 card::add_effect(effect* peffect) {
 	if (peffect->type & EFFECT_TYPE_SINGLE && !peffect->is_flag(EFFECT_FLAG_SINGLE_RANGE) && peffect->owner == this 
 		&& get_status(STATUS_DISABLED) && (peffect->reset_flag & RESET_DISABLE))
 		return 0;
+	if (!(peffect->type & EFFECT_TYPE_CONTINUOUS) && is_continuous_event(peffect->code))
+		return 0;
+	// the trigger effect in phase is "once per turn" by default
+	if (peffect->get_code_type() == CODE_PHASE && peffect->code & (PHASE_DRAW | PHASE_STANDBY | PHASE_END) && peffect->type & (EFFECT_TYPE_TRIGGER_O | EFFECT_TYPE_TRIGGER_F)
+		&& !peffect->is_flag(EFFECT_FLAG_COUNT_LIMIT)) {
+		peffect->flag[0] |= EFFECT_FLAG_COUNT_LIMIT;
+		peffect->count_limit = 1;
+		peffect->count_limit_max = 1;
+	}
 	card_set check_target = { this };
 	effect_container::iterator eit;
 	if (peffect->type & EFFECT_TYPE_SINGLE) {


### PR DESCRIPTION
@mercury233 
# Problem
1. The trigger effect in phase should be "once per turn" by default.
2. Some events are only available for EFFECT_TYPE_CONTINUOUS.

# Solution
1. Now it will add EFFECT_FLAG_COUNT_LIMIT to all trigger effects in PHASE_DRAW, PHASE_STANDBY, PHASE_END.
The steps in Battle Phase are excluded because trigger effects in those steps may have a more complicated ruling.

2. `add_effect()` will check if the event is reserved for EFFECT_TYPE_CONTINUOUS.


# Reference
https://yugioh-wiki.net/index.php?%A1%D4%B8%A1%B1%DC%A1%D5
Ｑ：１度のスタンバイフェイズ中に複数回効果を発動できますか？
Ａ：複数回発動する事はできません。(16/06/30)

https://ocg-rule.readthedocs.io/zh_CN/latest/c03/%E8%AF%B1%E5%8F%91%E7%B1%BB%E6%95%88%E6%9E%9C.html#id4
