### PR TITLE
Update is_capable_send_to_extra

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3674,16 +3674,16 @@ int32 card::is_capable_cost_to_deck(uint8 playerid) {
 		return FALSE;
 	return TRUE;
 }
-int32 card::is_capable_cost_to_extra(uint8 playerid) {
+int32 card::is_capable_cost_to_extra(uint8 playerid, uint8 faceup) {
 	uint32 redirect = 0;
 	uint32 dest = LOCATION_DECK;
-	if(!is_extra_deck_monster())
-		return FALSE;
 	if(current.location == LOCATION_EXTRA)
 		return FALSE;
 	if(is_affected_by_effect(EFFECT_CANNOT_USE_AS_COST))
 		return FALSE;
-	if(!is_capable_send_to_deck(playerid))
+	if(is_status(STATUS_LEAVE_CONFIRMED))
+		return FALSE;
+	if (!is_capable_send_to_extra(playerid, faceup))
 		return FALSE;
 	auto op_param = sendto_param;
 	sendto_param.location = dest;

--- a/card.cpp
+++ b/card.cpp
@@ -3570,7 +3570,7 @@ int32 card::is_capable_send_to_hand(uint8 playerid) {
 		return FALSE;
 	if(is_affected_by_effect(EFFECT_CANNOT_TO_HAND))
 		return FALSE;
-	if(is_extra_deck_monster() && !is_capable_send_to_extra(playerid))
+	if(is_extra_deck_monster() && !is_capable_send_to_extra(playerid, 0))
 		return FALSE;
 	if(!pduel->game_field->is_player_can_send_to_hand(playerid, this))
 		return FALSE;
@@ -3587,13 +3587,18 @@ int32 card::is_capable_send_to_deck(uint8 playerid) {
 		return FALSE;
 	return TRUE;
 }
-int32 card::is_capable_send_to_extra(uint8 playerid) {
-	if(!is_extra_deck_monster() && !(data.type & TYPE_PENDULUM))
-		return FALSE;
-	if(is_extra_deck_monster() && is_affected_by_effect(EFFECT_CANNOT_TO_DECK))
-		return FALSE;
-	if(!pduel->game_field->is_player_can_send_to_deck(playerid, this))
-		return FALSE;
+int32 card::is_capable_send_to_extra(uint8 playerid, uint8 faceup) {
+	if (faceup) {
+		if (!(data.type & TYPE_PENDULUM))
+			return FALSE;
+	} else {
+		if (!is_extra_deck_monster())
+			return FALSE;
+		if (is_affected_by_effect(EFFECT_CANNOT_TO_DECK))
+			return FALSE;
+		if (!pduel->game_field->is_player_can_send_to_deck(playerid, this))
+			return FALSE;
+	}
 	return TRUE;
 }
 int32 card::is_capable_cost_to_grave(uint8 playerid) {

--- a/card.h
+++ b/card.h
@@ -364,7 +364,7 @@ public:
 	int32 is_capable_send_to_grave(uint8 playerid);
 	int32 is_capable_send_to_hand(uint8 playerid);
 	int32 is_capable_send_to_deck(uint8 playerid);
-	int32 is_capable_send_to_extra(uint8 playerid);
+	int32 is_capable_send_to_extra(uint8 playerid, uint8 faceup = FALSE);
 	int32 is_capable_cost_to_grave(uint8 playerid);
 	int32 is_capable_cost_to_hand(uint8 playerid);
 	int32 is_capable_cost_to_deck(uint8 playerid);

--- a/card.h
+++ b/card.h
@@ -368,7 +368,7 @@ public:
 	int32 is_capable_cost_to_grave(uint8 playerid);
 	int32 is_capable_cost_to_hand(uint8 playerid);
 	int32 is_capable_cost_to_deck(uint8 playerid);
-	int32 is_capable_cost_to_extra(uint8 playerid);
+	int32 is_capable_cost_to_extra(uint8 playerid, uint8 faceup = 0);
 	int32 is_capable_attack();
 	int32 is_capable_attack_announce(uint8 playerid);
 	int32 is_capable_change_position(uint8 playerid);

--- a/card.h
+++ b/card.h
@@ -364,11 +364,11 @@ public:
 	int32 is_capable_send_to_grave(uint8 playerid);
 	int32 is_capable_send_to_hand(uint8 playerid);
 	int32 is_capable_send_to_deck(uint8 playerid);
-	int32 is_capable_send_to_extra(uint8 playerid, uint8 faceup = FALSE);
+	int32 is_capable_send_to_extra(uint8 playerid, uint8 faceup = 0);
 	int32 is_capable_cost_to_grave(uint8 playerid);
 	int32 is_capable_cost_to_hand(uint8 playerid);
 	int32 is_capable_cost_to_deck(uint8 playerid);
-	int32 is_capable_cost_to_extra(uint8 playerid);
+	int32 is_capable_cost_to_extra(uint8 playerid, uint8 faceup = 0);
 	int32 is_capable_attack();
 	int32 is_capable_attack_announce(uint8 playerid);
 	int32 is_capable_change_position(uint8 playerid);

--- a/card.h
+++ b/card.h
@@ -368,7 +368,7 @@ public:
 	int32 is_capable_cost_to_grave(uint8 playerid);
 	int32 is_capable_cost_to_hand(uint8 playerid);
 	int32 is_capable_cost_to_deck(uint8 playerid);
-	int32 is_capable_cost_to_extra(uint8 playerid, uint8 faceup = 0);
+	int32 is_capable_cost_to_extra(uint8 playerid);
 	int32 is_capable_attack();
 	int32 is_capable_attack_announce(uint8 playerid);
 	int32 is_capable_change_position(uint8 playerid);

--- a/field.cpp
+++ b/field.cpp
@@ -377,7 +377,7 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 			}
 		} else {
 			if((pcard->data.type & TYPE_PENDULUM) && (location == LOCATION_GRAVE)
-			        && pcard->is_capable_send_to_extra(playerid)
+			        && pcard->is_capable_send_to_extra(playerid, TRUE)
 			        && (((pcard->current.location == LOCATION_MZONE) && !pcard->is_status(STATUS_SUMMON_DISABLED))
 			        || ((pcard->current.location == LOCATION_SZONE) && !pcard->is_status(STATUS_ACTIVATE_DISABLED)))) {
 				location = LOCATION_EXTRA;

--- a/field.cpp
+++ b/field.cpp
@@ -377,7 +377,7 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 			}
 		} else {
 			if((pcard->data.type & TYPE_PENDULUM) && (location == LOCATION_GRAVE)
-			        && pcard->is_capable_send_to_extra(playerid, TRUE)
+			        && pcard->is_capable_send_to_extra(playerid, 1)
 			        && (((pcard->current.location == LOCATION_MZONE) && !pcard->is_status(STATUS_SUMMON_DISABLED))
 			        || ((pcard->current.location == LOCATION_SZONE) && !pcard->is_status(STATUS_ACTIVATE_DISABLED)))) {
 				location = LOCATION_EXTRA;

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2327,7 +2327,10 @@ int32 scriptlib::card_is_able_to_extra_as_cost(lua_State *L) {
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 p = pcard->pduel->game_field->core.reason_player;
-	if(pcard->is_capable_cost_to_extra(p))
+	uint32 faceup = 0;
+	if(lua_gettop(L) > 1)
+		faceup = lua_toboolean(L, 2);
+	if(pcard->is_capable_cost_to_extra(p, faceup))
 		lua_pushboolean(L, 1);
 	else
 		lua_pushboolean(L, 0);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2261,7 +2261,10 @@ int32 scriptlib::card_is_able_to_extra(lua_State *L) {
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 p = pcard->pduel->game_field->core.reason_player;
-	if(pcard->is_capable_send_to_extra(p))
+	uint32 faceup = 0;
+	if(lua_gettop(L) > 1)
+		faceup = lua_toboolean(L, 2);
+	if(pcard->is_capable_send_to_extra(p, faceup))
 		lua_pushboolean(L, 1);
 	else
 		lua_pushboolean(L, 0);
@@ -2324,7 +2327,10 @@ int32 scriptlib::card_is_able_to_extra_as_cost(lua_State *L) {
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 p = pcard->pduel->game_field->core.reason_player;
-	if(pcard->is_capable_cost_to_extra(p))
+	uint32 faceup = 0;
+	if(lua_gettop(L) > 1)
+		faceup = lua_toboolean(L, 2);
+	if(pcard->is_capable_cost_to_extra(p, faceup))
 		lua_pushboolean(L, 1);
 	else
 		lua_pushboolean(L, 0);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2327,10 +2327,7 @@ int32 scriptlib::card_is_able_to_extra_as_cost(lua_State *L) {
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 p = pcard->pduel->game_field->core.reason_player;
-	uint32 faceup = 0;
-	if(lua_gettop(L) > 1)
-		faceup = lua_toboolean(L, 2);
-	if(pcard->is_capable_cost_to_extra(p, faceup))
+	if(pcard->is_capable_cost_to_extra(p))
 		lua_pushboolean(L, 1);
 	else
 		lua_pushboolean(L, 0);

--- a/operations.cpp
+++ b/operations.cpp
@@ -3800,7 +3800,7 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 			         || (dest == LOCATION_DECK && !pcard->is_capable_send_to_deck(core.reason_player))
 			         || (dest == LOCATION_REMOVED && !pcard->is_removeable(core.reason_player, pcard->sendto_param.position, reason))
 			         || (dest == LOCATION_GRAVE && !pcard->is_capable_send_to_grave(core.reason_player))
-			         || (dest == LOCATION_EXTRA && !pcard->is_capable_send_to_extra(core.reason_player)))) {
+			         || (dest == LOCATION_EXTRA && !pcard->is_capable_send_to_extra(core.reason_player, (pcard->sendto_param.position & POS_FACEUP))))) {
 				pcard->current.reason = pcard->temp.reason;
 				pcard->current.reason_player = pcard->temp.reason_player;
 				pcard->current.reason_effect = pcard->temp.reason_effect;


### PR DESCRIPTION
The changes in #405 make it so:
- Effects with code EFFECT_CANNOT_TO_DECK that affect the cards no longer cause main deck pendulum monsters to not go to extra face-up.

But:
- Effects with code EFFECT_CANNOT_TO_DECK that affect the cards still cause extra deck pendulum monsters to not go to extra face-up.
- Effects with code EFFECT_CANNOT_TO_DECK that affect the players still cause any pendulum monster to not go to extra face-up. The pull request mentioned above was meant to update ruling for G.B. Hunter, but it had no effect on G.B. Hunter.

Other issues:
- Extra deck monsters that are not pendulum monsters should not be able to be sent to extra face-up.

Also:
- Added new boolean parameters to Card.IsAbleToExtra and Card.IsAbleToExtraAsCost. If that parameter is true, the functions check if that card can be sent to extra face-up, which requires it to be a pendulum monster. If that parameter is false or not given, the functions do whatever they do before.

@salix5 