### PR TITLE
update Group.SelectUnselect to support nil

### DIFF
--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -269,20 +269,23 @@ int32 scriptlib::group_select_unselect(lua_State *L) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_GROUP, 1);
-	check_param(L, PARAM_TYPE_GROUP, 2);
-	group* pgroup1 = *(group**)lua_touserdata(L, 1);
-	group* pgroup2 = *(group**)lua_touserdata(L, 2);
-	duel* pduel = pgroup1->pduel;
+	group* select_group = *(group**)lua_touserdata(L, 1);
+	group* unselect_group = 0;
+	if(check_param(L, PARAM_TYPE_GROUP, 2, TRUE))
+		unselect_group = *(group**)lua_touserdata(L, 2);
+	duel* pduel = select_group->pduel;
 	uint32 playerid = (uint32)lua_tointeger(L, 3);
 	if(playerid != 0 && playerid != 1)
 		return 0;
-	if(pgroup1->container.size() + pgroup2->container.size() == 0)
+	if(select_group->container.size() == 0 && (!unselect_group || unselect_group->container.size() == 0))
 		return 0;
-	for(auto it = pgroup2->container.begin(); it != pgroup2->container.end(); ++it) {
-		card* pcard = *it;
-		for(auto it2 = pgroup1->container.begin(); it2 != pgroup1->container.end(); ++it2) {
-			if((*it2) == pcard) {
-				return 0;
+	if(unselect_group) {
+		for(auto it = unselect_group->container.begin(); it != unselect_group->container.end(); ++it) {
+			card* pcard = *it;
+			for(auto it2 = select_group->container.begin(); it2 != select_group->container.end(); ++it2) {
+				if((*it2) == pcard) {
+					return 0;
+				}
 			}
 		}
 	}
@@ -306,11 +309,13 @@ int32 scriptlib::group_select_unselect(lua_State *L) {
 		min = max;
 	pduel->game_field->core.select_cards.clear();
 	pduel->game_field->core.unselect_cards.clear();
-	for(auto it = pgroup1->container.begin(); it != pgroup1->container.end(); ++it) {
+	for(auto it = select_group->container.begin(); it != select_group->container.end(); ++it) {
 		pduel->game_field->core.select_cards.push_back(*it);
 	}
-	for(auto it = pgroup2->container.begin(); it != pgroup2->container.end(); ++it) {
-		pduel->game_field->core.unselect_cards.push_back(*it);
+	if(unselect_group) {
+		for(auto it = unselect_group->container.begin(); it != unselect_group->container.end(); ++it) {
+			pduel->game_field->core.unselect_cards.push_back(*it);
+		}
 	}
 	pduel->game_field->add_process(PROCESSOR_SELECT_UNSELECT_CARD, 0, 0, 0, playerid + (cancelable << 16), min + (max << 16), finishable);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {


### PR DESCRIPTION
make it possible to use nil instead of empty group here

```lua
function c99234526.spcon(e,c)
	if c==nil then return true end
	local tp=c:GetControler()
	return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
		and Duel.IsExistingMatchingCard(c99234526.spfilter,tp,LOCATION_GRAVE,0,1,nil)
end
function c99234526.sptg(e,tp,eg,ep,ev,re,r,rp,chk,c)
	local g=Duel.GetMatchingGroup(c99234526.spfilter,tp,LOCATION_GRAVE,0,nil)
	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
	local tc=g:SelectUnselect(nil,tp,false,true)
	if tc then
		e:SetLabelObject(tc)
		return true
	else return false end
end
function c99234526.spop(e,tp,eg,ep,ev,re,r,rp,c)
	local g=e:GetLabelObject()
	Duel.Remove(g,POS_FACEUP,REASON_COST)
end
```