### PR TITLE
fix destroy replace

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -200,7 +200,7 @@ void field::special_summon_complete(effect* reason_effect, uint8 reason_player) 
 void field::destroy(card_set* targets, effect* reason_effect, uint32 reason, uint32 reason_player, uint32 playerid, uint32 destination, uint32 sequence) {
 	for(auto cit = targets->begin(); cit != targets->end();) {
 		card* pcard = *cit;
-		if(pcard->is_status(STATUS_DESTROY_CONFIRMED)) {
+		if(pcard->is_status(STATUS_DESTROY_CONFIRMED) && core.destroy_canceled.find(pcard) == core.destroy_canceled.end()) {
 			targets->erase(cit++);
 			continue;
 		}


### PR DESCRIPTION
Fix: If _Huginn, Wings of the Mysterune_ use its effect to replace the destroy of its equip card, the equip card will be kept on field.
![image](https://user-images.githubusercontent.com/13391795/162563568-8e56dbd8-9b61-4613-a2ba-782863911e06.png)

Replay:
[destroy replace and destroy again.zip](https://github.com/Fluorohydride/ygopro-core/files/8456542/destroy.replace.and.destroy.again.zip)
 