### PR TITLE
update Duel.MoveToField

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -265,7 +265,7 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 		pcard->sendto_param.position = POS_FACEDOWN_DEFENSE;
 	}
 	if (pcard->current.location) {
-		if (pcard->current.location == location) {
+		if (pcard->current.location == location && pcard->current.pzone == !!pzone) {
 			if (pcard->current.location == LOCATION_DECK) {
 				if(preplayer == playerid) {
 					pduel->write_buffer8(MSG_MOVE);

--- a/operations.cpp
+++ b/operations.cpp
@@ -289,7 +289,7 @@ void field::send_to(card* target, effect* reason_effect, uint32 reason, uint32 r
 void field::move_to_field(card* target, uint32 move_player, uint32 playerid, uint32 destination, uint32 positions, uint32 enable, uint32 ret, uint32 pzone, uint32 zone) {
 	if(!(destination & LOCATION_ONFIELD) || !positions)
 		return;
-	if(destination == target->current.location && playerid == target->current.controler)
+	if(destination == target->current.location && playerid == target->current.controler && target->current.pzone == !!pzone)
 		return;
 	target->to_field_param = (move_player << 24) + (playerid << 16) + (destination << 8) + positions;
 	add_process(PROCESSOR_MOVETOFIELD, 0, 0, (group*)target, enable, ret + (pzone << 8), zone);


### PR DESCRIPTION
Fix https://github.com/Fluorohydride/ygopro/issues/2421
Now it can move card from Pendulum zone to Spell zone.

In https://github.com/Fluorohydride/ygopro-pre-script/blob/master/scripts/DBTM-JP/c100418205.lua#L118 
Before: 
```lua
Duel.MoveSequence(tc,nseq)
```
Now:
```lua
Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true,1<<nseq)
```