### PR TITLE
Add Effect: EFFECT_CANNOT_BE_RITUAL_MATERIAL

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -4162,8 +4162,13 @@ int32 card::is_can_be_synchro_material(card* scard, card* tuner) {
 int32 card::is_can_be_ritual_material(card* scard) {
 	if(!(get_type() & TYPE_MONSTER))
 		return FALSE;
+	effect_set eset;
+	filter_effect(EFFECT_CANNOT_BE_RITUAL_MATERIAL, &eset);
+	for(int32 i = 0; i < eset.size(); ++i)
+		if(eset[i]->get_value(scard))
+			return FALSE;
 	if(current.location == LOCATION_GRAVE) {
-		effect_set eset;
+		eset.clear();
 		filter_effect(EFFECT_EXTRA_RITUAL_MATERIAL, &eset);
 		for(int32 i = 0; i < eset.size(); ++i)
 			if(eset[i]->get_value(scard))

--- a/effect.h
+++ b/effect.h
@@ -472,6 +472,7 @@ inline effect_flag operator|(effect_flag flag1, effect_flag flag2)
 #define EFFECT_TUNER					369
 #define EFFECT_KAISER_COLOSSEUM			370
 #define EFFECT_REPLACE_DAMAGE			371
+#define EFFECT_CANNOT_BE_RITUAL_MATERIAL	=272
 
 //#define EVENT_STARTUP		1000
 #define EVENT_FLIP			1001


### PR DESCRIPTION
Create a new type of Effect that cannot be used as material for ritual summons.