### PR TITLE
fix EVENT_PREDRAW

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -1473,7 +1473,7 @@ int32 field::process_point_event(int16 step, int32 skip_trigger, int32 skip_free
 			if(!core.hand_adjusted)
 				add_process(PROCESSOR_QUICK_EFFECT, 0, 0, 0, skip_freechain, infos.turn_player);
 		} else
-			add_process(PROCESSOR_QUICK_EFFECT, 0, 0, 0, skip_freechain, 1 - core.current_chain.back().triggering_player);
+			add_process(PROCESSOR_QUICK_EFFECT, 0, 0, 0, FALSE, 1 - core.current_chain.back().triggering_player);
 		return FALSE;
 	}
 	case 10: {
@@ -3742,7 +3742,7 @@ int32 field::process_turn(uint16 step, uint8 turn_player) {
 		pduel->write_buffer8(turn_player);
 		pduel->write_buffer32(27);
 		if(core.new_fchain.size() || core.new_ochain.size())
-			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, 0, 0);
+			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, 0x100, TRUE);
 		return FALSE;
 	}
 	case 2: {


### PR DESCRIPTION
修复1：
[根据规则](https://ocg-rule.readthedocs.io/zh_CN/latest/c02/%E5%9F%BA%E6%9C%AC%E7%94%A8%E8%AF%AD.html#id60
)，在抽卡阶段通常抽卡前，只能发动明确记述了抽卡前的效果，不能发自由时点的效果。
而且抽卡前的效果开的连锁结束后，实际抽卡前也不能再开连锁发动其他效果。
但如果发动了效果，就可以连锁包括自由时点效果在内的任意效果。与怪兽召唤中的时点类似。

目前Pro中，在抽卡前的效果连锁处理完毕后，实际抽卡前可以再开连锁发动自由时点的效果。
而且如果场上存在明确记述的抽卡前的效果，但选择不发动，可以在抽卡前“创造时点”发动自由连锁的效果。

为此应把抽卡前的PROCESSOR_POINT_EVENT设置skip_freechain和skip_new。

修复2：
当在skip_freechain的时点发动了效果之后，应可以连锁发动自由时点效果。

目前Pro中，如果这种时点发动了2速效果（例如雷王无效特殊召唤），会再开一个始终不skip_freechain的快速时点
https://github.com/Fluorohydride/ygopro-core/blob/0eec9ae41ae34e3f49a1905d12607d438fc0411d/processor.cpp#L1783
如果没有发动，则继续开skip_freechain的快速时点给对方
https://github.com/Fluorohydride/ygopro-core/blob/0eec9ae41ae34e3f49a1905d12607d438fc0411d/processor.cpp#L1789
但如果这种时点发动1速效果（抽卡前的效果在Pro都属于此类），开启的快速时点会继承skip_freechain，导致不能连锁发动，应统一不继承skip_freechain。