### PR TITLE
fix EFFECT_TO_GRAVE_REDIRECT_CB

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -4142,6 +4142,7 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 			core.sub_solving_event.push_back(e);
 			add_process(PROCESSOR_EXECUTE_OPERATION, 0, param->predirect, 0, pcard->current.controler, 0);
 		}
+		pcard->sendto_param.playerid |= 0x1u << 5;
 		++param->cvit;
 		core.units.begin()->step = 4;
 		return FALSE;
@@ -4222,7 +4223,8 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 		card_set equipings, overlays;
 		for(auto& pcard : targets->container) {
 			uint8 nloc = pcard->current.location;
-			if(pcard->equiping_target)
+			uint8 cb_redirected = pcard->sendto_param.playerid >> 5;
+			if(pcard->equiping_target && !cb_redirected)
 				pcard->unequip();
 			if(pcard->equiping_cards.size()) {
 				for(auto csit = pcard->equiping_cards.begin(); csit != pcard->equiping_cards.end();) {


### PR DESCRIPTION
If _Dragunity Javelin_ use its effect to equip to a monster, it will got `unequip` immediately.

Test puzzle:
```lua
Debug.SetAIName("AI")
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_PSEUDO_SHUFFLE+DUEL_SIMPLE_AI,5)
Debug.SetPlayerInfo(0,2000,0,0)
Debug.SetPlayerInfo(1,2000,0,0)

Debug.AddCard(21249921,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK)

Debug.AddCard(74701381,0,0,LOCATION_SZONE,2,POS_FACEDOWN)

Debug.AddCard(80549379,0,0,LOCATION_HAND,0,POS_FACEDOWN)

Debug.AddCard(83986578,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK)

Debug.ReloadFieldEnd()
aux.BeginPuzzle()
```
![image](https://user-images.githubusercontent.com/13391795/225238337-e209b49a-133e-43d0-97d1-dc629ce8f16c.png)

In this situation, Vajrayana won't be treated as has any card equipped.