### PR TITLE
fix Duel.SSet, Duel.MoveToField

### DIFF
--- a/field.h
+++ b/field.h
@@ -236,7 +236,7 @@ struct processor {
 	instant_f_list quick_f_chain;
 	card_set leave_confirmed;
 	card_set special_summoning;
-	card_set ss_tograve_set;
+	card_set unable_tofield_set;
 	card_set equiping_cards;
 	card_set control_adjust_set[2];
 	card_set unique_destroy_set;


### PR DESCRIPTION
fix: if player has no space in spell&trap zone, card(s) don't send to grave.
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23543&keyword=&tag=-1
> Question
> 相手が魔法カードの効果を発動し、それにチェーンして自分は「[オッドアイズ・ペンデュラムグラフ・ドラゴン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17145)」の『②』の効果を発動し、さらにチェーン３で「[ペンデュラム・スイッチ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13020)」の『②』の効果を発動しました。
> 
> 上記の状況で、「[オッドアイズ・ペンデュラムグラフ・ドラゴン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17145)」の効果処理時に、「[オッドアイズ・ペンデュラムグラフ・ドラゴン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17145)」がモンスターゾーンに存在し、ペンデュラムゾーンに既にカードが２枚置かれている場合、処理はどうなりますか？
> Answer
> 「[オッドアイズ・ペンデュラムグラフ・ドラゴン](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17145)」は**エクストラデッキに表側表示で加わり、処理が完了します**。

> Mail:
> Q.
> 自分のモンスターゾーンの「ダイナミスト・アンキロス」を対象として「ペンデュラム・スイッチ」の②の効果を発動し、チェーンして「ダイナミスト・ハウリング」を発動し、その効果処理で「ダイナミスト・レックス」と「ダイナミスト・ステゴサウラー」をペンデュラムゾーンに置いた場合、ペンデュラムゾーンに空きがありませんが、処理はどうなりますか？
> A.
> 「ダイナミスト・アンキロス」がエクストラデッキに表側表示で加わります。
> 
> Q.
> 除外されている「メタルフォーゼ・カウンター」を対象として「悪魔嬢マリス」の効果を発動し、チェーンして「ダイナミスト・ハウリング」を発動し、その効果処理で「ダイナミスト・レックス」と「ダイナミスト・ステゴサウラー」をペンデュラムゾーンに置いた事により、魔法＆罠ゾーンに空きがなくなった場合、処理はどうなりますか？
> A.
> 「メタルフォーゼ・カウンター」は墓地に置かれます。
> 
> Q.
> 自分フィールドに「人造人間－サイコ・ショッカー」として扱われている「人造人間－サイコ・ジャッカー」が存在する状態で、相手の「剛竜剣士ダイナスターP」を攻撃対象とした「サイコ・ギガサイバー」の攻撃宣言時に「サイコ・ギガサイバー」の②の効果を発動し、チェーンして相手が「ダイナミスト・ハウリング」を発動し、その効果処理で「ダイナミスト・レックス」と「ダイナミスト・ステゴサウラー」をペンデュラムゾーンに置いた事により、相手の魔法＆罠ゾーンに空きがなくなった場合、処理はどうなりますか？
> A.
> 墓地に送られます。