### PR TITLE
Update Card.IsRelateToEffect

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2073,15 +2073,15 @@ void card::create_relation(effect* peffect) {
 }
 int32 card::is_has_relation(effect* peffect, uint8 any_chain) {
 	if(!any_chain) {
-			for(auto cit = pduel->game_field->core.current_chain.rbegin(); cit != pduel->game_field->core.current_chain.rend(); ++cit) {
+		for(auto cit = pduel->game_field->core.current_chain.rbegin(); cit != pduel->game_field->core.current_chain.rend(); ++cit) {
 			if(peffect == cit->triggering_effect && relate_effect.find(std::make_pair(peffect, cit->chain_id)) != relate_effect.end())
 				return TRUE;
 		}
 	} else {
-			for(auto& it : relate_effect) {
-				if(it.first == peffect)
-					return TRUE;
-			}
+		for(auto& it : relate_effect) {
+			if(it.first == peffect)
+				return TRUE;
+		}
 	}
 	return FALSE;
 }

--- a/card.cpp
+++ b/card.cpp
@@ -2073,8 +2073,12 @@ void card::create_relation(effect* peffect) {
 }
 int32 card::is_has_relation(effect* peffect) {
 	for(auto& it : relate_effect) {
-		if(it.first == peffect)
-			return TRUE;
+		if(it.first == peffect) {
+			for(auto cit = pduel->game_field->core.current_chain.rbegin(); cit != pduel->game_field->core.current_chain.rend(); ++cit) {
+				if(cit->chain_id == it.second)
+					return TRUE;
+			}
+		}
 	}
 	return FALSE;
 }

--- a/card.cpp
+++ b/card.cpp
@@ -2071,10 +2071,17 @@ void card::create_relation(effect* peffect) {
 	}
 	relate_effect.emplace(peffect, (uint16)0);
 }
-int32 card::is_has_relation(effect* peffect) {
-	for(auto cit = pduel->game_field->core.current_chain.rbegin(); cit != pduel->game_field->core.current_chain.rend(); ++cit) {
-		if (peffect == cit->triggering_effect && relate_effect.find(std::make_pair(peffect, cit->chain_id)) != relate_effect.end())
-			return TRUE;
+int32 card::is_has_relation(effect* peffect, uint8 any_chain) {
+	if(!any_chain) {
+			for(auto cit = pduel->game_field->core.current_chain.rbegin(); cit != pduel->game_field->core.current_chain.rend(); ++cit) {
+			if(peffect == cit->triggering_effect && relate_effect.find(std::make_pair(peffect, cit->chain_id)) != relate_effect.end())
+				return TRUE;
+		}
+	} else {
+			for(auto& it : relate_effect) {
+				if(it.first == peffect)
+					return TRUE;
+			}
 	}
 	return FALSE;
 }

--- a/card.cpp
+++ b/card.cpp
@@ -2072,13 +2072,9 @@ void card::create_relation(effect* peffect) {
 	relate_effect.emplace(peffect, (uint16)0);
 }
 int32 card::is_has_relation(effect* peffect) {
-	for(auto& it : relate_effect) {
-		if(it.first == peffect) {
-			for(auto cit = pduel->game_field->core.current_chain.rbegin(); cit != pduel->game_field->core.current_chain.rend(); ++cit) {
-				if(cit->chain_id == it.second)
-					return TRUE;
-			}
-		}
+	for(auto cit = pduel->game_field->core.current_chain.rbegin(); cit != pduel->game_field->core.current_chain.rend(); ++cit) {
+		if (peffect == cit->triggering_effect && relate_effect.find(std::make_pair(peffect, cit->chain_id)) != relate_effect.end())
+			return TRUE;
 	}
 	return FALSE;
 }

--- a/card.h
+++ b/card.h
@@ -300,7 +300,7 @@ public:
 	void release_relation(const chain& ch);
 	void clear_relate_effect();
 	void create_relation(effect* peffect);
-	int32 is_has_relation(effect* peffect);
+	int32 is_has_relation(effect* peffect, uint8 any_chain = FALSE);
 	void release_relation(effect* peffect);
 	int32 leave_field_redirect(uint32 reason);
 	int32 destination_redirect(uint8 destination, uint32 reason);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -1900,7 +1900,11 @@ int32 scriptlib::card_is_relate_to_effect(lua_State *L) {
 	check_param(L, PARAM_TYPE_EFFECT, 2);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 2);
-	if(pcard && pcard->is_has_relation(peffect))
+	uint8 any_effect = FALSE;
+	if(lua_gettop(L) > 2) {
+		any_effect = lua_toboolean(L, 3);
+	}
+	if(pcard && pcard->is_has_relation(peffect, any_effect))
 		lua_pushboolean(L, 1);
 	else
 		lua_pushboolean(L, 0);


### PR DESCRIPTION
The effect relation check should work in current chain resolving only, rather than any possible chains.
This solves https://github.com/Fluorohydride/ygopro/issues/2389 , without changing any scripts.