### PR TITLE
fix single trigger effect in battle phase start

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -3839,6 +3839,8 @@ int32 field::process_turn(uint16 step, uint8 turn_player) {
 		return FALSE;
 	}
 	case 10: {
+		if(core.new_fchain.size() || core.new_ochain.size())
+			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, 0, 0);
 		add_process(PROCESSOR_PHASE_EVENT, 0, 0, 0, PHASE_BATTLE_START, 0);
 		return FALSE;
 	}


### PR DESCRIPTION
Fix: The effect of _Morphing Jar_ won't trigger if its position is set to face-up attack by the effect of _Evil HERO Malicious Fiend_ at the battle phase start
[test_MaliciousFiend.zip](https://github.com/Fluorohydride/ygopro-core/files/8649219/test_MaliciousFiend.zip)
