### PR TITLE
add Card.IsFaceupEx

### DIFF
--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2440,7 +2440,7 @@ int32 scriptlib::card_is_faceup_ex(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	lua_pushboolean(L, pcard->is_position(POS_FACEUP) | (pcard->current.location & (LOCATION_HAND | LOCATION_GRAVE)));
+	lua_pushboolean(L, pcard->is_position(POS_FACEUP) | (pcard->current.location & (LOCATION_HAND | LOCATION_GRAVE | LOCATION_DECK)));
 	return 1;
 }
 int32 scriptlib::card_is_attack_pos(lua_State *L) {

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2436,6 +2436,13 @@ int32 scriptlib::card_is_faceup(lua_State *L) {
 	lua_pushboolean(L, pcard->is_position(POS_FACEUP));
 	return 1;
 }
+int32 scriptlib::card_is_faceup_ex(lua_State *L) {
+	check_param_count(L, 1);
+	check_param(L, PARAM_TYPE_CARD, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
+	lua_pushboolean(L, pcard->is_position(POS_FACEUP) | (pcard->current.location & (LOCATION_HAND | LOCATION_GRAVE)));
+	return 1;
+}
 int32 scriptlib::card_is_attack_pos(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
@@ -3421,6 +3428,7 @@ static const struct luaL_Reg cardlib[] = {
 	{ "IsAttackable", scriptlib::card_is_attackable },
 	{ "IsChainAttackable", scriptlib::card_is_chain_attackable },
 	{ "IsFaceup", scriptlib::card_is_faceup },
+	{ "IsFaceupEx", scriptlib::card_is_faceup_ex },
 	{ "IsAttackPos", scriptlib::card_is_attack_pos },
 	{ "IsFacedown", scriptlib::card_is_facedown },
 	{ "IsDefensePos", scriptlib::card_is_defense_pos },

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -222,6 +222,7 @@ public:
 	static int32 card_is_attackable(lua_State *L);
 	static int32 card_is_chain_attackable(lua_State *L);
 	static int32 card_is_faceup(lua_State *L);
+	static int32 card_is_faceup_ex(lua_State *L);
 	static int32 card_is_attack_pos(lua_State *L);
 	static int32 card_is_facedown(lua_State *L);
 	static int32 card_is_defense_pos(lua_State *L);


### PR DESCRIPTION
For "_手札及び自分フィールドの表側表示のカードの中から_", "_自分の墓地のモンスター及び除外されている自分のモンスターの中から_" effects, cards in hand or grave shouldn't check faceup status.

before:
```lua
return (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and ...
```
after:
```lua
return c:IsFaceupEx() and ...
```