### PR TITLE
update EFFECT_CANNOT_TRIGGER

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1579,6 +1579,10 @@ int32 card::add_effect(effect* peffect) {
 		peffect->count_limit = 1;
 		peffect->count_limit_max = 1;
 	}
+	// add EFFECT_FLAG_IGNORE_IMMUNE to EFFECT_CANNOT_TRIGGER by default
+	if (peffect->code == EFFECT_CANNOT_TRIGGER) {
+		peffect->flag[0] |= EFFECT_FLAG_IGNORE_IMMUNE;
+	}
 	card_set check_target = { this };
 	effect_container::iterator eit;
 	if (peffect->type & EFFECT_TYPE_SINGLE) {


### PR DESCRIPTION
@mercury233 
Fluorohydride/ygopro#2422
Maybe we can add EFFECT_FLAG_IGNORE_IMMUNE to EFFECT_CANNOT_TRIGGER by default.
