### PR TITLE
fix get_rule_zone_fromex

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -819,7 +819,8 @@ uint32 field::get_linked_zone(int32 playerid) {
 }
 uint32 field::get_rule_zone_fromex(int32 playerid, card* pcard) {
 	if(core.duel_rule >= 4) {
-		if(core.duel_rule >= 5 && pcard && pcard->is_position(POS_FACEDOWN) && (pcard->data.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ)))
+		if(core.duel_rule >= 5 && pcard && (pcard->data.type & (TYPE_FUSION | TYPE_SYNCHRO | TYPE_XYZ))
+			&& (pcard->is_position(POS_FACEDOWN) || !(pcard->data.type & TYPE_PENDULUM)))
 			return 0x7f;
 		else
 			return get_linked_zone(playerid) | (1u << 5) | (1u << 6);


### PR DESCRIPTION
According to the Master Rule 2020 changes, F/S/X monsters in extra deck can be summoned to any main monster zones, except for face-up pendulum monsters.
But now in YGOPro all face-up monsters in extra deck will only be summoned to linked zones.
Generally it won't cause problem in duel because there is no way to put non-P F/S/X monster face-up in extra deck, but some single puzzles made earlier than master rule 3 may add cards face-up in extra deck so it won't work even in Master Rule 2020.