### PR TITLE
fix Duel.CalculateDamage()

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -3305,7 +3305,7 @@ int32 field::process_damage_step(uint16 step, uint32 new_attack) {
 	case 3: {
 		core.attacker = (card*)core.units.begin()->peffect;
 		core.attack_target = (card*)core.units.begin()->ptarget;
-		if (core.attacker) {
+		if(core.attacker) {
 			core.attacker->set_status(STATUS_ATTACK_CANCELED, TRUE);
 			core.attacker->announce_count++;
 			core.attacker->announced_cards.addcard(core.attack_target);

--- a/processor.cpp
+++ b/processor.cpp
@@ -3305,8 +3305,12 @@ int32 field::process_damage_step(uint16 step, uint32 new_attack) {
 	case 3: {
 		core.attacker = (card*)core.units.begin()->peffect;
 		core.attack_target = (card*)core.units.begin()->ptarget;
-		if(core.attacker)
+		if (core.attacker) {
 			core.attacker->set_status(STATUS_ATTACK_CANCELED, TRUE);
+			core.attacker->announce_count++;
+			core.attacker->announced_cards.addcard(core.attack_target);
+			attack_all_target_check();
+		}
 		if(core.attack_target)
 			core.attack_target->set_status(STATUS_ATTACK_CANCELED, TRUE);
 		core.effect_damage_step = 0;


### PR DESCRIPTION
# Problem
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=6373&request_locale=ja
ミュータント・ハイブレイン
Mutant Mindmaster
 ①：相手フィールドにモンスターが２体以上存在する場合、このカードの攻撃宣言時に、相手フィールドの表側攻撃表示モンスター１体を対象として発動できる。その相手の表側攻撃表示モンスター１体のコントロールをバトルフェイズ終了時まで得る。対象のモンスターはこのターン直接攻撃できず、攻撃可能な場合、相手モンスター１体を攻撃対象として選び、ダメージ計算を行う。 

■「ミュータント・ハイブレイン」の効果が適用された場合、コントロールを得たモンスターが攻撃可能であれば、攻撃対象を選び、ダメージステップに入ります。（戦闘の巻き戻しは発生しません。） 

If `Mutant Mindmaster` activates this effect, the rollback will not occur, and it cannot attack again.

[bug_mutant.zip](https://github.com/Fluorohydride/ygopro-core/files/11279966/bug_mutant.zip)
but_mutant.yrp
Mutant Mindmaster attacks (1st time)
Mutant Mindmaster activates 1st effect
Mutant Mindmaster attacks (2nd time)

# Reason
I think the reason is `core.attacker->announce_count` does not increase.

Now:
`announce_count` is added in

process_battle_command()
step 7
https://github.com/Fluorohydride/ygopro-core/blob/bf2339ce96152b6825c5a4064ac669def6caf976/processor.cpp#L2657

step 11
https://github.com/Fluorohydride/ygopro-core/blob/bf2339ce96152b6825c5a4064ac669def6caf976/processor.cpp#L2731

step 13
https://github.com/Fluorohydride/ygopro-core/blob/bf2339ce96152b6825c5a4064ac669def6caf976/processor.cpp#L2763


If the script uses `Duel.CalculateDamage()`, `core.attacker->announce_count` will not increase.


# Solution
Increase `core.attacker->announce_count`  in the end of  `process_damage_step()`.

Edit:
Update the status of attacker like `Duel.ChangeAttacker()`
https://github.com/Fluorohydride/ygopro-core/blob/bf2339ce96152b6825c5a4064ac669def6caf976/libduel.cpp#L1589


# Test
correct_mutant.yrp
Mutant Mindmaster attacks (1st time)
Mutant Mindmaster activates 1st effect
(Mutant Mindmaster cannot attack now)

