### PR TITLE
add Card.GetSpecialSummonInfo, Card.IsSpecialSummonSetCard

### DIFF
--- a/card.h
+++ b/card.h
@@ -157,6 +157,7 @@ public:
 	card_state previous;
 	card_state temp;
 	card_state current;
+	card_state spsummon;
 	query_cache q_cache;
 	uint8 owner;
 	uint8 summon_player;
@@ -227,6 +228,7 @@ public:
 	int32 is_pre_set_card(uint32 set_code);
 	int32 is_fusion_set_card(uint32 set_code);
 	int32 is_link_set_card(uint32 set_code);
+	int32 is_special_summon_set_card(uint32 set_code);
 	uint32 get_type();
 	uint32 get_fusion_type();
 	uint32 get_synchro_type();
@@ -313,6 +315,7 @@ public:
 	void add_card_target(card* pcard);
 	void cancel_card_target(card* pcard);
 	void clear_card_target();
+	void set_special_summon_status(effect* peffect);
 
 	void filter_effect(int32 code, effect_set* eset, uint8 sort = TRUE);
 	void filter_single_continuous_effect(int32 code, effect_set* eset, uint8 sort = TRUE);
@@ -399,10 +402,12 @@ public:
 #define SUMMON_TYPE_XYZ			0x49000000
 #define SUMMON_TYPE_PENDULUM	0x4a000000
 #define SUMMON_TYPE_LINK		0x4c000000
+
 //Counter
 #define COUNTER_WITHOUT_PERMIT	0x1000
 //#define COUNTER_NEED_ENABLE		0x2000
 
+//Assume
 #define ASSUME_CODE			1
 #define ASSUME_TYPE			2
 #define ASSUME_LEVEL		3
@@ -411,6 +416,18 @@ public:
 #define ASSUME_RACE			6
 #define ASSUME_ATTACK		7
 #define ASSUME_DEFENSE		8
+
+//Summon info
+#define SUMMON_INFO_CODE			0x01
+#define SUMMON_INFO_CODE2			0x02
+#define SUMMON_INFO_TYPE			0x04
+#define SUMMON_INFO_LEVEL			0x08
+#define SUMMON_INFO_RANK			0x10
+#define SUMMON_INFO_ATTRIBUTE		0x20
+#define SUMMON_INFO_RACE			0x40
+#define SUMMON_INFO_ATTACK			0x80
+#define SUMMON_INFO_DEFENSE			0x100
+#define SUMMON_INFO_REASON_EFFECT	0x200
 
 //double-name cards
 #define CARD_MARINE_DOLPHIN	78734254

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -245,6 +245,24 @@ int32 scriptlib::card_is_link_set_card(lua_State *L) {
 	lua_pushboolean(L, result);
 	return 1;
 }
+int32 scriptlib::card_is_special_summon_set_card(lua_State *L) {
+	check_param_count(L, 2);
+	check_param(L, PARAM_TYPE_CARD, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
+	uint32 count = lua_gettop(L) - 1;
+	uint32 result = FALSE;
+	for(uint32 i = 0; i < count; ++i) {
+		if(lua_isnil(L, i + 2))
+			continue;
+		uint32 set_code = (uint32)lua_tointeger(L, i + 2);
+		if(pcard->is_special_summon_set_card(set_code)) {
+			result = TRUE;
+			break;
+		}
+	}
+	lua_pushboolean(L, result);
+	return 1;
+}
 int32 scriptlib::card_get_type(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
@@ -864,6 +882,51 @@ int32 scriptlib::card_get_summon_player(lua_State *L) {
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	lua_pushinteger(L, pcard->summon_player);
 	return 1;
+}
+int32 scriptlib::card_get_special_summon_info(lua_State *L) {
+	check_param_count(L, 1);
+	check_param(L, PARAM_TYPE_CARD, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
+	uint32 args = lua_gettop(L) - 1;
+	for(uint32 i = 0; i < args; ++i) {
+		uint32 flag = (uint32)lua_tointeger(L, 2 + i);
+		switch(flag) {
+			case SUMMON_INFO_CODE:
+				lua_pushinteger(L, pcard->spsummon.code);
+				break;
+			case SUMMON_INFO_CODE2:
+				lua_pushinteger(L, pcard->spsummon.code2);
+				break;
+			case SUMMON_INFO_TYPE:
+				lua_pushinteger(L, pcard->spsummon.type);
+				break;
+			case SUMMON_INFO_LEVEL:
+				lua_pushinteger(L, pcard->spsummon.level);
+				break;
+			case SUMMON_INFO_RANK:
+				lua_pushinteger(L, pcard->spsummon.rank);
+				break;
+			case SUMMON_INFO_ATTRIBUTE:
+				lua_pushinteger(L, pcard->spsummon.attribute);
+				break;
+			case SUMMON_INFO_RACE:
+				lua_pushinteger(L, pcard->spsummon.race);
+				break;
+			case SUMMON_INFO_ATTACK:
+				lua_pushinteger(L, pcard->spsummon.attack);
+				break;
+			case SUMMON_INFO_DEFENSE:
+				lua_pushinteger(L, pcard->spsummon.defense);
+				break;
+			case SUMMON_INFO_REASON_EFFECT:
+				interpreter::effect2value(L, pcard->spsummon.reason_effect);
+				break;
+			default:
+				lua_pushnil(L);
+				break;
+		}
+	}
+	return args;
 }
 int32 scriptlib::card_get_destination(lua_State *L) {
 	check_param_count(L, 1);
@@ -3322,6 +3385,7 @@ static const struct luaL_Reg cardlib[] = {
 	{ "IsPreviousSetCard", scriptlib::card_is_pre_set_card },
 	{ "IsFusionSetCard", scriptlib::card_is_fusion_set_card },
 	{ "IsLinkSetCard", scriptlib::card_is_link_set_card },
+	{ "IsSpecialSummonSetCard", scriptlib::card_is_special_summon_set_card },
 	{ "GetType", scriptlib::card_get_type },
 	{ "GetOriginalType", scriptlib::card_get_origin_type },
 	{ "GetFusionType", scriptlib::card_get_fusion_type },
@@ -3395,6 +3459,7 @@ static const struct luaL_Reg cardlib[] = {
 	{ "GetSummonType", scriptlib::card_get_summon_type },
 	{ "GetSummonLocation", scriptlib::card_get_summon_location },
 	{ "GetSummonPlayer", scriptlib::card_get_summon_player },
+	{ "GetSpecialSummonInfo", scriptlib::card_get_special_summon_info },
 	{ "GetDestination", scriptlib::card_get_destination },
 	{ "GetLeaveFieldDest", scriptlib::card_get_leave_field_dest },
 	{ "GetTurnID", scriptlib::card_get_turnid },

--- a/operations.cpp
+++ b/operations.cpp
@@ -2940,13 +2940,15 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		return FALSE;
 	}
 	case 17: {
+		effect* proc = core.units.begin()->peffect;
 		set_spsummon_counter(sumplayer);
 		check_card_counter(target, ACTIVITY_SPSUMMON, sumplayer);
 		if(target->spsummon_code)
 			++core.spsummon_once_map[sumplayer][target->spsummon_code];
-		raise_single_event(target, 0, EVENT_SPSUMMON_SUCCESS, core.units.begin()->peffect, 0, sumplayer, sumplayer, 0);
+		target->set_special_summon_status(proc);
+		raise_single_event(target, 0, EVENT_SPSUMMON_SUCCESS, proc, 0, sumplayer, sumplayer, 0);
 		process_single_event();
-		raise_event(target, EVENT_SPSUMMON_SUCCESS, core.units.begin()->peffect, 0, sumplayer, sumplayer, 0);
+		raise_event(target, EVENT_SPSUMMON_SUCCESS, proc, 0, sumplayer, sumplayer, 0);
 		process_instant_event();
 		if(core.current_chain.size() == 0) {
 			adjust_all();
@@ -3133,6 +3135,7 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		for(auto& pcard : pgroup->container) {
 			if(pcard->spsummon_code)
 				spsummon_once_set.insert(pcard->spsummon_code);
+			pcard->set_special_summon_status(pcard->current.reason_effect);
 		}
 		for(auto& cit : spsummon_once_set)
 			++core.spsummon_once_map[sumplayer][cit];
@@ -3335,6 +3338,7 @@ int32 field::special_summon(uint16 step, effect* reason_effect, uint8 reason_pla
 		pduel->write_buffer8(MSG_SPSUMMONED);
 		for(auto& pcard : targets->container) {
 			check_card_counter(pcard, ACTIVITY_SPSUMMON, pcard->summon_player);
+			pcard->set_special_summon_status(pcard->current.reason_effect);
 			if(!(pcard->current.position & POS_FACEDOWN))
 				raise_single_event(pcard, 0, EVENT_SPSUMMON_SUCCESS, pcard->current.reason_effect, 0, pcard->current.reason_player, pcard->summon_player, 0);
 			int32 summontype = pcard->summon_info & 0xff000000;

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -30,6 +30,7 @@ public:
 	static int32 card_is_pre_set_card(lua_State *L);
 	static int32 card_is_fusion_set_card(lua_State *L);
 	static int32 card_is_link_set_card(lua_State *L);
+	static int32 card_is_special_summon_set_card(lua_State *L);
 	static int32 card_get_type(lua_State *L);
 	static int32 card_get_origin_type(lua_State *L);
 	static int32 card_get_fusion_type(lua_State *L);
@@ -133,6 +134,7 @@ public:
 	static int32 card_is_summon_type(lua_State *L);
 	static int32 card_is_summon_location(lua_State *L);
 	static int32 card_is_summon_player(lua_State *L);
+	static int32 card_get_special_summon_info(lua_State *L);
 	static int32 card_is_status(lua_State *L);
 	static int32 card_is_not_tuner(lua_State *L);
 	static int32 card_is_tuner(lua_State* L);


### PR DESCRIPTION
if activated monster didn't have on the field by itself cost, "When/If this card is Special Summoned by the effect of a monster"'s condition is checked except mzone (ref: https://github.com/Fluorohydride/ygopro-scripts/pull/1916).

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23826&keyword=&tag=-1
> Question
> 「[輪廻独断](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=16408)」の効果で墓地のモンスターが獣族になっている状況で、天使族である「[丘と芽吹の春化精](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17418)」の『①：このカードと、モンスター１体または「春化精」カード１枚を手札から捨てて発動できる。デッキから「[丘と芽吹の春化精](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17418)」以外の「春化精」カード１枚を手札に加える。その後、自分の墓地から地属性モンスター１体を選んで特殊召喚できる』効果を発動し、「[森の聖獣 カラントーサ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10922)」を特殊召喚した場合、「[森の聖獣 カラントーサ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10922)」の効果を発動できますか？（『獣族モンスターの効果で特殊召喚に成功した』ことになりますか？）
> Answer
> 発動できません（天使族モンスターの効果で特殊召喚されたことになります）。
> 
> 原則として、**「[森の聖獣 カラントーサ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10922)」がモンスター効果によって特殊召喚に成功したタイミングで、その効果を発動したモンスターの種族を参照します**。ただし、**効果を発動したモンスターが発動したところに存在しなくなっていた場合（同一チェーン上で発動した効果のコストや処理によって発動したところを離れていた場合）には、発動時の種族を参照します**。
> 
> 質問の状況ですと、「[森の聖獣 カラントーサ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10922)」は手札の「[丘と芽吹の春化精](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17418)」の効果によって特殊召喚されています。「[森の聖獣 カラントーサ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10922)」が特殊召喚に成功した時点で、「[丘と芽吹の春化精](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17418)」は発動したところ（手札）に存在していませんので、この効果の発動時の「[丘と芽吹の春化精](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17418)」の種族を参照することになります。手札の「[丘と芽吹の春化精](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17418)」は天使族の状態で効果を発動していますので、「[森の聖獣 カラントーサ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=10922)」は『獣族モンスターの効果で特殊召喚に成功した』ことにならず、①の効果を発動できません。

if activated monster didn't have on the zone by itself cost, `Card.GetSpecialSummonInfo` and `Card.IsSpecialSummonSetCard` can check activated zone.