### PR TITLE
fix Card.IsCanBeDisabledByEffect()

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3434,8 +3434,10 @@ int32 card::is_affect_by_effect(effect* reason_effect) {
 		return FALSE;
 	return TRUE;
 }
-int32 card::is_can_be_disabled_by_effect(effect* reason_effect) {
-	if (is_status(STATUS_DISABLED))
+int32 card::is_can_be_disabled_by_effect(effect* reason_effect, bool is_monster_effect) {
+	if (is_monster_effect && is_status(STATUS_DISABLED))
+		return FALSE;
+	if(!is_monster_effect && !(get_type() & TYPE_TRAPMONSTER) && is_status(STATUS_DISABLED))
 		return FALSE;
 	if (is_affected_by_effect(EFFECT_CANNOT_DISABLE))
 		return FALSE;

--- a/card.h
+++ b/card.h
@@ -353,7 +353,7 @@ public:
 	int32 is_setable_mzone(uint8 playerid, uint8 ignore_count, effect* peffect, uint8 min_tribute, uint32 zone = 0x1f);
 	int32 is_setable_szone(uint8 playerid, uint8 ignore_fd = 0);
 	int32 is_affect_by_effect(effect* reason_effect);
-	int32 is_can_be_disabled_by_effect(effect* reason_effect);
+	int32 is_can_be_disabled_by_effect(effect* reason_effect, bool is_monster_effect);
 	int32 is_destructable();
 	int32 is_destructable_by_battle(card* pcard);
 	effect* check_indestructable_by_effect(effect* reason_effect, uint8 playerid);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -3004,7 +3004,10 @@ int32 scriptlib::card_is_can_be_disabled_by_effect(lua_State* L) {
 	check_param(L, PARAM_TYPE_EFFECT, 2);
 	card* pcard = *(card**)lua_touserdata(L, 1);
 	effect* peffect = *(effect**)lua_touserdata(L, 2);
-	lua_pushboolean(L, pcard->is_can_be_disabled_by_effect(peffect));
+	bool is_monster_effect = true;
+	if (lua_gettop(L) > 2)
+		is_monster_effect = lua_toboolean(L, 3);
+	lua_pushboolean(L, pcard->is_can_be_disabled_by_effect(peffect, is_monster_effect));
 	return 1;
 }
 int32 scriptlib::card_is_can_be_effect_target(lua_State *L) {


### PR DESCRIPTION
@mercury233 
Card.IsCanBeDisabledByEffect(e, true)
The check for negating monster effect, rejected if the target is `STATUS_DISABLED`.
(The default option)
Ex. 無限泡影

Card.IsCanBeDisabledByEffect(e, false)
The check for negating card effect, rejected if the target is not a Trap Monster and it is `STATUS_DISABLED`.
Ex. エルシャドール・アプカローネ