### PR TITLE
fix Duel.IsPlayerCanDiscardDeckAsCost

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -2969,14 +2969,19 @@ int32 field::is_player_can_discard_deck_as_cost(uint8 playerid, int32 count) {
 	card* topcard = player[playerid].list_main.back();
 	if((count == 1) && topcard->is_position(POS_FACEUP))
 		return topcard->is_capable_cost_to_grave(playerid);
-	bool cant_remove = !is_player_can_action(playerid, EFFECT_CANNOT_REMOVE);
+	bool cant_remove_s = !is_player_can_action(playerid, EFFECT_CANNOT_REMOVE);
+	bool cant_remove_o = !is_player_can_action(1 - playerid, EFFECT_CANNOT_REMOVE);
 	effect_set eset;
 	filter_field_effect(EFFECT_TO_GRAVE_REDIRECT, &eset);
 	for(int32 i = 0; i < eset.size(); ++i) {
 		uint32 redirect = eset[i]->get_value();
-		if((redirect & LOCATION_REMOVED) && (cant_remove || topcard->is_affected_by_effect(EFFECT_CANNOT_REMOVE)))
-			continue;
 		uint8 p = eset[i]->get_handler_player();
+		if(redirect & LOCATION_REMOVED) {
+			if(topcard->is_affected_by_effect(EFFECT_CANNOT_REMOVE))
+				continue;
+			if(cant_remove_s && (p == playerid) || cant_remove_o && (p != playerid))
+				continue;
+		}
 		if((p == playerid && eset[i]->s_range & LOCATION_DECK) || (p != playerid && eset[i]->o_range & LOCATION_DECK))
 			return FALSE;
 	}


### PR DESCRIPTION
_Chaos Hunter_ will only prevent 1 player to banish, so the [`is_player_can_action`](https://github.com/Fluorohydride/ygopro-core/pull/349) need to be checked separately.