### PR TITLE
update Duel.Overlay

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -262,6 +262,13 @@ uint32 card::get_infos(byte* buf, int32 query_flag, int32 use_cache) {
 }
 uint32 card::get_info_location() {
 	if(overlay_target) {
+		if(overlay_target->overlay_target) {
+			uint32 c = overlay_target->overlay_target->current.controler | 0x10;
+			uint32 l = overlay_target->overlay_target->current.location | LOCATION_OVERLAY;
+			uint32 s = overlay_target->overlay_target->current.sequence;
+			uint32 ss = overlay_target->current.sequence;
+			return c + (l << 8) + (s << 16) + (ss << 24);
+		}
 		uint32 c = overlay_target->current.controler;
 		uint32 l = overlay_target->current.location | LOCATION_OVERLAY;
 		uint32 s = overlay_target->current.sequence;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3420,12 +3420,17 @@ int32 scriptlib::duel_overlay(lua_State *L) {
 		pgroup = *(group**) lua_touserdata(L, 2);
 	} else
 		return luaL_error(L, "Parameter %d should be \"Card\" or \"Group\".", 2);
-	if(pcard) {
-		card::card_set cset;
+	card::card_set cset;
+	if(pcard)
 		cset.insert(pcard);
-		target->xyz_overlay(&cset);
-	} else
-		target->xyz_overlay(&pgroup->container);
+	else
+		cset.insert(pgroup->container.begin(), pgroup->container.end());
+	card::card_set oset;
+	for(auto& pcard : cset)
+		oset.insert(pcard->xyz_materials.begin(), pcard->xyz_materials.end());
+	target->xyz_overlay(&cset);
+	duel* pduel = interpreter::get_duel_info(L);
+	pduel->game_field->send_to(&oset, pduel->game_field->core.reason_effect, REASON_RULE, pduel->game_field->core.reason_player, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
 	uint32 adjust = TRUE;
 	if(lua_gettop(L) > 2) {
 		adjust = lua_toboolean(L, 3);


### PR DESCRIPTION
Requires https://github.com/Fluorohydride/ygopro/pull/2468

**Problem 1:**
All operations in YGOPro which make Xyz monster leave the field will handle xyz materials automatically,
but `Duel.Overlay` won't, you must do this in script, it is strange since if you want to overlay the xyz materials to the new monster (effect of _Number 75: Bamboozling Gossip Shadow_) you should use `Duel.Overlay` to the xyz materials ahead.
```lua
local og=tc:GetOverlayGroup()
if og:GetCount()>0 then
	Duel.SendtoGrave(og,REASON_RULE)
end
Duel.Overlay(c,Group.FromCards(tc))
```

**Problem 2:**
If we change the order of `Duel.SendtoGrave` and `Duel.Overlay` in the above script, the YGOPro client will crash, because it can't find the overlay handler to deattach from.

**Problem 3:**
If _Number 101: Silent Honor ARK_ select _Kashtira Arise-Heart_ to attach, the xyz materials of Arise-Heart should be sent to grave after Arise-Heart is attached, so them shouldn't be redirected to banish.
But now in YGOPro them will be banished because `Duel.SendtoGrave` is called before `Duel.Overlay`.