### PR TITLE
fix & update Duel.NegateActivation and NegateEffect

### DIFF
--- a/field.h
+++ b/field.h
@@ -558,7 +558,7 @@ public:
 
 	//operations
 	int32 negate_chain(uint8 chaincount);
-	int32 disable_chain(uint8 chaincount);
+	int32 disable_chain(uint8 chaincount, uint8 forced);
 	void change_chain_effect(uint8 chaincount, int32 replace_op);
 	void change_target(uint8 chaincount, group* targets);
 	void change_target_player(uint8 chaincount, uint8 playerid);

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1764,8 +1764,11 @@ int32 scriptlib::duel_negate_activate(lua_State *L) {
 int32 scriptlib::duel_negate_effect(lua_State *L) {
 	check_param_count(L, 1);
 	uint32 c = (uint32)lua_tointeger(L, 1);
+	uint8 forced = FALSE;
+	if(lua_gettop(L) > 1)
+		forced = lua_toboolean(L, 2);
 	duel* pduel = interpreter::get_duel_info(L);
-	lua_pushboolean(L, pduel->game_field->disable_chain(c));
+	lua_pushboolean(L, pduel->game_field->disable_chain(c, forced));
 	return 1;
 }
 int32 scriptlib::duel_negate_related_chain(lua_State *L) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -4314,6 +4314,17 @@ int32 scriptlib::duel_is_chain_disablable(lua_State * L) {
 	lua_pushboolean(L, 1);
 	return 1;
 }
+int32 scriptlib::duel_is_chain_disabled(lua_State* L) {
+	check_param_count(L, 1);
+	int32 chaincount = (int32)lua_tointeger(L, 1);
+	duel* pduel = interpreter::get_duel_info(L);
+	if(pduel->game_field->core.chain_solving) {
+		lua_pushboolean(L, pduel->game_field->is_chain_disabled(chaincount));
+		return 1;
+	}
+	lua_pushboolean(L, 0);
+	return 1;
+}
 int32 scriptlib::duel_check_chain_target(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_CARD, 2);
@@ -4756,6 +4767,7 @@ static const struct luaL_Reg duellib[] = {
 	{ "IsPlayerCanAdditionalSummon", scriptlib::duel_is_player_can_additional_summon },
 	{ "IsChainNegatable", scriptlib::duel_is_chain_negatable },
 	{ "IsChainDisablable", scriptlib::duel_is_chain_disablable },
+	{ "IsChainDisabled", scriptlib::duel_is_chain_disabled },
 	{ "CheckChainTarget", scriptlib::duel_check_chain_target },
 	{ "CheckChainUniqueness", scriptlib::duel_check_chain_uniqueness },
 	{ "GetActivityCount", scriptlib::duel_get_activity_count },

--- a/operations.cpp
+++ b/operations.cpp
@@ -20,7 +20,7 @@ int32 field::negate_chain(uint8 chaincount) {
 	chain& pchain = core.current_chain[chaincount - 1];
 	card* phandler = pchain.triggering_effect->handler;
 	if(!(pchain.flag & CHAIN_DISABLE_ACTIVATE) && is_chain_negatable(pchain.chain_count)
-	        && (!phandler->is_has_relation(pchain) || phandler->is_affect_by_effect(core.reason_effect))) {
+		&& (!phandler->is_has_relation(pchain) || phandler->is_affect_by_effect(core.reason_effect))) {
 		pchain.flag |= CHAIN_DISABLE_ACTIVATE;
 		pchain.disable_reason = core.reason_effect;
 		pchain.disable_player = core.reason_player;
@@ -37,7 +37,7 @@ int32 field::negate_chain(uint8 chaincount) {
 	}
 	return FALSE;
 }
-int32 field::disable_chain(uint8 chaincount) {
+int32 field::disable_chain(uint8 chaincount, uint8 forced) {
 	if(core.current_chain.size() == 0)
 		return FALSE;
 	if(chaincount > core.current_chain.size() || chaincount < 1)
@@ -45,7 +45,8 @@ int32 field::disable_chain(uint8 chaincount) {
 	chain& pchain = core.current_chain[chaincount - 1];
 	card* phandler = pchain.triggering_effect->handler;
 	if(!(pchain.flag & CHAIN_DISABLE_EFFECT) && is_chain_disablable(pchain.chain_count)
-	        && (!phandler->is_has_relation(pchain) || phandler->is_affect_by_effect(core.reason_effect))) {
+		&& (!phandler->is_has_relation(pchain) || phandler->is_affect_by_effect(core.reason_effect))
+		&& !(phandler->is_has_relation(pchain) && phandler->is_status(STATUS_DISABLED) && !forced)) {
 		core.current_chain[chaincount - 1].flag |= CHAIN_DISABLE_EFFECT;
 		core.current_chain[chaincount - 1].disable_reason = core.reason_effect;
 		core.current_chain[chaincount - 1].disable_player = core.reason_player;

--- a/operations.cpp
+++ b/operations.cpp
@@ -18,20 +18,21 @@ int32 field::negate_chain(uint8 chaincount) {
 	if(chaincount > core.current_chain.size() || chaincount < 1)
 		chaincount = (uint8)core.current_chain.size();
 	chain& pchain = core.current_chain[chaincount - 1];
+	card* phandler = pchain.triggering_effect->handler;
 	if(!(pchain.flag & CHAIN_DISABLE_ACTIVATE) && is_chain_negatable(pchain.chain_count)
-	        && pchain.triggering_effect->handler->is_affect_by_effect(core.reason_effect) ) {
+	        && (!phandler->is_has_relation(pchain) || phandler->is_affect_by_effect(core.reason_effect))) {
 		pchain.flag |= CHAIN_DISABLE_ACTIVATE;
 		pchain.disable_reason = core.reason_effect;
 		pchain.disable_player = core.reason_player;
-		if((pchain.triggering_effect->type & EFFECT_TYPE_ACTIVATE) && (pchain.triggering_effect->handler->current.location == LOCATION_SZONE)) {
-			pchain.triggering_effect->handler->set_status(STATUS_LEAVE_CONFIRMED, TRUE);
-			pchain.triggering_effect->handler->set_status(STATUS_ACTIVATE_DISABLED, TRUE);
+		if((pchain.triggering_effect->type & EFFECT_TYPE_ACTIVATE) && (phandler->current.location == LOCATION_SZONE)) {
+			phandler->set_status(STATUS_LEAVE_CONFIRMED, TRUE);
+			phandler->set_status(STATUS_ACTIVATE_DISABLED, TRUE);
 		}
 		pduel->write_buffer8(MSG_CHAIN_NEGATED);
 		pduel->write_buffer8(chaincount);
 		if(pchain.triggering_location == LOCATION_DECK
 			|| core.duel_rule >= 5 && pchain.triggering_location == LOCATION_EXTRA && (pchain.triggering_position & POS_FACEDOWN))
-			pchain.triggering_effect->handler->release_relation(pchain);
+			phandler->release_relation(pchain);
 		return TRUE;
 	}
 	return FALSE;
@@ -42,8 +43,9 @@ int32 field::disable_chain(uint8 chaincount) {
 	if(chaincount > core.current_chain.size() || chaincount < 1)
 		chaincount = (uint8)core.current_chain.size();
 	chain& pchain = core.current_chain[chaincount - 1];
+	card* phandler = pchain.triggering_effect->handler;
 	if(!(pchain.flag & CHAIN_DISABLE_EFFECT) && is_chain_disablable(pchain.chain_count)
-	        && pchain.triggering_effect->handler->is_affect_by_effect(core.reason_effect)) {
+	        && (!phandler->is_has_relation(pchain) || phandler->is_affect_by_effect(core.reason_effect))) {
 		core.current_chain[chaincount - 1].flag |= CHAIN_DISABLE_EFFECT;
 		core.current_chain[chaincount - 1].disable_reason = core.reason_effect;
 		core.current_chain[chaincount - 1].disable_player = core.reason_player;
@@ -51,7 +53,7 @@ int32 field::disable_chain(uint8 chaincount) {
 		pduel->write_buffer8(chaincount);
 		if(pchain.triggering_location == LOCATION_DECK
 			|| core.duel_rule >= 5 && pchain.triggering_location == LOCATION_EXTRA && (pchain.triggering_position & POS_FACEDOWN))
-			pchain.triggering_effect->handler->release_relation(pchain);
+			phandler->release_relation(pchain);
 		return TRUE;
 	}
 	return FALSE;

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -582,6 +582,7 @@ public:
 	static int32 duel_is_player_can_additional_summon(lua_State *L);
 	static int32 duel_is_chain_negatable(lua_State *L);
 	static int32 duel_is_chain_disablable(lua_State *L);
+	static int32 duel_is_chain_disabled(lua_State *L);
 	static int32 duel_check_chain_target(lua_State *L);
 	static int32 duel_check_chain_uniqueness(lua_State *L);
 	static int32 duel_get_activity_count(lua_State *L);


### PR DESCRIPTION
Fix1:
If the effect handler don't have releation with the triggering effect, `NegateActivation` and `NegateEffect` shouldn't check immunity.
Example: If _Greedy Venom Fusion Dragon_ activated the 2nd effect, and chained by _Starlight Road_, special summon _Greedy Venom Fusion Dragon_ back to the field and let it be affected by _Tyrant's Temper_, the effect of _Starlight Road_ should still resolve.

Fix2:
See https://github.com/Fluorohydride/ygopro-scripts/pull/1882 and https://github.com/Fluorohydride/ygopro-scripts/pull/1869
