### PR TITLE
update Duel.TossCoin()

### DIFF
--- a/field.h
+++ b/field.h
@@ -20,6 +20,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#define MAX_COIN_COUNT	20
+
 class card;
 struct card_data;
 class duel;
@@ -315,7 +317,9 @@ struct processor {
 	uint32 set_group_used_zones;
 	uint8 set_group_seq[7];
 	uint8 dice_result[5];
-	uint8 coin_result[5];
+	uint8 coin_result[MAX_COIN_COUNT];
+	int32 coin_count;
+
 	uint8 to_bp;
 	uint8 to_m2;
 	uint8 to_ep;
@@ -361,7 +365,7 @@ struct processor {
 		limit_tuner(nullptr), limit_syn(nullptr), limit_syn_minc(0), limit_syn_maxc(0), limit_xyz(nullptr), limit_xyz_minc(0), limit_xyz_maxc(0), limit_link(nullptr), limit_link_card(nullptr),
 		limit_link_minc(0), limit_link_maxc(0), not_material(FALSE), attack_cancelable(FALSE), attack_rollback(FALSE), effect_damage_step(0), battle_damage{ 0 }, summon_count{ 0 }, extra_summon{ FALSE },
 		spe_effect{ 0 }, duel_options(0), duel_rule(0), copy_reset(0), copy_reset_count(0), last_control_changed_id(0), set_group_used_zones(0), set_group_seq{ 0 }, dice_result{ 0 }, coin_result{ 0 },
-		to_bp(FALSE), to_m2(FALSE), to_ep(FALSE), skip_m2(FALSE), chain_attack(FALSE), chain_attacker_id(0), chain_attack_target(nullptr), attack_player(PLAYER_NONE), selfdes_disabled(FALSE),
+		coin_count(0), to_bp(FALSE), to_m2(FALSE), to_ep(FALSE), skip_m2(FALSE), chain_attack(FALSE), chain_attacker_id(0), chain_attack_target(nullptr), attack_player(PLAYER_NONE), selfdes_disabled(FALSE),
 		overdraw{ FALSE }, check_level(0), shuffle_check_disabled(FALSE), shuffle_hand_check{ FALSE }, shuffle_deck_check{ FALSE }, deck_reversed(FALSE), remove_brainwashing(FALSE), flip_delayed(FALSE),
 		damage_calculated(FALSE), hand_adjusted(FALSE), summon_state_count{ 0 }, normalsummon_state_count{ 0 }, flipsummon_state_count{ 0 }, spsummon_state_count{ 0 }, attack_state_count{ 0 },
 		battle_phase_count{ 0 }, battled_count{ 0 }, phase_action(FALSE), hint_timing{ 0 }, current_player(PLAYER_NONE), conti_player(PLAYER_NONE) {}
@@ -629,7 +633,7 @@ public:
 	int32 select_xyz_material(int16 step, uint8 playerid, uint32 lv, card* pcard, int32 min, int32 max);
 	int32 select_release_cards(int16 step, uint8 playerid, uint8 cancelable, int32 min, int32 max);
 	int32 select_tribute_cards(int16 step, card* target, uint8 playerid, uint8 cancelable, int32 min, int32 max, uint8 toplayer, uint32 zone);
-	int32 toss_coin(uint16 step, effect* reason_effect, uint8 reason_player, uint8 playerid, uint8 count);
+	int32 toss_coin(uint16 step, effect* reason_effect, uint8 reason_player, uint8 playerid, int32 count);
 	int32 toss_dice(uint16 step, effect* reason_effect, uint8 reason_player, uint8 playerid, uint8 count1, uint8 count2);
 	int32 rock_paper_scissors(uint16 step, uint8 repeat);
 

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3970,14 +3970,14 @@ int32 scriptlib::duel_toss_coin(lua_State * L) {
 	duel* pduel = interpreter::get_duel_info(L);
 	int32 playerid = (int32)lua_tointeger(L, 1);
 	int32 count = (int32)lua_tointeger(L, 2);
-	if((playerid != 0 && playerid != 1) || count <= 0)
+	if((playerid != 0 && playerid != 1) || count == 0 || count < -1)
 		return 0;
 	if(count > MAX_COIN_COUNT)
 		count = MAX_COIN_COUNT;
 	pduel->game_field->add_process(PROCESSOR_TOSS_COIN, 0, pduel->game_field->core.reason_effect, 0, (pduel->game_field->core.reason_player << 16) + playerid, count);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
-		int32 count = (int32)lua_tointeger(L, 2);
+		int32 count = pduel->game_field->core.coin_count;
 		for(int32 i = 0; i < count; ++i)
 			lua_pushinteger(L, pduel->game_field->core.coin_result[i]);
 		return count;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3972,8 +3972,8 @@ int32 scriptlib::duel_toss_coin(lua_State * L) {
 	int32 count = (int32)lua_tointeger(L, 2);
 	if((playerid != 0 && playerid != 1) || count <= 0)
 		return 0;
-	if(count > 5)
-		count = 5;
+	if(count > MAX_COIN_COUNT)
+		count = MAX_COIN_COUNT;
 	pduel->game_field->add_process(PROCESSOR_TOSS_COIN, 0, pduel->game_field->core.reason_effect, 0, (pduel->game_field->core.reason_player << 16) + playerid, count);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
@@ -4024,9 +4024,9 @@ int32 scriptlib::duel_rock_paper_scissors(lua_State * L) {
 }
 int32 scriptlib::duel_get_coin_result(lua_State * L) {
 	duel* pduel = interpreter::get_duel_info(L);
-	for(int32 i = 0; i < 5; ++i)
+	for(int32 i = 0; i < pduel->game_field->core.coin_count; ++i)
 		lua_pushinteger(L, pduel->game_field->core.coin_result[i]);
-	return 5;
+	return pduel->game_field->core.coin_count;
 }
 int32 scriptlib::duel_get_dice_result(lua_State * L) {
 	duel* pduel = interpreter::get_duel_info(L);
@@ -4037,7 +4037,7 @@ int32 scriptlib::duel_get_dice_result(lua_State * L) {
 int32 scriptlib::duel_set_coin_result(lua_State * L) {
 	duel* pduel = interpreter::get_duel_info(L);
 	int32 res;
-	for(int32 i = 0; i < 5; ++i) {
+	for(int32 i = 0; i < MAX_COIN_COUNT; ++i) {
 		res = (int32)lua_tointeger(L, i + 1);
 		if(res != 0 && res != 1)
 			res = 0;

--- a/operations.cpp
+++ b/operations.cpp
@@ -6312,6 +6312,8 @@ int32 field::select_tribute_cards(int16 step, card* target, uint8 playerid, uint
 	return TRUE;
 }
 int32 field::toss_coin(uint16 step, effect * reason_effect, uint8 reason_player, uint8 playerid, int32 count) {
+	if (count == 0 || count < -1)
+		return TRUE;
 	if (count > MAX_COIN_COUNT)
 		count = MAX_COIN_COUNT;
 	switch(step) {
@@ -6337,13 +6339,33 @@ int32 field::toss_coin(uint16 step, effect * reason_effect, uint8 reason_player,
 			}
 		}
 		if(!peffect) {
-			pduel->write_buffer8(MSG_TOSS_COIN);
-			pduel->write_buffer8(playerid);
-			pduel->write_buffer8((uint8)count);
-			core.coin_count = count;
-			for(int32 i = 0; i < count; ++i) {
-				core.coin_result[i] = pduel->get_next_integer(0, 1);
-				pduel->write_buffer8(core.coin_result[i]);
+			if (count > 0) {
+				pduel->write_buffer8(MSG_TOSS_COIN);
+				pduel->write_buffer8(playerid);
+				pduel->write_buffer8((uint8)count);
+				core.coin_count = count;
+				for (int32 i = 0; i < count; ++i) {
+					core.coin_result[i] = pduel->get_next_integer(0, 1);
+					pduel->write_buffer8(core.coin_result[i]);
+				}
+			}
+			else if (count == -1) {
+				core.coin_count = 0;
+				for (int32 i = 0; i < MAX_COIN_COUNT; ++i) {
+					core.coin_result[i] = pduel->get_next_integer(0, 1);
+					if (!core.coin_result[i]) {
+						core.coin_count = i + 1;
+						break;
+					}
+				}
+				if (!core.coin_count)
+					core.coin_count == MAX_COIN_COUNT;
+				pduel->write_buffer8(MSG_TOSS_COIN);
+				pduel->write_buffer8(playerid);
+				pduel->write_buffer8((uint8)core.coin_count);
+				for (int32 i = 0; i < core.coin_count; ++i) {
+					pduel->write_buffer8(core.coin_result[i]);
+				}
 			}
 			raise_event((card*)0, EVENT_TOSS_COIN_NEGATE, reason_effect, 0, reason_player, playerid, count);
 			process_instant_event();
@@ -6355,7 +6377,7 @@ int32 field::toss_coin(uint16 step, effect * reason_effect, uint8 reason_player,
 		return FALSE;
 	}
 	case 1: {
-		raise_event((card*)0, EVENT_TOSS_COIN, reason_effect, 0, reason_player, playerid, count);
+		raise_event((card*)0, EVENT_TOSS_COIN, reason_effect, 0, reason_player, playerid, core.coin_count);
 		process_instant_event();
 		return TRUE;
 	}

--- a/operations.cpp
+++ b/operations.cpp
@@ -6311,7 +6311,9 @@ int32 field::select_tribute_cards(int16 step, card* target, uint8 playerid, uint
 	}
 	return TRUE;
 }
-int32 field::toss_coin(uint16 step, effect * reason_effect, uint8 reason_player, uint8 playerid, uint8 count) {
+int32 field::toss_coin(uint16 step, effect * reason_effect, uint8 reason_player, uint8 playerid, int32 count) {
+	if (count > MAX_COIN_COUNT)
+		count = MAX_COIN_COUNT;
 	switch(step) {
 	case 0: {
 		effect_set eset;
@@ -6323,7 +6325,7 @@ int32 field::toss_coin(uint16 step, effect * reason_effect, uint8 reason_player,
 		e.reason = 0;
 		e.reason_effect = reason_effect;
 		e.reason_player = reason_player;
-		for(uint8 i = 0; i < 5; ++i)
+		for(int32 i = 0; i < MAX_COIN_COUNT; ++i)
 			core.coin_result[i] = 0;
 		auto pr = effects.continuous_effect.equal_range(EFFECT_TOSS_COIN_REPLACE);
 		for(auto eit = pr.first; eit != pr.second;) {
@@ -6337,7 +6339,8 @@ int32 field::toss_coin(uint16 step, effect * reason_effect, uint8 reason_player,
 		if(!peffect) {
 			pduel->write_buffer8(MSG_TOSS_COIN);
 			pduel->write_buffer8(playerid);
-			pduel->write_buffer8(count);
+			pduel->write_buffer8((uint8)count);
+			core.coin_count = count;
 			for(int32 i = 0; i < count; ++i) {
 				core.coin_result[i] = pduel->get_next_integer(0, 1);
 				pduel->write_buffer8(core.coin_result[i]);


### PR DESCRIPTION
@mercury233 
update the tossing coin function

- add `MAX_COIN_COUNT`
The max count of one coin toss process.
Now it is 20.
每次投擲硬幣的最大次數，目前是20

- add `core.coin_count`
Now Duel.TossCoin, Duel.GetCoinResult will only return the coin result, not the whole array.
Duel.TossCoin, Duel.GetCoinResult 現在只會傳回結果而不是整個陣列

- Duel.TossCoin(), `count`=-1
Toss until tail occurs
投擲硬幣直到反面出現
