### PR TITLE
fix Duel.NegateActivation and Duel.NegateEffect

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -18,7 +18,7 @@ int32 field::negate_chain(uint8 chaincount) {
 	if(chaincount > core.current_chain.size() || chaincount < 1)
 		chaincount = (uint8)core.current_chain.size();
 	chain& pchain = core.current_chain[chaincount - 1];
-	card* phandler = pchain.triggering_effect->handler;
+	card* phandler = pchain.triggering_effect->get_handler();
 	if(!(pchain.flag & CHAIN_DISABLE_ACTIVATE) && is_chain_negatable(pchain.chain_count)
 		&& (!phandler->is_has_relation(pchain) || phandler->is_affect_by_effect(core.reason_effect))) {
 		pchain.flag |= CHAIN_DISABLE_ACTIVATE;
@@ -43,7 +43,7 @@ int32 field::disable_chain(uint8 chaincount, uint8 forced) {
 	if(chaincount > core.current_chain.size() || chaincount < 1)
 		chaincount = (uint8)core.current_chain.size();
 	chain& pchain = core.current_chain[chaincount - 1];
-	card* phandler = pchain.triggering_effect->handler;
+	card* phandler = pchain.triggering_effect->get_handler();
 	if(!(pchain.flag & CHAIN_DISABLE_EFFECT) && is_chain_disablable(pchain.chain_count)
 		&& (!phandler->is_has_relation(pchain) || phandler->is_affect_by_effect(core.reason_effect))
 		&& !(phandler->is_has_relation(pchain) && phandler->is_status(STATUS_DISABLED) && !forced)) {


### PR DESCRIPTION
fix: if Tyrant's Temper and xyz monster with `EFFECT_TYPE_XMATERIAL` effect(e.g. Zoodiac) as material have on the field, `Duel.NegateActivation` and `Duel.NegateEffect` don't check immunity.

> Q.
> 自分フィールドに、「十二獣ラビーナ」をエクシーズ素材としている「十二獣タイグリス」1体と「暴君の威圧」1枚がそれぞれ表側表示で存在しています。
> この状況で、その「十二獣タイグリス」を対象として相手が「死者への手向け」を発動し、チェーンして自分がエクシーズ素材となっている「十二獣ラビーナ」の『●このカードを対象とする相手の魔法カードの効果が発動した時、このカードのX素材を１つ取り除いて発動できる。その発動を無効にする』効果を発動した時、さらにチェーンして相手が「天罰」を発動しました。
> 「暴君の威圧」の効果が適用され「十二獣タイグリス」は罠カードの効果を受けませんが、「天罰」の効果処理はどのようになりますか？
> A.
> ご質問の場合、**「十二獣タイグリス」は罠カードの効果を受けませんので、「天罰」の効果処理は何も行われません**。
> したがって、「死者への手向け」の発動は無効になります。