### PR TITLE
add EFFECT_REPLACE_DAMAGE

### DIFF
--- a/effect.h
+++ b/effect.h
@@ -471,6 +471,7 @@ inline effect_flag operator|(effect_flag flag1, effect_flag flag2)
 #define EFFECT_LIMIT_SPECIAL_SUMMON_POSITION	368
 #define EFFECT_TUNER					369
 #define EFFECT_KAISER_COLOSSEUM			370
+#define EFFECT_REPLACE_DAMAGE			371
 
 //#define EVENT_STARTUP		1000
 #define EVENT_FLIP			1001

--- a/operations.cpp
+++ b/operations.cpp
@@ -500,6 +500,19 @@ int32 field::damage(uint16 step, effect* reason_effect, uint32 reason, uint8 rea
 			if(val == 0)
 				return TRUE;
 		}
+		eset.clear();
+		filter_player_effect(playerid, EFFECT_REPLACE_DAMAGE, &eset);
+		for (int32 i = 0; i < eset.size(); ++i) {
+			pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
+			pduel->lua->add_param(val, PARAM_TYPE_INT);
+			pduel->lua->add_param(reason, PARAM_TYPE_INT);
+			pduel->lua->add_param(reason_player, PARAM_TYPE_INT);
+			pduel->lua->add_param(reason_card, PARAM_TYPE_CARD);
+			val = eset[i]->get_value(5);
+			returns.ivalue[0] = val;
+			if (val == 0)
+				return TRUE;
+		}
 		core.units.begin()->arg3 = val;
 		if(is_step) {
 			core.units.begin()->step = 9;


### PR DESCRIPTION
@mercury233 
# Problem
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=21280&keyword=&tag=-1&request_locale=ja
There are 2 types of modifying damage (from high to low priority):
- Change damage to X
- Replace damage to some action (Black-Winged Dragon, Defect Compiler)

If the damage is changed into 0, replacing damage will not occur.

# Solution
add EFFECT_REPLACE_DAMAGE





