### PR TITLE
Revert "don't trigger EVENT_ADJUST recursively"

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -5019,10 +5019,8 @@ int32 field::adjust_step(uint16 step) {
 		return FALSE;
 	}
 	case 15: {
-		if(!check_event(EVENT_ADJUST)) {
-			raise_event((card*)0, EVENT_ADJUST, 0, 0, PLAYER_NONE, PLAYER_NONE, 0);
-			process_instant_event();
-		}
+		raise_event((card*)0, EVENT_ADJUST, 0, 0, PLAYER_NONE, PLAYER_NONE, 0);
+		process_instant_event();
 		return FALSE;
 	}
 	case 16: {


### PR DESCRIPTION
Reverts Fluorohydride/ygopro-core#388

Replay: [2.zip](https://github.com/Fluorohydride/ygopro-core/files/7660285/2.zip)
