### PR TITLE
remove argument passing by nil_event

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -3381,8 +3381,9 @@ int32 field::get_cteffect(effect* peffect, int32 playerid, int32 store) {
 			continue;
 		uint32 code = efit.first;
 		if(code == EVENT_FREE_CHAIN || code == EVENT_PHASE + infos.phase) {
-			nil_event.event_code = code;
-			if(get_cteffect_evt(feffect, playerid, nil_event, store) && !store)
+			tevent test_event;
+			test_event.event_code = code;
+			if(get_cteffect_evt(feffect, playerid, test_event, store) && !store)
 				return TRUE;
 		} else {
 			for(const auto& ev : core.point_event) {
@@ -3431,8 +3432,9 @@ int32 field::check_cteffect_hint(effect* peffect, uint8 playerid) {
 			continue;
 		uint32 code = efit.first;
 		if(code == EVENT_FREE_CHAIN || code == EVENT_PHASE + infos.phase) {
-			nil_event.event_code = code;
-			if(get_cteffect_evt(feffect, playerid, nil_event, FALSE)
+			tevent test_event;
+			test_event.event_code = code;
+			if(get_cteffect_evt(feffect, playerid, test_event, FALSE)
 				&& (code != EVENT_FREE_CHAIN || check_hint_timing(feffect)))
 				return TRUE;
 		} else {

--- a/operations.cpp
+++ b/operations.cpp
@@ -5092,8 +5092,9 @@ int32 field::activate_effect(uint16 step, effect* peffect) {
 	case 0: {
 		card* phandler = peffect->get_handler();
 		int32 playerid = phandler->current.controler;
-		nil_event.event_code = EVENT_FREE_CHAIN;
-		if(!peffect->is_activateable(playerid, nil_event))
+		tevent test_event;
+		test_event.event_code = EVENT_FREE_CHAIN;
+		if(!peffect->is_activateable(playerid, test_event))
 			return TRUE;
 		chain newchain;
 		newchain.flag = 0;


### PR DESCRIPTION
# Problem
`nil_event`
It is modified by multiple functions for passing arguments.
Passing the arguments by global variables might cause lots of problems.

# Solution
Now they will use new `tevent` variables.