### PR TITLE
update interpreter::interpreter()

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -21,28 +21,15 @@ interpreter::interpreter(duel* pd): coroutines(256) {
 	no_action = 0;
 	call_depth = 0;
 	//Initial
-	luaL_openlibs(lua_state);
-	lua_pushnil(lua_state);
-	lua_setglobal(lua_state, "io");
-	lua_pushnil(lua_state);
-	lua_setglobal(lua_state, "os");
-	lua_pushnil(lua_state);
-	lua_setglobal(lua_state, "package");
-	lua_pushnil(lua_state);
-	lua_setglobal(lua_state, "debug");
-	lua_pushnil(lua_state);
-	lua_setglobal(lua_state, "coroutine");
-	luaL_getsubtable(lua_state, LUA_REGISTRYINDEX, "_LOADED");
-	lua_pushnil(lua_state);
-	lua_setfield(lua_state, -2, "io");
-	lua_pushnil(lua_state);
-	lua_setfield(lua_state, -2, "os");
-	lua_pushnil(lua_state);
-	lua_setfield(lua_state, -2, "package");
-	lua_pushnil(lua_state);
-	lua_setfield(lua_state, -2, "debug");
-	lua_pushnil(lua_state);
-	lua_setfield(lua_state, -2, "coroutine");
+	luaL_requiref(lua_state, "base", luaopen_base, 0);
+	lua_pop(lua_state, 1);
+	luaL_requiref(lua_state, "string", luaopen_string, 1);
+	lua_pop(lua_state, 1);
+	luaL_requiref(lua_state, "utf8", luaopen_utf8, 1);
+	lua_pop(lua_state, 1);
+	luaL_requiref(lua_state, "table", luaopen_table, 1);
+	lua_pop(lua_state, 1);
+	luaL_requiref(lua_state, "math", luaopen_math, 1);
 	lua_pop(lua_state, 1);
 	//open all libs
 	scriptlib::open_cardlib(lua_state);


### PR DESCRIPTION
# Problem
https://www.lua.org/manual/5.4/manual.html#6
> Alternatively, the host program can open them individually by using [luaL_requiref](https://www.lua.org/manual/5.4/manual.html#luaL_requiref) to call luaopen_base (for the basic library), luaopen_package (for the package library), luaopen_coroutine (for the coroutine library), luaopen_string (for the string library), luaopen_utf8 (for the UTF-8 library), luaopen_table (for the table library), luaopen_math (for the mathematical library), luaopen_io (for the I/O library), luaopen_os (for the operating system library), and luaopen_debug (for the debug library). These functions are declared in lualib.h.

https://www.lua.org/manual/5.4/manual.html#luaL_requiref
void luaL_requiref (lua_State *L, const char *modname,  lua_CFunction openf, int glb);
> If package.loaded[modname] is not true, calls the function openf with the string modname as an argument and sets the call result to package.loaded[modname], as if that function has been called through require.

> If glb is true, also stores the module into the global modname.

> Leaves a copy of the module on the stack. 

If we do not want to use libraries like `io`, `os`, we can open necessary libraries.

# Solution
Now it use `luaL_requiref()` to  open necessary libraries.
