### PR TITLE
fix & update Effect.IsCostChecked, add Effect.SetCostCheck

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -412,7 +412,7 @@ int32 effect::is_activate_ready(effect* reason_effect, uint8 playerid, const tev
 		}
 	}
 	if(!neglect_cost && !(type & EFFECT_TYPE_CONTINUOUS)) {
-		cost_checked = TRUE;
+		reason_effect->cost_checked = TRUE;
 		if(cost) {
 			pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 			pduel->lua->add_param(playerid, PARAM_TYPE_INT);
@@ -424,10 +424,12 @@ int32 effect::is_activate_ready(effect* reason_effect, uint8 playerid, const tev
 			pduel->lua->add_param(e.reason_player, PARAM_TYPE_INT);
 			pduel->lua->add_param((ptr)0, PARAM_TYPE_INT);
 			if(!pduel->lua->check_condition(cost, 9)) {
-				cost_checked = FALSE;
+				reason_effect->cost_checked = FALSE;
 				return FALSE;
 			}
 		}
+	} else {
+		reason_effect->cost_checked = FALSE;
 	}
 	if(!neglect_target && target) {
 		pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
@@ -440,11 +442,11 @@ int32 effect::is_activate_ready(effect* reason_effect, uint8 playerid, const tev
 		pduel->lua->add_param(e.reason_player, PARAM_TYPE_INT);
 		pduel->lua->add_param((ptr)0, PARAM_TYPE_INT);
 		if(!pduel->lua->check_condition(target, 9)) {
-			cost_checked = FALSE;
+			reason_effect->cost_checked = FALSE;
 			return FALSE;
 		}
 	}
-	cost_checked = FALSE;
+	reason_effect->cost_checked = FALSE;
 	return TRUE;
 }
 int32 effect::is_activate_ready(uint8 playerid, const tevent& e, int32 neglect_cond, int32 neglect_cost, int32 neglect_target) {

--- a/libeffect.cpp
+++ b/libeffect.cpp
@@ -526,6 +526,14 @@ int32 scriptlib::effect_is_cost_checked(lua_State *L) {
 	lua_pushboolean(L, peffect->cost_checked);
 	return 1;
 }
+int32 scriptlib::effect_set_cost_check(lua_State *L) {
+	check_param_count(L, 2);
+	check_param(L, PARAM_TYPE_EFFECT, 1);
+	effect* peffect = *(effect**) lua_touserdata(L, 1);
+	uint8 cost_check = lua_toboolean(L, 2);
+	peffect->cost_checked = cost_check;
+	return 0;
+}
 int32 scriptlib::effect_get_activate_location(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
@@ -618,6 +626,7 @@ static const struct luaL_Reg effectlib[] = {
 	{ "IsActivatable", scriptlib::effect_is_activatable },
 	{ "IsActivated", scriptlib::effect_is_activated },
 	{ "IsCostChecked", scriptlib::effect_is_cost_checked },
+	{ "SetCostCheck", scriptlib::effect_set_cost_check },
 	{ "GetActivateLocation", scriptlib::effect_get_activate_location },
 	{ "GetActivateSequence", scriptlib::effect_get_activate_sequence },
 	{ "CheckCountLimit", scriptlib::effect_check_count_limit },

--- a/processor.cpp
+++ b/processor.cpp
@@ -4147,6 +4147,7 @@ int32 field::add_chain(uint16 step) {
 	case 5: {
 		auto& clit = core.current_chain.back();
 		effect* peffect = clit.triggering_effect;
+		peffect->cost_checked = TRUE;
 		if(peffect->cost) {
 			core.sub_solving_event.push_back(clit.evt);
 			add_process(PROCESSOR_EXECUTE_COST, 0, peffect, 0, clit.triggering_player, 0);
@@ -4166,6 +4167,7 @@ int32 field::add_chain(uint16 step) {
 		break_effect();
 		auto& clit = core.current_chain.back();
 		effect* peffect = clit.triggering_effect;
+		peffect->cost_checked = FALSE;
 		card* phandler = peffect->get_handler();
 		if(clit.target_cards && clit.target_cards->container.size()) {
 			if(peffect->is_flag(EFFECT_FLAG_CARD_TARGET)) {

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -331,6 +331,7 @@ public:
 	static int32 effect_is_activatable(lua_State *L);
 	static int32 effect_is_activated(lua_State *L);
 	static int32 effect_is_cost_checked(lua_State *L);
+	static int32 effect_set_cost_check(lua_State *L);
 	static int32 effect_get_activate_location(lua_State *L);
 	static int32 effect_get_activate_sequence(lua_State *L);
 	static int32 effect_check_count_limit(lua_State *L);


### PR DESCRIPTION
fix: `Effect.IsCostChecked` return true in case Junk Collector, Trap of Darkness and so on copies normal trap's effect that used `Effect.IsCostChecked`.
(because `Card.CheckActivateEffect` change copied normal trap's `cost_checked`, but doesn't change Junk Collector's `cost_checked`.)
update 1: `Effect.IsCostChecked` can return true when the effect activate (chk=1).
(see https://github.com/Fluorohydride/ygopro-scripts/pull/1931 .)
update 2: add `Effect.SetCostCheck`.
(need by Destiny HERO - Diamond Dude and Serial Spell.)