### PR TITLE
update Duel.CheckPhaseActivity

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -4187,7 +4187,6 @@ int32 field::add_chain(uint16 step) {
 				&& phandler->is_has_relation(clit) && phandler->current.location == LOCATION_SZONE
 				&& !peffect->is_flag(EFFECT_FLAG_FIELD_ONLY))
 			clit.flag |= CHAIN_CONTINUOUS_CARD;
-		core.phase_action = TRUE;
 		pduel->write_buffer8(MSG_CHAINED);
 		pduel->write_buffer8(clit.chain_count);
 		raise_event(phandler, EVENT_CHAINING, peffect, 0, clit.triggering_player, clit.triggering_player, clit.chain_count);
@@ -4305,6 +4304,7 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 	auto cait = core.current_chain.rbegin();
 	switch(step) {
 	case 0: {
+		core.phase_action = TRUE;
 		pduel->write_buffer8(MSG_CHAIN_SOLVING);
 		pduel->write_buffer8(cait->chain_count);
 		add_to_disable_check_list(cait->triggering_effect->get_handler());


### PR DESCRIPTION
Before: _Pop-Up_ can activate _Magical Mid-Breaker Field_ only if _Pop-Up_ is in chain 1 of Main 1 start
After: _Pop-Up_ can activate _Magical Mid-Breaker Field_ if _Pop-Up_ is in any chain of Main 1 start

>Q.
自分メインフェイズの開始時、自分が「メタバース」を発動した場合、その「メタバース」の効果の処理によってデッキから「半魔導帯域」を発動する事はできますか？
A.
できます。

>Q.
自分メインフェイズの開始時、自分がチェーン1で「スローライフ」を発動し、チェーン2で「メタバース」を発動した場合、「メタバース」の効果の処理によってデッキから「半魔導帯域」を発動する事はできますか？
A.
できます。

>Q.
「王宮の勅命」の効果が適用中、自分メインフェイズの開始時、自分がチェーン1とチェーン2で2枚の「メタバース」を発動しました。
この場合、チェーン2の「メタバース」の効果処理によってデッキから「半魔導帯域」を発動する事はできますか？
また、チェーン1の「メタバース」の効果処理によってデッキから「半魔導帯域」を発動する事はできますか？
A.
いずれも可能です。
