### PR TITLE
fix event after end phase

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -3932,12 +3932,17 @@ int32 field::process_turn(uint16 step, uint8 turn_player) {
 		return FALSE;
 	}
 	case 18: {
+		if (core.new_fchain.size() || core.new_ochain.size())
+			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, 0, 0);
+		return FALSE;
+	}
+	case 19: {
 		raise_event((card*)0, EVENT_TURN_END, 0, 0, 0, turn_player, 0);
 		process_instant_event();
 		adjust_all();
 		return FALSE;
 	}
-	case 19: {
+	case 20: {
 		core.new_fchain.clear();
 		core.new_ochain.clear();
 		core.quick_f_chain.clear();


### PR DESCRIPTION
Fix: If one monster equips _Smoke Grenade of the Thief_ and _Rod of Silence - Kay'est_, which is negated by _Infinite Impermanence_, when the player ended the turn, _Rod of Silence - Kay'est_ get back in effect, _Smoke Grenade of the Thief_ is destroyed, but the grenade can't trigger effect.
replay (works after fixed): [2023-02-24 11-40-46.zip](https://github.com/Fluorohydride/ygopro-core/files/10820481/2023-02-24.11-40-46.zip)
