### PR TITLE
fix delayed quick effect

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -299,6 +299,8 @@ int32 effect::is_activateable(uint8 playerid, const tevent& e, int32 neglect_con
 				return FALSE;
 			if((phandler->get_type() & TYPE_CONTINUOUS) && (phandler->get_type() & TYPE_EQUIP))
 				return FALSE;
+			if((type & EFFECT_TYPE_QUICK_O) && is_flag(EFFECT_FLAG_DELAY) && !in_range(phandler))
+				return FALSE;
 			if(!neglect_faceup && (phandler->current.location & (LOCATION_ONFIELD | LOCATION_REMOVED))) {
 				if(!phandler->is_position(POS_FACEUP) && !is_flag(EFFECT_FLAG_SET_AVAILABLE))
 					return FALSE;

--- a/processor.cpp
+++ b/processor.cpp
@@ -1683,6 +1683,13 @@ int32 field::process_quick_effect(int16 step, int32 skip_freechain, uint8 priori
 					core.select_chains.push_back(newchain);
 				}
 			}
+			pr = effects.quick_o_effect.equal_range(ev.event_code);
+			for(auto eit = pr.first; eit != pr.second;) {
+				effect* peffect = eit->second;
+				++eit;
+				if(peffect->is_flag(EFFECT_FLAG_DELAY) && peffect->is_condition_check(peffect->get_handler()->current.controler, ev))
+					core.delayed_quick.emplace(peffect, ev);
+			}
 		}
 		// delayed quick
 		for(auto eit = core.delayed_quick.begin(); eit != core.delayed_quick.end();) {


### PR DESCRIPTION
@salix5 
There are two problems about the only card in OCG with delayed quick effect: _Droll & Lock Bird_
```lua
Debug.SetAIName("AI")
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_PSEUDO_SHUFFLE+DUEL_SIMPLE_AI,5)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(94145021,1,1,LOCATION_DECK,0,POS_FACEDOWN)
Debug.AddCard(94145021,1,1,LOCATION_HAND,0,POS_FACEDOWN)

Debug.AddCard(21076084,0,0,LOCATION_SZONE,0,POS_FACEDOWN)
Debug.AddCard(83968380,0,0,LOCATION_SZONE,1,POS_FACEDOWN)

Debug.AddCard(46986414,0,0,LOCATION_DECK,0,POS_FACEDOWN)

Debug.ReloadFieldEnd()
aux.BeginPuzzle()
```

The player has 1 _Droll & Lock Bird_ in hand, 1 in deck, his opponent activate _Trickstar Reincarnation_, and chain _Jar of Greed_, after the effects resolved, he should able to activate the bird just drown against the jar.
But now in YGOPro he can't activate the bird in hand, what is more, he can activate the banished bird.

The delayed quick effect implement in YGOPro rely on the range of the handler when the event triggered, so it don't check the range before activating.