### PR TITLE
update EFFECT_INDESTRUCTABLE_COUNT

### DIFF
--- a/field.h
+++ b/field.h
@@ -252,6 +252,7 @@ struct processor {
 	card_set operated_set;
 	card_set discarded_set;
 	card_set destroy_canceled;
+	card_set indestructable_count_set;
 	card_set delayed_enable_set;
 	card_set set_group_pre_set;
 	card_set set_group_set;


### PR DESCRIPTION
@mercury233 
# Problem
神碑の翼フギン
②：このカード以外の自分フィールドのカードが効果で破壊される場合、代わりにフィールドのこのカードを除外できる。

[test_runick.zip](https://github.com/Fluorohydride/ygopro-core/files/11510076/test_runick.zip)
Single mode script
Special Summon 神碑の翼フギン 
Apply まどろみの神碑
Summon Monster X
Activate ブラック・ホール

Now: The 2nd effect of 神碑の翼フギン can apply.
Correct: The 2nd effect of 神碑の翼フギン cannot apply.

 monsters with EFFECT_INDESTRUCTABLE_COUNT cannot apply EFFECT_DESTROY_REPLACE

# Solution
Now monsters with EFFECT_INDESTRUCTABLE_COUNT will be put in `core.indestructable_count_set`.
Their `STATUS_DESTROY_CONFIRMED` will be erased after EFFECT_DESTROY_REPLACE checking.

# Reference
https://ocg-rule.readthedocs.io/zh_CN/latest/c06/2023.html#id60
23/3/19
我方场上存在「神碑之翼 胡基」「神碑之泉」的状况，对方「魔女的一击」的效果处理时，「神碑之翼 胡基」也是确定被破坏的卡，不能适用②效果。此外，即使「神碑之翼 胡基」已经适用了「微睡的神碑」的效果，不会被这次效果破坏的场合，也不能适用②效果。
我方场上存在「神碑之翼 胡基」「神碑之泉」，且「神碑之翼 胡基」适用了「禁忌的圣衣」的效果的状况，对方「裁决之龙」的效果处理时，「神碑之翼 胡基」可以适用②效果，结果「神碑之泉」不被这个效果破坏，留在场上。

https://ocg-rule.readthedocs.io/zh_CN/latest/c06/2023.html#id61
23/3/21
我方场上存在「神碑之翼 胡基」「神碑之翼 穆宁」和宣言了魔法师族的「DNA改造手术」，对方发动「黑洞」的场合，如果「神碑之翼 胡基」已经适用了「禁忌的圣衣」的效果，那么可以适用『这张卡以外的自己场上的卡被效果破坏的场合，可以作为代替把场上的这张卡除外』效果，结果「神碑之翼 穆宁」不被破坏；如果「神碑之翼 胡基」适用的是「闪珖龙 星尘」「我我我护盾」这样的效果，不能适用②效果，结果自身不被这次效果破坏，「神碑之翼 穆宁」被破坏。

我方场上存在因「复制梁龙」的效果，变成魔法师族的「沙漠守护者」和1只昆虫族怪兽，对方发动「黑洞」的场合，如果「沙漠守护者」已经适用了「闪珖龙 星尘」「我我我护盾」这样的效果，也不能适用自身『自己场上存在的昆虫族怪兽被破坏的场合，可以作为代替把这张卡破坏』效果，结果那只昆虫族怪兽被「黑洞」的效果破坏。

我方场上存在「魔界特派员 死亡主播」和1只恶魔族怪兽，对方发动「最终战争」的场合，如果那只恶魔族怪兽已经适用了「禁忌的圣衣」的效果，那么可以适用「魔界特派员 死亡主播」的①效果，作为代替解放这只恶魔族怪兽，让自身不被破坏；如果那只恶魔族怪兽已经适用了「微睡的神碑」的效果，那么不能适用「魔界特派员 死亡主播」的①效果，结果「魔界特派员 死亡主播」被破坏，那只恶魔族怪兽不被这次破坏，留在场上。

我方场上存在「盾徽配列场」和1只机械族X怪兽，对方发动「最终战争」的场合，如果「盾徽配列场」已经适用了「黑魔导强化」的『自己场上的魔法·陷阱卡不会被对方的效果破坏』效果，那么可以适用③效果，把自身送去墓地作为代替，让那只机械族X怪兽不被破坏；如果「盾徽配列场」已经适用了「纯爱妖精快乐回忆」的『那张卡直到下个回合的结束时只有1次不会被效果破坏』效果，不能适用③效果，结果只有那只机械族X怪兽被破坏。


