### PR TITLE
fix Duel.SwapDeckAndGrave

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -1075,6 +1075,7 @@ void field::swap_deck_and_grave(uint8 playerid) {
 		pcard->apply_field_effect();
 		pcard->enable_field_effect(true);
 		pcard->reset(RESET_TODECK, RESET_EVENT);
+		pcard->set_status(STATUS_PROC_COMPLETE, FALSE);
 	}
 	for(auto& pcard : ex) {
 		pcard->current.position = POS_FACEDOWN_DEFENSE;
@@ -1085,6 +1086,7 @@ void field::swap_deck_and_grave(uint8 playerid) {
 		pcard->apply_field_effect();
 		pcard->enable_field_effect(true);
 		pcard->reset(RESET_TODECK, RESET_EVENT);
+		pcard->set_status(STATUS_PROC_COMPLETE, FALSE);
 	}
 	player[playerid].list_extra.insert(player[playerid].list_extra.end() - player[playerid].extra_p_count, ex.begin(), ex.end());
 	reset_sequence(playerid, LOCATION_GRAVE);


### PR DESCRIPTION
If a ritual monster is summoned and sent to grave, it will has `STATUS_PROC_COMPLETE`, but if it is returned to deck by the effect of _Exchange of the Spirit_, and sent to grave again, it shouldn't has that status.

Test puzzle: [test_SwapDeckAndGrave.zip](https://github.com/Fluorohydride/ygopro-core/files/11474929/test_SwapDeckAndGrave.zip)
