### PR TITLE
refuse Group.SelectWithSumEqual with more than 127 max

### DIFF
--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -441,6 +441,8 @@ int32 scriptlib::group_select_with_sum_equal(lua_State *L) {
 		min = 0;
 	if(max < min)
 		max = min;
+	if(max > 127)
+		return luaL_error(L, "Parameter \"max\" exceeded 127.");
 	int32 extraargs = lua_gettop(L) - 6;
 	pduel->game_field->core.select_cards.assign(pgroup->container.begin(), pgroup->container.end());
 	for(auto& pcard : pduel->game_field->core.must_select_cards) {


### PR DESCRIPTION
If `max` go beyond 127, `arg2` here will exceed int32.
https://github.com/Fluorohydride/ygopro-core/blob/11772de2fa87f561d3b3e276f1e89205664e5cac/libgroup.cpp#L461

But, we still can't select among all cards in a group bigger than 127: https://github.com/Fluorohydride/ygopro-core/pull/449
And, `Group.SelectWithSum...` are not safe for values bigger than 65535: https://github.com/Fluorohydride/ygopro-scripts/pull/1785

BTW, it is the only problem I found in https://github.com/Fluorohydride/ygopro-core/pull/451
