### PR TITLE
update release functions

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3584,7 +3584,7 @@ int32 card::is_releasable_by_summon(uint8 playerid, card *pcard) {
 		return FALSE;
 	return TRUE;
 }
-int32 card::is_releasable_by_nonsummon(uint8 playerid) {
+int32 card::is_releasable_by_nonsummon(uint8 playerid, uint32 reason) {
 	if(is_status(STATUS_SUMMONING))
 		return FALSE;
 	if(overlay_target)
@@ -3593,7 +3593,7 @@ int32 card::is_releasable_by_nonsummon(uint8 playerid) {
 		return FALSE;
 	if((current.location == LOCATION_HAND) && (data.type & (TYPE_SPELL | TYPE_TRAP)))
 		return FALSE;
-	if(!pduel->game_field->is_player_can_release(playerid, this))
+	if(!pduel->game_field->is_player_can_release(playerid, this, reason))
 		return FALSE;
 	if(is_affected_by_effect(EFFECT_UNRELEASABLE_NONSUM))
 		return FALSE;

--- a/card.cpp
+++ b/card.cpp
@@ -3576,7 +3576,7 @@ int32 card::is_releasable_by_summon(uint8 playerid, card *pcard) {
 		return FALSE;
 	if(current.location & (LOCATION_GRAVE | LOCATION_REMOVED))
 		return FALSE;
-	if(!pduel->game_field->is_player_can_release(playerid, this))
+	if(!pduel->game_field->is_player_can_release(playerid, this, REASON_SUMMON))
 		return FALSE;
 	if(is_affected_by_effect(EFFECT_UNRELEASABLE_SUM, pcard))
 		return FALSE;

--- a/card.h
+++ b/card.h
@@ -361,7 +361,7 @@ public:
 	int32 is_removeable(uint8 playerid, uint8 pos, uint32 reason);
 	int32 is_removeable_as_cost(uint8 playerid, uint8 pos);
 	int32 is_releasable_by_summon(uint8 playerid, card* pcard);
-	int32 is_releasable_by_nonsummon(uint8 playerid);
+	int32 is_releasable_by_nonsummon(uint8 playerid, uint32 reason = 0u);
 	int32 is_releasable_by_effect(uint8 playerid, effect* reason_effect);
 	int32 is_capable_send_to_grave(uint8 playerid);
 	int32 is_capable_send_to_hand(uint8 playerid);

--- a/card.h
+++ b/card.h
@@ -361,7 +361,7 @@ public:
 	int32 is_removeable(uint8 playerid, uint8 pos, uint32 reason);
 	int32 is_removeable_as_cost(uint8 playerid, uint8 pos);
 	int32 is_releasable_by_summon(uint8 playerid, card* pcard);
-	int32 is_releasable_by_nonsummon(uint8 playerid, uint32 reason = 0u);
+	int32 is_releasable_by_nonsummon(uint8 playerid, uint32 reason);
 	int32 is_releasable_by_effect(uint8 playerid, effect* reason_effect);
 	int32 is_capable_send_to_grave(uint8 playerid);
 	int32 is_capable_send_to_hand(uint8 playerid);

--- a/common.h
+++ b/common.h
@@ -165,6 +165,8 @@ struct card_sort {
 #define REASON_REVEAL		0x8000000	//
 #define REASON_LINK			0x10000000	//
 #define REASON_LOST_OVERLAY	0x20000000	//
+#define REASON_MAINTENANCE	0x40000000	//
+#define REASON_ACTION		0x80000000	//
 
 //Status
 #define STATUS_DISABLED				0x0001	//

--- a/field.cpp
+++ b/field.cpp
@@ -1697,8 +1697,10 @@ effect* field::is_player_affected_by_effect(uint8 playerid, uint32 code) {
 }
 int32 field::get_release_list(uint8 playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason) {
 	uint32 rcount = 0;
+	effect* re = core.reason_effect;
 	for(auto& pcard : player[playerid].list_mzone) {
 		if(pcard && pcard != exc && !(exg && exg->has_card(pcard)) && pcard->is_releasable_by_nonsummon(playerid, reason)
+		        && (reason != REASON_EFFECT || pcard->is_releasable_by_effect(playerid, re))
 		        && (!use_con || pduel->lua->check_matching(pcard, fun, exarg))) {
 			if(release_list)
 				release_list->insert(pcard);
@@ -1709,6 +1711,7 @@ int32 field::get_release_list(uint8 playerid, card_set* release_list, card_set* 
 	if(use_hand) {
 		for(auto& pcard : player[playerid].list_hand) {
 			if(pcard && pcard != exc && !(exg && exg->has_card(pcard)) && pcard->is_releasable_by_nonsummon(playerid, reason)
+				    && (reason != REASON_EFFECT || pcard->is_releasable_by_effect(playerid, re))
 			        && (!use_con || pduel->lua->check_matching(pcard, fun, exarg))) {
 				if(release_list)
 					release_list->insert(pcard);
@@ -1720,7 +1723,9 @@ int32 field::get_release_list(uint8 playerid, card_set* release_list, card_set* 
 	int32 ex_oneof_max = 0;
 	for(auto& pcard : player[1 - playerid].list_mzone) {
 		if(pcard && pcard != exc && !(exg && exg->has_card(pcard)) && (pcard->is_position(POS_FACEUP) || !use_con)
-		        && pcard->is_releasable_by_nonsummon(playerid, reason) && (!use_con || pduel->lua->check_matching(pcard, fun, exarg))) {
+		        && pcard->is_releasable_by_nonsummon(playerid, reason)
+			    && (reason != REASON_EFFECT || pcard->is_releasable_by_effect(playerid, re))
+			    && (!use_con || pduel->lua->check_matching(pcard, fun, exarg))) {
 			pcard->release_param = 1;
 			if(pcard->is_affected_by_effect(EFFECT_EXTRA_RELEASE)) {
 				if(ex_list)
@@ -1731,7 +1736,7 @@ int32 field::get_release_list(uint8 playerid, card_set* release_list, card_set* 
 				if(!peffect || (peffect->is_flag(EFFECT_FLAG_COUNT_LIMIT) && peffect->count_limit == 0))
 					continue;
 				pduel->lua->add_param(core.reason_effect, PARAM_TYPE_EFFECT);
-				pduel->lua->add_param(REASON_COST, PARAM_TYPE_INT);
+				pduel->lua->add_param(reason, PARAM_TYPE_INT);
 				pduel->lua->add_param(core.reason_player, PARAM_TYPE_INT);
 				if(!peffect->check_value_condition(3))
 					continue;

--- a/field.cpp
+++ b/field.cpp
@@ -1857,7 +1857,7 @@ int32 field::get_draw_count(uint8 playerid) {
 void field::get_ritual_material(uint8 playerid, effect* peffect, card_set* material, uint8 no_level) {
 	for(auto& pcard : player[playerid].list_mzone) {
 		if(pcard && pcard->is_affect_by_effect(peffect)
-		        && pcard->is_releasable_by_nonsummon(playerid) && pcard->is_releasable_by_effect(playerid, peffect)
+		        && pcard->is_releasable_by_nonsummon(playerid, REASON_EFFECT) && pcard->is_releasable_by_effect(playerid, peffect)
 				&& (no_level || pcard->get_level() > 0))
 			material->insert(pcard);
 		if(pcard && pcard->is_affected_by_effect(EFFECT_OVERLAY_RITUAL_MATERIAL))
@@ -1868,12 +1868,12 @@ void field::get_ritual_material(uint8 playerid, effect* peffect, card_set* mater
 	for(auto& pcard : player[1 - playerid].list_mzone) {
 		if(pcard && pcard->is_affect_by_effect(peffect)
 		        && pcard->is_affected_by_effect(EFFECT_EXTRA_RELEASE) && pcard->is_position(POS_FACEUP)
-		        && pcard->is_releasable_by_nonsummon(playerid) && pcard->is_releasable_by_effect(playerid, peffect)
+		        && pcard->is_releasable_by_nonsummon(playerid, REASON_EFFECT) && pcard->is_releasable_by_effect(playerid, peffect)
 				&& (no_level || pcard->get_level() > 0))
 			material->insert(pcard);
 	}
 	for(auto& pcard : player[playerid].list_hand)
-		if((pcard->data.type & TYPE_MONSTER) && pcard->is_releasable_by_nonsummon(playerid))
+		if((pcard->data.type & TYPE_MONSTER) && pcard->is_releasable_by_nonsummon(playerid, REASON_EFFECT))
 			material->insert(pcard);
 	for(auto& pcard : player[playerid].list_grave)
 		if((pcard->data.type & TYPE_MONSTER)

--- a/field.h
+++ b/field.h
@@ -447,8 +447,8 @@ public:
 	int32 filter_field_card(uint8 self, uint32 location, uint32 location2, group* pgroup);
 	effect* is_player_affected_by_effect(uint8 playerid, uint32 code);
 
-	int32 get_release_list(uint8 playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg);
-	int32 check_release_list(uint8 playerid, int32 count, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg);
+	int32 get_release_list(uint8 playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason = 0u);
+	int32 check_release_list(uint8 playerid, int32 count, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason = 0u);
 	int32 get_summon_release_list(card* target, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, group* mg = NULL, uint32 ex = 0, uint32 releasable = 0xff00ff, uint32 pos = 0x1);
 	int32 get_summon_count_limit(uint8 playerid);
 	int32 get_draw_count(uint8 playerid);
@@ -510,7 +510,7 @@ public:
 	int32 is_player_can_flipsummon(uint8 playerid, card* pcard);
 	int32 is_player_can_spsummon_monster(uint8 playerid, uint8 toplayer, uint8 sumpos, uint32 sumtype, card_data* pdata);
 	int32 is_player_can_spsummon_count(uint8 playerid, uint32 count);
-	int32 is_player_can_release(uint8 playerid, card* pcard);
+	int32 is_player_can_release(uint8 playerid, card* pcard, uint32 reason = 0u);
 	int32 is_player_can_place_counter(uint8 playerid, card* pcard, uint16 countertype, uint16 count);
 	int32 is_player_can_remove_counter(uint8 playerid, card* pcard, uint8 s, uint8 o, uint16 countertype, uint16 count, uint32 reason);
 	int32 is_player_can_remove_overlay_card(uint8 playerid, card* pcard, uint8 s, uint8 o, uint16 count, uint32 reason);

--- a/field.h
+++ b/field.h
@@ -447,8 +447,8 @@ public:
 	int32 filter_field_card(uint8 self, uint32 location, uint32 location2, group* pgroup);
 	effect* is_player_affected_by_effect(uint8 playerid, uint32 code);
 
-	int32 get_release_list(uint8 playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason = 0u);
-	int32 check_release_list(uint8 playerid, int32 count, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason = 0u);
+	int32 get_release_list(uint8 playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason);
+	int32 check_release_list(uint8 playerid, int32 count, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason);
 	int32 get_summon_release_list(card* target, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, group* mg = NULL, uint32 ex = 0, uint32 releasable = 0xff00ff, uint32 pos = 0x1);
 	int32 get_summon_count_limit(uint8 playerid);
 	int32 get_draw_count(uint8 playerid);

--- a/field.h
+++ b/field.h
@@ -510,7 +510,7 @@ public:
 	int32 is_player_can_flipsummon(uint8 playerid, card* pcard);
 	int32 is_player_can_spsummon_monster(uint8 playerid, uint8 toplayer, uint8 sumpos, uint32 sumtype, card_data* pdata);
 	int32 is_player_can_spsummon_count(uint8 playerid, uint32 count);
-	int32 is_player_can_release(uint8 playerid, card* pcard, uint32 reason = 0u);
+	int32 is_player_can_release(uint8 playerid, card* pcard, uint32 reason);
 	int32 is_player_can_place_counter(uint8 playerid, card* pcard, uint16 countertype, uint16 count);
 	int32 is_player_can_remove_counter(uint8 playerid, card* pcard, uint8 s, uint8 o, uint16 countertype, uint16 count, uint32 reason);
 	int32 is_player_can_remove_overlay_card(uint8 playerid, card* pcard, uint8 s, uint8 o, uint16 count, uint32 reason);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2410,7 +2410,7 @@ int32 scriptlib::card_is_releasable(lua_State *L) {
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 p = pcard->pduel->game_field->core.reason_player;
-	uint32 reason = 0;
+	uint32 reason = REASON_COST;
 	if (lua_gettop(L) >= 2)
 		reason = (uint32)lua_tointeger(L, 2);
 	if(pcard->is_releasable_by_nonsummon(p, reason))

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2410,7 +2410,10 @@ int32 scriptlib::card_is_releasable(lua_State *L) {
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 p = pcard->pduel->game_field->core.reason_player;
-	if(pcard->is_releasable_by_nonsummon(p))
+	uint32 reason = 0;
+	if (!lua_isnil(L, 2))
+		reason = (uint32)lua_tointeger(L, 2);
+	if(pcard->is_releasable_by_nonsummon(p, reason))
 		lua_pushboolean(L, 1);
 	else
 		lua_pushboolean(L, 0);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2411,7 +2411,7 @@ int32 scriptlib::card_is_releasable(lua_State *L) {
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 p = pcard->pduel->game_field->core.reason_player;
 	uint32 reason = 0;
-	if (!lua_isnil(L, 2))
+	if (lua_gettop(L) >= 2)
 		reason = (uint32)lua_tointeger(L, 2);
 	if(pcard->is_releasable_by_nonsummon(p, reason))
 		lua_pushboolean(L, 1);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2422,7 +2422,7 @@ int32 scriptlib::card_is_releasable_by_effect(lua_State *L) {
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	uint32 p = pcard->pduel->game_field->core.reason_player;
 	effect* re = pcard->pduel->game_field->core.reason_effect;
-	if(pcard->is_releasable_by_nonsummon(p) && pcard->is_releasable_by_effect(p, re))
+	if(pcard->is_releasable_by_nonsummon(p, REASON_EFFECT) && pcard->is_releasable_by_effect(p, re))
 		lua_pushboolean(L, 1);
 	else
 		lua_pushboolean(L, 0);

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2647,7 +2647,7 @@ int32 scriptlib::duel_get_release_group_count(lua_State *L) {
 	if (lua_gettop(L) >= 3)
 		reason = (uint32)lua_tointeger(L, 3);
 	duel* pduel = interpreter::get_duel_info(L);
-	lua_pushinteger(L, pduel->game_field->get_release_list(playerid, 0, 0, 0, FALSE, hand, 0, 0, nullptr, nullptr, reason));
+	lua_pushinteger(L, pduel->game_field->get_release_list(playerid, nullptr, nullptr, FALSE, FALSE, hand, 0, 0, nullptr, nullptr, reason));
 	return 1;
 }
 int32 scriptlib::duel_check_release_group(lua_State *L) {
@@ -2671,7 +2671,7 @@ int32 scriptlib::duel_check_release_group(lua_State *L) {
 		pexgroup = *(group**) lua_touserdata(L, 5);
 	uint32 extraargs = lua_gettop(L) - must_param;
 	duel* pduel = interpreter::get_duel_info(L);
-	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, FALSE, 2, extraargs, pexception, pexgroup, reason);
+	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, FALSE, 3, extraargs, pexception, pexgroup, reason);
 	pduel->game_field->core.must_select_cards.clear();
 	lua_pushboolean(L, result);
 	return 1;
@@ -2734,7 +2734,7 @@ int32 scriptlib::duel_check_release_group_ex(lua_State *L) {
 		pexgroup = *(group**) lua_touserdata(L, 5);
 	uint32 extraargs = lua_gettop(L) - must_param;
 	duel* pduel = interpreter::get_duel_info(L);
-	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, TRUE, 2, extraargs, pexception, pexgroup, reason);
+	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, TRUE, 3, extraargs, pexception, pexgroup, reason);
 	pduel->game_field->core.must_select_cards.clear();
 	lua_pushboolean(L, result);
 	return 1;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2621,7 +2621,7 @@ int32 scriptlib::duel_get_release_group(lua_State *L) {
 	uint32 hand = FALSE;
 	if(lua_gettop(L) > 1)
 		hand = lua_toboolean(L, 2);
-	uint32 reason = 0;
+	uint32 reason = REASON_COST;
 	if (lua_gettop(L) >= 3)
 		reason = (uint32)lua_tointeger(L, 3);
 	duel* pduel = interpreter::get_duel_info(L);
@@ -2643,7 +2643,7 @@ int32 scriptlib::duel_get_release_group_count(lua_State *L) {
 	uint32 hand = FALSE;
 	if(lua_gettop(L) > 1)
 		hand = lua_toboolean(L, 2);
-	uint32 reason = 0;
+	uint32 reason = REASON_COST;
 	if (lua_gettop(L) >= 3)
 		reason = (uint32)lua_tointeger(L, 3);
 	duel* pduel = interpreter::get_duel_info(L);

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2677,30 +2677,32 @@ int32 scriptlib::duel_check_release_group(lua_State *L) {
 	return 1;
 }
 int32 scriptlib::duel_select_release_group(lua_State *L) {
+	const int32 must_param = 6;
 	check_action_permission(L);
-	check_param_count(L, 5);
-	int32 playerid = (int32)lua_tointeger(L, 1);
+	check_param_count(L, must_param);
+	uint32 reason = (uint32)lua_tointeger(L, 1);
+	int32 playerid = (int32)lua_tointeger(L, 2);
 	if(playerid != 0 && playerid != 1)
 		return 0;
 	int32 use_con = FALSE;
-	if(!lua_isnil(L, 2)) {
-		check_param(L, PARAM_TYPE_FUNCTION, 2);
+	if(!lua_isnil(L, 3)) {
+		check_param(L, PARAM_TYPE_FUNCTION, 3);
 		use_con = TRUE;
 	}
+	uint32 min = (uint32)lua_tointeger(L, 4);
+	uint32 max = (uint32)lua_tointeger(L, 5);
 	card* pexception = 0;
 	group* pexgroup = 0;
-	if(check_param(L, PARAM_TYPE_CARD, 5, TRUE))
-		pexception = *(card**) lua_touserdata(L, 5);
-	else if(check_param(L, PARAM_TYPE_GROUP, 5, TRUE))
-		pexgroup = *(group**) lua_touserdata(L, 5);
-	uint32 extraargs = lua_gettop(L) - 5;
+	if(check_param(L, PARAM_TYPE_CARD, 6, TRUE))
+		pexception = *(card**) lua_touserdata(L, 6);
+	else if(check_param(L, PARAM_TYPE_GROUP, 6, TRUE))
+		pexgroup = *(group**) lua_touserdata(L, 6);
+	uint32 extraargs = lua_gettop(L) - must_param;
 	duel* pduel = interpreter::get_duel_info(L);
-	uint32 min = (uint32)lua_tointeger(L, 3);
-	uint32 max = (uint32)lua_tointeger(L, 4);
 	pduel->game_field->core.release_cards.clear();
 	pduel->game_field->core.release_cards_ex.clear();
 	pduel->game_field->core.release_cards_ex_oneof.clear();
-	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_con, FALSE, 2, extraargs, pexception, pexgroup);
+	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_con, FALSE, 3, extraargs, pexception, pexgroup, reason);
 	pduel->game_field->add_process(PROCESSOR_SELECT_RELEASE, 0, 0, 0, playerid, (max << 16) + min);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
@@ -2740,30 +2742,32 @@ int32 scriptlib::duel_check_release_group_ex(lua_State *L) {
 	return 1;
 }
 int32 scriptlib::duel_select_release_group_ex(lua_State *L) {
+	const int32 must_param = 6;
 	check_action_permission(L);
-	check_param_count(L, 5);
-	int32 playerid = (int32)lua_tointeger(L, 1);
+	check_param_count(L, must_param);
+	uint32 reason = (uint32)lua_tointeger(L, 1);
+	int32 playerid = (int32)lua_tointeger(L, 2);
 	if(playerid != 0 && playerid != 1)
 		return 0;
 	int32 use_con = FALSE;
-	if(!lua_isnil(L, 2)) {
-		check_param(L, PARAM_TYPE_FUNCTION, 2);
+	if(!lua_isnil(L, 3)) {
+		check_param(L, PARAM_TYPE_FUNCTION, 3);
 		use_con = TRUE;
 	}
+	uint32 min = (uint32)lua_tointeger(L, 4);
+	uint32 max = (uint32)lua_tointeger(L, 5);
 	card* pexception = 0;
 	group* pexgroup = 0;
-	if(check_param(L, PARAM_TYPE_CARD, 5, TRUE))
-		pexception = *(card**) lua_touserdata(L, 5);
-	else if(check_param(L, PARAM_TYPE_GROUP, 5, TRUE))
-		pexgroup = *(group**) lua_touserdata(L, 5);
-	uint32 extraargs = lua_gettop(L) - 5;
+	if(check_param(L, PARAM_TYPE_CARD, 6, TRUE))
+		pexception = *(card**) lua_touserdata(L, 6);
+	else if(check_param(L, PARAM_TYPE_GROUP, 6, TRUE))
+		pexgroup = *(group**) lua_touserdata(L, 6);
+	uint32 extraargs = lua_gettop(L) - must_param;
 	duel* pduel = interpreter::get_duel_info(L);
-	uint32 min = (uint32)lua_tointeger(L, 3);
-	uint32 max = (uint32)lua_tointeger(L, 4);
 	pduel->game_field->core.release_cards.clear();
 	pduel->game_field->core.release_cards_ex.clear();
 	pduel->game_field->core.release_cards_ex_oneof.clear();
-	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_con, TRUE, 2, extraargs, pexception, pexgroup);
+	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_con, TRUE, 3, extraargs, pexception, pexgroup, reason);
 	pduel->game_field->add_process(PROCESSOR_SELECT_RELEASE, 0, 0, 0, playerid, (max << 16) + min);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2645,25 +2645,27 @@ int32 scriptlib::duel_get_release_group_count(lua_State *L) {
 	return 1;
 }
 int32 scriptlib::duel_check_release_group(lua_State *L) {
-	check_param_count(L, 4);
-	int32 playerid = (int32)lua_tointeger(L, 1);
+	const int32 must_param = 5;
+	check_param_count(L, must_param);
+	uint32 reason = (uint32)lua_tointeger(L, 1);
+	int32 playerid = (int32)lua_tointeger(L, 2);
 	if(playerid != 0 && playerid != 1)
 		return 0;
 	int32 use_con = FALSE;
-	if(!lua_isnil(L, 2)) {
-		check_param(L, PARAM_TYPE_FUNCTION, 2);
+	if(!lua_isnil(L, 3)) {
+		check_param(L, PARAM_TYPE_FUNCTION, 3);
 		use_con = TRUE;
 	}
+	uint32 fcount = (uint32)lua_tointeger(L, 4);
 	card* pexception = 0;
 	group* pexgroup = 0;
-	if(check_param(L, PARAM_TYPE_CARD, 4, TRUE))
-		pexception = *(card**) lua_touserdata(L, 4);
-	else if(check_param(L, PARAM_TYPE_GROUP, 4, TRUE))
-		pexgroup = *(group**) lua_touserdata(L, 4);
-	uint32 extraargs = lua_gettop(L) - 4;
+	if(check_param(L, PARAM_TYPE_CARD, 5, TRUE))
+		pexception = *(card**) lua_touserdata(L, 5);
+	else if(check_param(L, PARAM_TYPE_GROUP, 5, TRUE))
+		pexgroup = *(group**) lua_touserdata(L, 5);
+	uint32 extraargs = lua_gettop(L) - must_param;
 	duel* pduel = interpreter::get_duel_info(L);
-	uint32 fcount = (uint32)lua_tointeger(L, 3);
-	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, FALSE, 2, extraargs, pexception, pexgroup);
+	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, FALSE, 2, extraargs, pexception, pexgroup, reason);
 	pduel->game_field->core.must_select_cards.clear();
 	lua_pushboolean(L, result);
 	return 1;
@@ -2706,25 +2708,27 @@ int32 scriptlib::duel_select_release_group(lua_State *L) {
 	});
 }
 int32 scriptlib::duel_check_release_group_ex(lua_State *L) {
-	check_param_count(L, 4);
-	int32 playerid = (int32)lua_tointeger(L, 1);
+	const int32 must_param = 5;
+	check_param_count(L, must_param);
+	uint32 reason = (uint32)lua_tointeger(L, 1);
+	int32 playerid = (int32)lua_tointeger(L, 2);
 	if(playerid != 0 && playerid != 1)
 		return 0;
 	int32 use_con = FALSE;
-	if(!lua_isnil(L, 2)) {
-		check_param(L, PARAM_TYPE_FUNCTION, 2);
+	if(!lua_isnil(L, 3)) {
+		check_param(L, PARAM_TYPE_FUNCTION, 3);
 		use_con = TRUE;
 	}
+	uint32 fcount = (uint32)lua_tointeger(L, 4);
 	card* pexception = 0;
 	group* pexgroup = 0;
-	if(check_param(L, PARAM_TYPE_CARD, 4, TRUE))
-		pexception = *(card**) lua_touserdata(L, 4);
-	else if(check_param(L, PARAM_TYPE_GROUP, 4, TRUE))
-		pexgroup = *(group**) lua_touserdata(L, 4);
-	uint32 extraargs = lua_gettop(L) - 4;
+	if(check_param(L, PARAM_TYPE_CARD, 5, TRUE))
+		pexception = *(card**) lua_touserdata(L, 5);
+	else if(check_param(L, PARAM_TYPE_GROUP, 5, TRUE))
+		pexgroup = *(group**) lua_touserdata(L, 5);
+	uint32 extraargs = lua_gettop(L) - must_param;
 	duel* pduel = interpreter::get_duel_info(L);
-	uint32 fcount = (uint32)lua_tointeger(L, 3);
-	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, TRUE, 2, extraargs, pexception, pexgroup);
+	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, TRUE, 2, extraargs, pexception, pexgroup, reason);
 	pduel->game_field->core.must_select_cards.clear();
 	lua_pushboolean(L, result);
 	return 1;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -4324,7 +4324,10 @@ int32 scriptlib::duel_is_player_can_release(lua_State * L) {
 		check_param_count(L, 2);
 		check_param(L, PARAM_TYPE_CARD, 2);
 		card* pcard = *(card**) lua_touserdata(L, 2);
-		lua_pushboolean(L, pduel->game_field->is_player_can_release(playerid, pcard));
+		uint32 reason = 0;
+		if (!lua_isnil(L, 3))
+			reason = (uint32)lua_tointeger(L, 3);
+		lua_pushboolean(L, pduel->game_field->is_player_can_release(playerid, pcard, reason));
 	}
 	return 1;
 }

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -4334,7 +4334,7 @@ int32 scriptlib::duel_is_player_can_release(lua_State * L) {
 		check_param_count(L, 2);
 		check_param(L, PARAM_TYPE_CARD, 2);
 		card* pcard = *(card**) lua_touserdata(L, 2);
-		uint32 reason = 0;
+		uint32 reason = REASON_COST;
 		if (lua_gettop(L) >= 3)
 			reason = (uint32)lua_tointeger(L, 3);
 		lua_pushboolean(L, pduel->game_field->is_player_can_release(playerid, pcard, reason));

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -4325,7 +4325,7 @@ int32 scriptlib::duel_is_player_can_release(lua_State * L) {
 		check_param(L, PARAM_TYPE_CARD, 2);
 		card* pcard = *(card**) lua_touserdata(L, 2);
 		uint32 reason = 0;
-		if (!lua_isnil(L, 3))
+		if (lua_gettop(L) >= 3)
 			reason = (uint32)lua_tointeger(L, 3);
 		lua_pushboolean(L, pduel->game_field->is_player_can_release(playerid, pcard, reason));
 	}

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2621,9 +2621,12 @@ int32 scriptlib::duel_get_release_group(lua_State *L) {
 	uint32 hand = FALSE;
 	if(lua_gettop(L) > 1)
 		hand = lua_toboolean(L, 2);
+	uint32 reason = 0;
+	if (lua_gettop(L) >= 3)
+		reason = (uint32)lua_tointeger(L, 3);
 	duel* pduel = interpreter::get_duel_info(L);
 	group* pgroup = pduel->new_group();
-	pduel->game_field->get_release_list(playerid, &pgroup->container, &pgroup->container, &pgroup->container, FALSE, hand, 0, 0, 0, 0);
+	pduel->game_field->get_release_list(playerid, &pgroup->container, &pgroup->container, &pgroup->container, FALSE, hand, 0, 0, nullptr, nullptr, reason);
 	interpreter::group2value(L, pgroup);
 	return 1;
 }
@@ -2640,8 +2643,11 @@ int32 scriptlib::duel_get_release_group_count(lua_State *L) {
 	uint32 hand = FALSE;
 	if(lua_gettop(L) > 1)
 		hand = lua_toboolean(L, 2);
+	uint32 reason = 0;
+	if (lua_gettop(L) >= 3)
+		reason = (uint32)lua_tointeger(L, 3);
 	duel* pduel = interpreter::get_duel_info(L);
-	lua_pushinteger(L, pduel->game_field->get_release_list(playerid, 0, 0, 0, FALSE, hand, 0, 0, 0, 0));
+	lua_pushinteger(L, pduel->game_field->get_release_list(playerid, 0, 0, 0, FALSE, hand, 0, 0, nullptr, nullptr, reason));
 	return 1;
 }
 int32 scriptlib::duel_check_release_group(lua_State *L) {

--- a/operations.cpp
+++ b/operations.cpp
@@ -3739,7 +3739,7 @@ int32 field::release(uint16 step, group * targets, effect * reason_effect, uint3
 			card* pcard = *rm;
 			if (pcard->get_status(STATUS_SUMMONING | STATUS_SPSUMMON_STEP)
 			        || ((reason & REASON_SUMMON) && !pcard->is_releasable_by_summon(reason_player, pcard->current.reason_card))
-			        || (!(pcard->current.reason & (REASON_RULE | REASON_SUMMON | REASON_COST))
+			        || (!(pcard->current.reason & (REASON_RULE | REASON_SUMMON | REASON_COST | REASON_SPSUMMON))
 			            && (!pcard->is_affect_by_effect(pcard->current.reason_effect) || !pcard->is_releasable_by_nonsummon(reason_player, reason)))) {
 				pcard->current.reason = pcard->temp.reason;
 				pcard->current.reason_effect = pcard->temp.reason_effect;

--- a/operations.cpp
+++ b/operations.cpp
@@ -3740,7 +3740,7 @@ int32 field::release(uint16 step, group * targets, effect * reason_effect, uint3
 			if (pcard->get_status(STATUS_SUMMONING | STATUS_SPSUMMON_STEP)
 			        || ((reason & REASON_SUMMON) && !pcard->is_releasable_by_summon(reason_player, pcard->current.reason_card))
 			        || (!(pcard->current.reason & (REASON_RULE | REASON_SUMMON | REASON_COST))
-			            && (!pcard->is_affect_by_effect(pcard->current.reason_effect) || !pcard->is_releasable_by_nonsummon(reason_player)))) {
+			            && (!pcard->is_affect_by_effect(pcard->current.reason_effect) || !pcard->is_releasable_by_nonsummon(reason_player, reason)))) {
 				pcard->current.reason = pcard->temp.reason;
 				pcard->current.reason_effect = pcard->temp.reason_effect;
 				pcard->current.reason_player = pcard->temp.reason_player;

--- a/operations.cpp
+++ b/operations.cpp
@@ -3738,9 +3738,9 @@ int32 field::release(uint16 step, group * targets, effect * reason_effect, uint3
 			auto rm = cit++;
 			card* pcard = *rm;
 			if (pcard->get_status(STATUS_SUMMONING | STATUS_SPSUMMON_STEP)
-			        || ((reason & REASON_SUMMON) && !pcard->is_releasable_by_summon(reason_player, pcard->current.reason_card))
-			        || (!(pcard->current.reason & (REASON_RULE | REASON_SUMMON | REASON_COST | REASON_SPSUMMON))
-			            && (!pcard->is_affect_by_effect(pcard->current.reason_effect) || !pcard->is_releasable_by_nonsummon(reason_player, reason)))) {
+				|| ((reason & REASON_SUMMON) && !pcard->is_releasable_by_summon(reason_player, pcard->current.reason_card))
+				|| ((reason & REASON_EFFECT)
+					&& (!pcard->is_affect_by_effect(pcard->current.reason_effect) || !pcard->is_releasable_by_nonsummon(reason_player, reason)))) {
 				pcard->current.reason = pcard->temp.reason;
 				pcard->current.reason_effect = pcard->temp.reason_effect;
 				pcard->current.reason_player = pcard->temp.reason_player;


### PR DESCRIPTION
# Problem
EFFECT_CANNOT_RELEASE cannot check reason.
It is necessary for Ritual Beast Ulti-Reirautari (聖霊獣騎 レイラウタリ).

# Solution
https://github.com/Fluorohydride/ygopro-scripts/pull/2242

target function of EFFECT_CANNOT_RELEASE
Target function:
add 4th param: reason
```lua
function s.rellimit(e,c,tp,r)
	return r&REASON_COST~=0
end
```

## Lua functions
class Card
Card.IsReleasable 
add 2nd param: reason (optional, default: REASON_COST)

class Duel
CheckReleaseGroup
SelectReleaseGroup
CheckReleaseGroupEx
SelectReleaseGroupEx
add 1st param: reason

GetReleaseGroup
GetReleaseGroupCount
add 3rd param: reason (optional, default: REASON_COST)

IsPlayerCanRelease
add 3rd param: reason (optional, default: REASON_COST)

## Release Reason
Now the main reasons are:
`REASON_ACTION`: "This card cannot declare an attack unless"...
`REASON_COST`: The card is released by the cost of activation.
`REASON_EFFECT`: The card is released by effect.
`REASON_MAINTENANCE`: The maintenance cost.
`REASON_SPSUMMON`: The card is released by the Special Summon procedure.
`REASON_SUMMON`: The card is released by Advance Summon.
`REASON_RULE`: The card is is released by non-effect actions like 痛み分け/Share the Pain.


# Test
[test_cannot_release.zip](https://github.com/Fluorohydride/ygopro-core/files/13406736/test_cannot_release.zip)

test_cannot_release.lua
Single mode script
Add test card with id=1
Level 1/Earth/Warrior/ATK 1/DEF 1

c1.lua
The script of 1
EFFECT_CANNOT_RELEASE with reason

インフェルノイド・アシュメダイ
Infernoid Piaty
From https://github.com/Fluorohydride/ygopro-scripts/pull/2222

When `1` is on the field:
The 2nd effect of `Infernoid Piaty` cannot be activated.
`Black Illusion Ritual` can be activated.

