### PR TITLE
add Duel.GetReadyChain

### DIFF
--- a/field.h
+++ b/field.h
@@ -298,6 +298,7 @@ struct processor {
 	uint8 dice_result[5]{ 0 };
 	uint8 coin_result[MAX_COIN_COUNT]{ 0 };
 	int32 coin_count{ 0 };
+	bool is_target_ready{ false };
 
 	uint8 to_bp{ FALSE };
 	uint8 to_m2{ FALSE };

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2121,6 +2121,15 @@ int32 scriptlib::duel_get_current_chain(lua_State *L) {
 	lua_pushinteger(L, pduel->game_field->core.current_chain.size());
 	return 1;
 }
+int32 scriptlib::duel_get_ready_chain(lua_State* L) {
+	duel* pduel = interpreter::get_duel_info(L);
+	int32 size = (int32)pduel->game_field->core.current_chain.size();
+	if (size && !pduel->game_field->core.is_target_ready) {
+		--size;
+	}
+	lua_pushinteger(L, size);
+	return 1;
+}
 int32 scriptlib::duel_get_chain_info(lua_State *L) {
 	check_param_count(L, 1);
 	uint32 c = (uint32)lua_tointeger(L, 1);
@@ -4780,6 +4789,7 @@ static const struct luaL_Reg duellib[] = {
 	{ "GetFieldCard", scriptlib::duel_get_field_card },
 	{ "CheckLocation", scriptlib::duel_check_location },
 	{ "GetCurrentChain", scriptlib::duel_get_current_chain },
+	{ "GetReadyChain", scriptlib::duel_get_ready_chain },
 	{ "GetChainInfo", scriptlib::duel_get_chain_info },
 	{ "GetChainEvent", scriptlib::duel_get_chain_event },
 	{ "GetFirstTarget", scriptlib::duel_get_first_target },

--- a/processor.cpp
+++ b/processor.cpp
@@ -4071,6 +4071,7 @@ int32 field::add_chain(uint16 step) {
 		if(phandler->current.location == LOCATION_HAND)
 			clit.flag |= CHAIN_HAND_EFFECT;
 		core.current_chain.push_back(clit);
+		core.is_target_ready = false;
 		check_chain_counter(peffect, clit.triggering_player, clit.chain_count);
 		// triggered events which are not caused by event create relation with the handler
 		if(!peffect->is_flag(EFFECT_FLAG_FIELD_ONLY) 
@@ -4173,6 +4174,7 @@ int32 field::add_chain(uint16 step) {
 	}
 	case 7: {
 		break_effect();
+		core.is_target_ready = true;
 		auto& clit = core.current_chain.back();
 		effect* peffect = clit.triggering_effect;
 		peffect->cost_checked = FALSE;

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -484,6 +484,7 @@ public:
 	static int32 duel_get_field_card(lua_State *L);
 	static int32 duel_check_location(lua_State *L);
 	static int32 duel_get_current_chain(lua_State *L);
+	static int32 duel_get_ready_chain(lua_State* L);
 	static int32 duel_get_chain_info(lua_State *L);
 	static int32 duel_get_chain_event(lua_State *L);
 	static int32 duel_get_first_target(lua_State *L);


### PR DESCRIPTION
@mercury233 
# Problem
#482
I think the reason is:
The real condition of 神の宣告/Solemn Judgment is:
The number of ready chain in current chain is 0.
(Ready: the target function has completed.)

Duel.CurrentChain()
The number of chain blocks in current chain.

If Solemn Judgment is copied by another effect, these values will be different.

# Solution
Duel.GetReadyChain()
The number of ready chain blocks in current chain.
