### PR TITLE
fix ATK calculating

### DIFF
--- a/card.h
+++ b/card.h
@@ -232,6 +232,8 @@ public:
 	uint32 get_synchro_type();
 	uint32 get_xyz_type();
 	uint32 get_link_type();
+	std::pair<int32, int32> get_base_atk_def();
+	std::pair<int32, int32> get_atk_def();
 	int32 get_base_attack();
 	int32 get_attack();
 	int32 get_base_defense();

--- a/effect.h
+++ b/effect.h
@@ -188,7 +188,7 @@ enum effect_flag : uint32 {
 	EFFECT_FLAG_UNCOPYABLE			= 0x40000,
 	EFFECT_FLAG_OATH				= 0x80000,
 	EFFECT_FLAG_SPSUM_PARAM			= 0x100000,
-	EFFECT_FLAG_REPEAT				= 0x200000,
+//	EFFECT_FLAG_REPEAT				= 0x200000,
 	EFFECT_FLAG_NO_TURN_RESET		= 0x400000,
 	EFFECT_FLAG_EVENT_PLAYER		= 0x800000,
 	EFFECT_FLAG_OWNER_RELATE		= 0x1000000,
@@ -203,6 +203,8 @@ enum effect_flag : uint32 {
 enum effect_flag2 : uint32 {
 	EFFECT_FLAG2_MILLENNIUM_RESTRICT	= 0x0001,
 	EFFECT_FLAG2_COF					= 0x0002,
+	EFFECT_FLAG2_WICKED					= 0x0004,
+	EFFECT_FLAG2_OPTION					= 0x0008,
 };
 inline effect_flag operator|(effect_flag flag1, effect_flag flag2)
 {
@@ -308,8 +310,8 @@ inline effect_flag operator|(effect_flag flag1, effect_flag flag2)
 #define EFFECT_REVERSE_UPDATE			108	//
 #define EFFECT_SWAP_AD					109	//
 #define EFFECT_SWAP_BASE_AD				110	//
-//#define EFFECT_SWAP_ATTACK_FINAL		111
-//#define EFFECT_SWAP_DEFENSE_FINAL		112
+#define EFFECT_SET_BASE_ATTACK_FINAL	111	//
+#define EFFECT_SET_BASE_DEFENSE_FINAL	112	//
 #define EFFECT_ADD_CODE					113	//
 #define EFFECT_CHANGE_CODE				114	//
 #define EFFECT_ADD_TYPE					115	//

--- a/field.cpp
+++ b/field.cpp
@@ -36,8 +36,9 @@ void chain::set_triggering_state(card* pcard) {
 	triggering_state.rank = pcard->get_rank();
 	triggering_state.attribute = pcard->get_attribute();
 	triggering_state.race = pcard->get_race();
-	triggering_state.attack = pcard->get_attack();
-	triggering_state.defense = pcard->get_defense();
+	std::pair<int32, int32> atk_def = pcard->get_atk_def();
+	triggering_state.attack = atk_def.first;
+	triggering_state.defense = atk_def.second;
 }
 bool tevent::operator< (const tevent& v) const {
 	return std::memcmp(this, &v, sizeof(tevent)) < 0;

--- a/operations.cpp
+++ b/operations.cpp
@@ -3822,8 +3822,9 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 						pcard->previous.rank = pcard->get_rank();
 						pcard->previous.attribute = pcard->get_attribute();
 						pcard->previous.race = pcard->get_race();
-						pcard->previous.attack = pcard->get_attack();
-						pcard->previous.defense = pcard->get_defense();
+						std::pair<int32, int32> atk_def = pcard->get_atk_def();
+						pcard->previous.attack = atk_def.first;
+						pcard->previous.defense = atk_def.second;
 					}
 				} else {
 					effect_set eset;

--- a/processor.cpp
+++ b/processor.cpp
@@ -2876,7 +2876,8 @@ int32 field::process_battle_command(uint16 step) {
 	}
 	case 26: {
 		// Duel.CalculateDamage() goes here
-		uint32 aa = core.attacker->get_attack(), ad = core.attacker->get_defense();
+		std::pair<int32, int32> atk_def = core.attacker->get_atk_def();
+		uint32 aa = atk_def.first, ad = atk_def.second;
 		uint32 da = 0, dd = 0;
 		uint8 pa = core.attacker->current.controler, pd;
 		core.attacker->q_cache.attack = aa;
@@ -2884,8 +2885,9 @@ int32 field::process_battle_command(uint16 step) {
 		core.attacker->set_status(STATUS_BATTLE_RESULT, FALSE);
 		core.attacker->set_status(STATUS_BATTLE_DESTROYED, FALSE);
 		if(core.attack_target) {
-			da = core.attack_target->get_attack();
-			dd = core.attack_target->get_defense();
+			atk_def = core.attack_target->get_atk_def();
+			da = atk_def.first;
+			dd = atk_def.second;
 			core.attack_target->q_cache.attack = da;
 			core.attack_target->q_cache.defense = dd;
 			core.attack_target->set_status(STATUS_BATTLE_RESULT, FALSE);


### PR DESCRIPTION
# Problem
- Fluorohydride/ygopro#2403

- [country1_T3.zip](https://github.com/Fluorohydride/ygopro-core/files/7777310/country1_T3.zip)

The order of calculating original ATK is wrong.

# Solution
Calculating ATK and DEF separately will cause a lot of problems.

Now ATK and DEF are calculated by
```cpp
get_base_atk_def()
```
```cpp
get_atk_def()
```
at the same time.

---
`EFFECT_FLAG2_OPTION`
The effect of オプション/Gradius' Option
Precedence 1

`EFFECT_FLAG2_WICKED`
The effect of 邪神アバター/The Wicked Avatar, 邪神ドレッド・ルート/The Wicked Dreadroot
Precedence 2

`EFFECT_SWAP_AD`
The effect of スーパーバグマン/Super Crashbug
Precedence 3

---
 `EFFECT_SET_BASE_ATTACK_FINAL`
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=8149&keyword=&tag=-1
Setting original ATK of itself should be calculated first.

Therefore, changing original ATK should be separated into 2 parts:

- Setting original ATK of itself
```lua
EFFECT_TYPE_SINGLE, EFFECT_SET_BASE_ATTACK
```
They will be calculated before other buff.


- changing original ATK (収縮/Shrink)
```lua
EFFECT_TYPE_SINGLE, EFFECT_SET_BASE_ATTACK_FINAL
```
They will be sorted by effect ID.


## Gain ATK
EFFECT_UPDATE_ATTACK

up：temp gain (activating effect)
upc：continuous gain (equip cards)

## Setting ATK of itself, temp value
EFFECT_TYPE_SINGLE, EFFECT_SET_ATTACK, no flag

Example:
万物創世龍/Ten Thousand Dragon
> If Summoned this way, the ATK/DEF of this card becomes 10,000.

It will be erased by another temp value.


## Setting ATK of itself, continuous value
EFFECT_TYPE_SINGLE, EFFECT_SET_ATTACK, EFFECT_FLAG_SINGLE_RANGE

Example:
ザ・カリキュレーター/The Calculator
>  The ATK of this card is the combined Levels of all face-up monsters you control x 300. 

It will change dynamically, and it will not be erased by another temp value.

Setting ATK of itself should be calculated first.


## changing ATK, temp value
EFFECT_TYPE_SINGLE, EFFECT_SET_ATTACK_FINAL

Example:
BF－疾風のゲイル/Blackwing - Gale the Whirlwind
> Once per turn: You can target 1 face-up monster your opponent controls; that target's ATK and DEF become half its current ATK and DEF. 

Erase all temp gains.
Erase all temp values.
ATK = X


## changing ATK, continuous value
non-single type, EFFECT_SET_ATTACK

Example:
巨大化/Megamorph
> While your LP is lower than your opponent's, the equipped monster's ATK becomes double its original ATK.

ATK = X + upc

## Setting original ATK of itself, temp value
EFFECT_TYPE_SINGLE, EFFECT_SET_BASE_ATTACK, no flag

Example:
召命の神弓－アポロウーサ/Apollousa, Bow of the Goddess
> The original ATK of this card becomes 800 x the number of Link Materials used for its Link Summon.

It will be erased by another temp value.


## setting original ATK of itself, continuous value
EFFECT_TYPE_SINGLE, EFFECT_SET_BASE_ATTACK, EFFECT_FLAG_SINGLE_RANGE

Example:
ワイトキング/King of the Skull Servants
> The original ATK of this card is the combined number of "King of the Skull Servants" and "Skull Servant" in your GY x 1000.

It will change dynamically, and it will not be erased by another temp value.

Setting original ATK should be calculated first.


## changing  original ATK, temp value
EFFECT_TYPE_SINGLE, EFFECT_SET_BASE_ATTACK_FINAL

Example:
収縮/Shrink
> Target 1 face-up monster on the field; its original ATK becomes halved until the end of this turn. 

Erase all temp values of ATK.
Erase all temp values of original ATK.
original ATK = X


## changing original ATK, continuous value
non-single type, EFFECT_SET_BASE_ATTACK

Example:
進化する人類/Unstable Evolution
> While your LP is lower than your opponent's, the equipped monster's original ATK becomes 2400.

original ATK = X

# Reference
changing ATK:
巨大化
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9095&keyword=&tag=-1&request_locale=ja
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=6248&keyword=&tag=-1&request_locale=ja

changing original ATK
収縮
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=13056&keyword=&tag=-1&request_locale=ja
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=7944&keyword=&tag=-1&request_locale=ja

進化する人類
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=9585&keyword=&tag=-1&request_locale=ja

Wiki：ステータス 
https://yugioh-wiki.net/index.php?%A5%B9%A5%C6%A1%BC%A5%BF%A5%B9

ocg-rule：攻守计算#会反复计算的效果
https://ocg-rule.readthedocs.io/zh_CN/latest/c03/%E6%94%BB%E5%AE%88%E8%AE%A1%E7%AE%97.html#id15

