### PR TITLE
add Card.IsSpecialSummonableCard

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2997,6 +2997,25 @@ int32 card::is_summonable_card() {
 		| TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ | TYPE_LINK
 		| TYPE_TOKEN | TYPE_TRAPMONSTER));
 }
+int32 card::is_spsummonable_card() {
+	if(!(data.type & TYPE_MONSTER))
+		return FALSE;
+	if(is_affected_by_effect(EFFECT_REVIVE_LIMIT) && !is_status(STATUS_PROC_COMPLETE)
+		&& (current.location & (LOCATION_GRAVE | LOCATION_REMOVED | LOCATION_SZONE)))
+		return FALSE;
+	effect_set eset;
+	filter_effect(EFFECT_SPSUMMON_CONDITION, &eset);
+	for(int32 i = 0; i < eset.size(); ++i) {
+		pduel->lua->add_param(pduel->game_field->core.reason_effect, PARAM_TYPE_EFFECT);
+		pduel->lua->add_param(pduel->game_field->core.reason_player, PARAM_TYPE_INT);
+		pduel->lua->add_param(SUMMON_TYPE_SPECIAL, PARAM_TYPE_INT);
+		pduel->lua->add_param((void*)0, PARAM_TYPE_INT);
+		pduel->lua->add_param((void*)0, PARAM_TYPE_INT);
+		if(!eset[i]->check_value_condition(5))
+			return FALSE;
+	}
+	return TRUE;
+}
 int32 card::is_fusion_summonable_card(uint32 summon_type) {
 	if(!(data.type & TYPE_FUSION))
 		return FALSE;

--- a/card.h
+++ b/card.h
@@ -338,6 +338,7 @@ public:
 	int32 check_cost_condition(int32 ecode, int32 playerid);
 	int32 check_cost_condition(int32 ecode, int32 playerid, int32 sumtype);
 	int32 is_summonable_card();
+	int32 is_spsummonable_card();
 	int32 is_fusion_summonable_card(uint32 summon_type);
 	int32 is_spsummonable(effect* proc, material_info info = null_info);
 	int32 is_summonable(effect* proc, uint8 min_tribute, uint32 zone = 0x1f, uint32 releasable = 0xff00ff);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2024,6 +2024,13 @@ int32 scriptlib::card_is_summonable(lua_State *L) {
 	lua_pushboolean(L, pcard->is_summonable_card());
 	return 1;
 }
+int32 scriptlib::card_is_special_summonable_card(lua_State *L) {
+	check_param_count(L, 1);
+	check_param(L, PARAM_TYPE_CARD, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
+	lua_pushboolean(L, pcard->is_spsummonable_card());
+	return 1;
+}
 int32 scriptlib::card_is_fusion_summonable_card(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
@@ -3413,6 +3420,7 @@ static const struct luaL_Reg cardlib[] = {
 	{ "IsDisabled", scriptlib::card_is_disabled },
 	{ "IsDestructable", scriptlib::card_is_destructable },
 	{ "IsSummonableCard", scriptlib::card_is_summonable },
+	{ "IsSpecialSummonableCard", scriptlib::card_is_special_summonable_card },
 	{ "IsFusionSummonableCard", scriptlib::card_is_fusion_summonable_card },
 	{ "IsSpecialSummonable", scriptlib::card_is_special_summonable },
 	{ "IsSynchroSummonable", scriptlib::card_is_synchro_summonable },

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -196,6 +196,7 @@ public:
 	static int32 card_is_disabled(lua_State *L);
 	static int32 card_is_destructable(lua_State *L);
 	static int32 card_is_summonable(lua_State *L);
+	static int32 card_is_special_summonable_card(lua_State *L);
 	static int32 card_is_fusion_summonable_card(lua_State *L);
 	static int32 card_is_msetable(lua_State *L);
 	static int32 card_is_ssetable(lua_State *L);


### PR DESCRIPTION
fix: if Barrier Statue and/or Vanity's Emptiness has on the field, The Deep Grave cannot activate.

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=10917&keyword=&tag=-1
> 「[業火の結界像](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6884)」のモンスター効果が適用されている場合でも、炎属性以外の属性を持つモンスターを対象として、「[深すぎた墓穴](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13794)」のカードの発動を行う事はできます。

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=21861&keyword=&tag=-1
> 「[虚無空間](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9153)」の効果が適用されている場合でも、「[深すぎた墓穴](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13794)」のカードの発動を行う事はできます。

but, if `Card.IsCanBeSpecialSummoned` removed in The Deep Grave, The Deep Grave can target the monster that cannot be special summon.

> mail:
> Q.
> 相手の墓地の「古代の機械巨人」を対象として自分は「深すぎた墓穴」を発動できますか？
> A.
> できません。
> 
> Q.
> 自分の墓地の、「ドラグマ・パニッシュメント」の効果で直接エクストラデッキから墓地へ送られた「メレオロジック・アグリゲーター」を対象として自分は「深すぎた墓穴」を発動できますか？
> A.
> 発動できません。

so, add `Card.IsSpecialSummonableCard` and use to The Deep Grave.