### PR TITLE
Update effect.cpp

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -21,7 +21,7 @@ bool is_continuous_event(uint32 code) {
 	else if (code & 0xf0000)
 		return false;
 	else if (code & EVENT_PHASE_START)
-		return (code & 0x23ff) == code;
+		return (code & 0x2fff) == code;
 	else
 		return continuous_event.find(code) != continuous_event.end();
 }

--- a/effect.cpp
+++ b/effect.cpp
@@ -21,7 +21,7 @@ bool is_continuous_event(uint32 code) {
 	else if (code & 0xf0000)
 		return false;
 	else if (code & 0xf000)
-		return !!(code & EVENT_PHASE_START);
+		return (code & EVENT_PHASE_START) && (code < 0x10000);
 	else
 		return continuous_event.find(code) != continuous_event.end();
 }

--- a/effect.cpp
+++ b/effect.cpp
@@ -16,14 +16,7 @@ bool effect_sort_id(const effect* e1, const effect* e2) {
 }
 // return: code is an event reserved for EFFECT_TYPE_CONTINUOUS or not
 bool is_continuous_event(uint32 code) {
-	if (code & EVENT_CUSTOM)
-		return false;
-	else if (code & 0xf0000)
-		return false;
-	else if (code & EVENT_PHASE_START)
-		return (code & 0x2fff) == code;
-	else
-		return continuous_event.find(code) != continuous_event.end();
+	return (code & (EVENT_PHASE_START + 0xfff)) == code || continuous_event.find(code) != continuous_event.end();
 }
 
 effect::effect(duel* pd) {

--- a/effect.cpp
+++ b/effect.cpp
@@ -20,8 +20,8 @@ bool is_continuous_event(uint32 code) {
 		return false;
 	else if (code & 0xf0000)
 		return false;
-	else if (code & 0xf000)
-		return (code & EVENT_PHASE_START) && (code < 0x10000);
+	else if (code & EVENT_PHASE_START)
+		return (code & 0x23ff) == code;
 	else
 		return continuous_event.find(code) != continuous_event.end();
 }


### PR DESCRIPTION
According to function card::add_effect in file card.cpp, line 1574, if an effect is considered `is_continuous_event` and is not `EFFECT_TYPE_CONTINUOUS`, it cannot be registered to a card. This is likely to discourage some naughty kids who make chainned triggered effects trigger every `EVENT_ADJUST`, but there is something with it.

For now if an effect has `(code & EVENT_PHASE_START) > 0`, and it does not have `(code & 0xf0000) > 0`, it will be considered `is_continuous_event` regardless, even if it was a custom aura effect that uses its card code as its effect code, and becomes unable to be registered to a card. A card code 14711019 is 0xe078eb in hex, it happens to have 0x2000 (the value of EVENT_PHASE_START), and it happens to match no bit with 0xf0000, so its custom aura effect could not be registered. Many konami cards such as Blue-Eyes Spirit Dragon are implemented with custom aura effects, while none of their card codes happen to match the criteria for now, sooner or later there will be one.

What I changed: if an effect has `(code & (EVENT_PHASE_START + 0xfff)) == code`, it matches the criteria of `is_continuous_event`. Any excess bit makes it don't. It should now cover all necessary EVENT_PHASE_START, and does not affect custom aura effects and custom event triggers.