### PR TITLE
fix check STATUS_BATTLE_DESTROYED

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -3153,11 +3153,11 @@ int32 field::process_battle_command(uint16 step) {
 		if(core.attack_target)
 			raise_single_event(core.attack_target, 0, EVENT_DAMAGE_STEP_END, 0, 0, 0, 0, 1);
 		raise_event((card*)0, EVENT_DAMAGE_STEP_END, 0, 0, 0, 0, 0);
+		process_single_event();
+		process_instant_event();
 		core.attacker->set_status(STATUS_BATTLE_DESTROYED, FALSE);
 		if(core.attack_target)
 			core.attack_target->set_status(STATUS_BATTLE_DESTROYED, FALSE);
-		process_single_event();
-		process_instant_event();
 		pduel->write_buffer8(MSG_HINT);
 		pduel->write_buffer8(HINT_EVENT);
 		pduel->write_buffer8(0);


### PR DESCRIPTION
fix: if Dragonecro Nethersoul Dragon would be destroyed by battle, Dragonecro Nethersoul Dragon don't activate.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7613&keyword=&tag=-1
> 「冥界龍 ドラゴネクロ」自身が戦闘によって破壊される場合においても、効果が発動します。
> 
> したがって、「冥界龍 ドラゴネクロ」自身が戦闘によって破壊され墓地へ送られる場合であれば、ダメージステップ終了時に墓地へ送られた際に効果が発動します。

![rule001](https://i.gyazo.com/ab9f40af03eb4ad118b16948ab55f56f.png)
![rule002](https://i.gyazo.com/14fd4f9ea4eb1a1f5d6edc38307a61ec.png)

because `Card.IsStatus(STATUS_BATTLE_DESTROYED)` was false in `EVENT_DAMAGE_STEP_END`.