### PR TITLE
fix card::add_effect()

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1571,7 +1571,7 @@ int32 card::add_effect(effect* peffect) {
 	if (peffect->type & EFFECT_TYPE_SINGLE && !peffect->is_flag(EFFECT_FLAG_SINGLE_RANGE) && peffect->owner == this 
 		&& get_status(STATUS_DISABLED) && (peffect->reset_flag & RESET_DISABLE))
 		return 0;
-	if (!(peffect->type & EFFECT_TYPE_CONTINUOUS) && is_continuous_event(peffect->code))
+	if (peffect->type & EFFECT_TYPES_TRIGGER_LIKE && is_continuous_event(peffect->code))
 		return 0;
 	// the trigger effect in phase is "once per turn" by default
 	if (peffect->get_code_type() == CODE_PHASE && peffect->code & (PHASE_DRAW | PHASE_STANDBY | PHASE_END) && peffect->type & (EFFECT_TYPE_TRIGGER_O | EFFECT_TYPE_TRIGGER_F)

--- a/effect.h
+++ b/effect.h
@@ -166,6 +166,8 @@ public:
 #define EFFECT_TYPE_GRANT			0x2000	//
 #define EFFECT_TYPE_TARGET			0x4000	//
 
+#define EFFECT_TYPES_TRIGGER_LIKE	(EFFECT_TYPE_ACTIVATE | EFFECT_TYPE_TRIGGER_O | EFFECT_TYPE_TRIGGER_F | EFFECT_TYPE_QUICK_O | EFFECT_TYPE_QUICK_F)
+
 //========== Flags ==========
 enum effect_flag : uint32 {
 	EFFECT_FLAG_INITIAL				= 0x0001,
@@ -466,7 +468,7 @@ inline effect_flag operator|(effect_flag flag1, effect_flag flag2)
 #define EFFECT_ACTIVATION_COUNT_LIMIT	367
 #define EFFECT_LIMIT_SPECIAL_SUMMON_POSITION	368
 
-#define EVENT_STARTUP		1000
+//#define EVENT_STARTUP		1000
 #define EVENT_FLIP			1001
 #define EVENT_FREE_CHAIN	1002
 #define EVENT_DESTROY		1010
@@ -543,7 +545,7 @@ inline effect_flag operator|(effect_flag flag1, effect_flag flag2)
 #define DOUBLE_DAMAGE				0x80000000
 #define HALF_DAMAGE					0x80000001
 
-// The type of bit field in code
+// The type of event in code
 #define CODE_CUSTOM		1	// header + id (28 bits)
 #define CODE_COUNTER	2	// header + counter_id (16 bits)
 #define CODE_PHASE		3	// header + phase_id (12 bits)


### PR DESCRIPTION
# Problem
#463
The changes in #408 will reject some normal effects with bit 0xf000.

# Reason
The effect types have 2 categories:

A. trigger-like
```cpp
EFFECT_TYPE_ACTIVATE
EFFECT_TYPE_TRIGGER_O
EFFECT_TYPE_TRIGGER_F
EFFECT_TYPE_QUICK_O
EFFECT_TYPE_QUICK_F
```
The code is an event.

B. other
The code is an effect code.

# Solution
Now the check is limited to trigger-like effects.
These effects cannot use continuous_event.
