### PR TITLE
fix chain attack

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -2477,7 +2477,7 @@ int32 field::get_attack_target(card* pcard, card_vector* v, uint8 chain_attack, 
 		return atype;
 	if((mcount == 0 || pcard->is_affected_by_effect(EFFECT_DIRECT_ATTACK) || core.attack_player)
 		&& !pcard->is_affected_by_effect(EFFECT_CANNOT_DIRECT_ATTACK)
-		&& !(extra_count_m && pcard->announce_count > extra_count)
+		&& !(!chain_attack && extra_count_m && pcard->announce_count > extra_count)
 		&& !(chain_attack && core.chain_attack_target))
 		pcard->direct_attackable = 1;
 	return atype;


### PR DESCRIPTION
Mail:
>Q.
バトルフェイズ開始時に自分で「アクションマジック－ダブル・バンキング」を発動し、その後「白闘気白鯨」で戦闘して相手フィールド上の最後のモンスターを破壊した場合、「アクションマジック－ダブル・バンキング」の効果を適用して再度攻撃して直接攻撃することはできますか？
A.
ご質問の場合、「白闘気白鯨」はプレイヤーに直接攻撃できます。

Currently in YGOPro, monster which has "extra attack on monster" can't direct attack again with chain attack effect.