### PR TITLE
fix: summon in Chain Link 1

### DIFF
--- a/field.h
+++ b/field.h
@@ -570,6 +570,12 @@ public:
 	void operation_replace(int32 type, int32 step, group* targets);
 	void select_tribute_cards(card* target, uint8 playerid, uint8 cancelable, int32 min, int32 max, uint8 toplayer, uint32 zone);
 
+	// summon
+	int32 summon(uint16 step, uint8 sumplayer, card* target, effect* proc, uint8 ignore_count, uint8 min_tribute, uint32 zone, uint32 action_type);
+	int32 mset(uint16 step, uint8 setplayer, card* ptarget, effect* proc, uint8 ignore_count, uint8 min_tribute, uint32 zone, uint32 action_type);
+	int32 flip_summon(uint16 step, uint8 sumplayer, card* target, uint32 action_type);
+	int32 special_summon_rule(uint16 step, uint8 sumplayer, card* target, uint32 summon_type, uint32 action_type);
+
 	int32 remove_counter(uint16 step, uint32 reason, card* pcard, uint8 rplayer, uint8 s, uint8 o, uint16 countertype, uint16 count);
 	int32 remove_overlay_card(uint16 step, uint32 reason, card* pcard, uint8 rplayer, uint8 s, uint8 o, uint16 min, uint16 max);
 	int32 get_control(uint16 step, effect* reason_effect, uint8 reason_player, group* targets, uint8 playerid, uint16 reset_phase, uint8 reset_count, uint32 zone);
@@ -580,12 +586,8 @@ public:
 	int32 draw(uint16 step, effect* reason_effect, uint32 reason, uint8 reason_player, uint8 playerid, int32 count);
 	int32 damage(uint16 step, effect* reason_effect, uint32 reason, uint8 reason_player, card* reason_card, uint8 playerid, int32 amount, uint32 is_step);
 	int32 recover(uint16 step, effect* reason_effect, uint32 reason, uint8 reason_player, uint8 playerid, int32 amount, uint32 is_step);
-	int32 summon(uint16 step, uint8 sumplayer, card* target, effect* proc, uint8 ignore_count, uint8 min_tribute, uint32 zone);
-	int32 flip_summon(uint16 step, uint8 sumplayer, card* target);
-	int32 mset(uint16 step, uint8 setplayer, card* ptarget, effect* proc, uint8 ignore_count, uint8 min_tribute, uint32 zone);
 	int32 sset(uint16 step, uint8 setplayer, uint8 toplayer, card* ptarget, effect* reason_effect);
 	int32 sset_g(uint16 step, uint8 setplayer, uint8 toplayer, group* ptarget, uint8 confirm, effect* reason_effect);
-	int32 special_summon_rule(uint16 step, uint8 sumplayer, card* target, uint32 summon_type);
 	int32 special_summon_step(uint16 step, group* targets, card* target, uint32 zone);
 	int32 special_summon(uint16 step, effect* reason_effect, uint8 reason_player, group* targets, uint32 zone);
 	int32 destroy_replace(uint16 step, group* targets, card* target, uint8 battle);
@@ -705,6 +707,8 @@ public:
 #define GLOBALFLAG_TUNE_MAGICIAN		0x400
 #define GLOBALFLAG_ACTIVATION_COUNT		0x800
 //
+
+#define SUMMON_IN_CHAIN	1
 
 #define PROCESSOR_ADJUST			1
 #define PROCESSOR_HINT				2

--- a/field.h
+++ b/field.h
@@ -174,7 +174,8 @@ struct processor {
 
 	processor_list units;
 	processor_list subunits;
-	processor_unit reserved;
+	processor_unit damage_step_reserved;
+	processor_unit summon_reserved;
 	card_vector select_cards;
 	card_vector unselect_cards;
 	card_vector summonable_cards;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -301,7 +301,7 @@ int32 scriptlib::duel_summon(lua_State *L) {
 	pduel->game_field->core.summon_cancelable = FALSE;
 	pduel->game_field->summon(playerid, pcard, peffect, ignore_count, min_tribute, zone);
 	if(pduel->game_field->core.current_chain.size()) {
-		pduel->game_field->core.reserved = pduel->game_field->core.subunits.back();
+		pduel->game_field->core.summon_reserved = pduel->game_field->core.subunits.back();
 		pduel->game_field->core.subunits.pop_back();
 		pduel->game_field->core.summoning_card = pcard;
 	}
@@ -324,7 +324,7 @@ int32 scriptlib::duel_special_summon_rule(lua_State *L) {
 	pduel->game_field->core.summon_cancelable = FALSE;
 	pduel->game_field->special_summon_rule(playerid, pcard, sumtype);
 	if(pduel->game_field->core.current_chain.size()) {
-		pduel->game_field->core.reserved = pduel->game_field->core.subunits.back();
+		pduel->game_field->core.summon_reserved = pduel->game_field->core.subunits.back();
 		pduel->game_field->core.subunits.pop_back();
 		pduel->game_field->core.summoning_card = pcard;
 	}
@@ -368,7 +368,7 @@ int32 scriptlib::duel_synchro_summon(lua_State *L) {
 	pduel->game_field->core.summon_cancelable = FALSE;
 	pduel->game_field->special_summon_rule(playerid, pcard, SUMMON_TYPE_SYNCHRO);
 	if(pduel->game_field->core.current_chain.size()) {
-		pduel->game_field->core.reserved = pduel->game_field->core.subunits.back();
+		pduel->game_field->core.summon_reserved = pduel->game_field->core.subunits.back();
 		pduel->game_field->core.subunits.pop_back();
 		pduel->game_field->core.summoning_card = pcard;
 	}
@@ -404,7 +404,7 @@ int32 scriptlib::duel_xyz_summon(lua_State *L) {
 	pduel->game_field->core.summon_cancelable = FALSE;
 	pduel->game_field->special_summon_rule(playerid, pcard, SUMMON_TYPE_XYZ);
 	if(pduel->game_field->core.current_chain.size()) {
-		pduel->game_field->core.reserved = pduel->game_field->core.subunits.back();
+		pduel->game_field->core.summon_reserved = pduel->game_field->core.subunits.back();
 		pduel->game_field->core.subunits.pop_back();
 		pduel->game_field->core.summoning_card = pcard;
 	}
@@ -448,7 +448,7 @@ int32 scriptlib::duel_link_summon(lua_State *L) {
 	pduel->game_field->core.summon_cancelable = FALSE;
 	pduel->game_field->special_summon_rule(playerid, pcard, SUMMON_TYPE_LINK);
 	if(pduel->game_field->core.current_chain.size()) {
-		pduel->game_field->core.reserved = pduel->game_field->core.subunits.back();
+		pduel->game_field->core.summon_reserved = pduel->game_field->core.subunits.back();
 		pduel->game_field->core.subunits.pop_back();
 		pduel->game_field->core.summoning_card = pcard;
 	}
@@ -480,7 +480,7 @@ int32 scriptlib::duel_setm(lua_State *L) {
 	pduel->game_field->core.summon_cancelable = FALSE;
 	pduel->game_field->mset(playerid, pcard, peffect, ignore_count, min_tribute, zone);
 	if(pduel->game_field->core.current_chain.size()) {
-		pduel->game_field->core.reserved = pduel->game_field->core.subunits.back();
+		pduel->game_field->core.summon_reserved = pduel->game_field->core.subunits.back();
 		pduel->game_field->core.subunits.pop_back();
 		pduel->game_field->core.summoning_card = pcard;
 	}

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -302,6 +302,7 @@ int32 scriptlib::duel_summon(lua_State *L) {
 	pduel->game_field->summon(playerid, pcard, peffect, ignore_count, min_tribute, zone);
 	if(pduel->game_field->core.current_chain.size()) {
 		pduel->game_field->core.summon_reserved = pduel->game_field->core.subunits.back();
+		pduel->game_field->core.summon_reserved.arg3 = SUMMON_IN_CHAIN;
 		pduel->game_field->core.subunits.pop_back();
 		pduel->game_field->core.summoning_card = pcard;
 	}
@@ -325,6 +326,7 @@ int32 scriptlib::duel_special_summon_rule(lua_State *L) {
 	pduel->game_field->special_summon_rule(playerid, pcard, sumtype);
 	if(pduel->game_field->core.current_chain.size()) {
 		pduel->game_field->core.summon_reserved = pduel->game_field->core.subunits.back();
+		pduel->game_field->core.summon_reserved.arg3 = SUMMON_IN_CHAIN;
 		pduel->game_field->core.subunits.pop_back();
 		pduel->game_field->core.summoning_card = pcard;
 	}
@@ -369,6 +371,7 @@ int32 scriptlib::duel_synchro_summon(lua_State *L) {
 	pduel->game_field->special_summon_rule(playerid, pcard, SUMMON_TYPE_SYNCHRO);
 	if(pduel->game_field->core.current_chain.size()) {
 		pduel->game_field->core.summon_reserved = pduel->game_field->core.subunits.back();
+		pduel->game_field->core.summon_reserved.arg3 = SUMMON_IN_CHAIN;
 		pduel->game_field->core.subunits.pop_back();
 		pduel->game_field->core.summoning_card = pcard;
 	}
@@ -405,6 +408,7 @@ int32 scriptlib::duel_xyz_summon(lua_State *L) {
 	pduel->game_field->special_summon_rule(playerid, pcard, SUMMON_TYPE_XYZ);
 	if(pduel->game_field->core.current_chain.size()) {
 		pduel->game_field->core.summon_reserved = pduel->game_field->core.subunits.back();
+		pduel->game_field->core.summon_reserved.arg3 = SUMMON_IN_CHAIN;
 		pduel->game_field->core.subunits.pop_back();
 		pduel->game_field->core.summoning_card = pcard;
 	}
@@ -449,6 +453,7 @@ int32 scriptlib::duel_link_summon(lua_State *L) {
 	pduel->game_field->special_summon_rule(playerid, pcard, SUMMON_TYPE_LINK);
 	if(pduel->game_field->core.current_chain.size()) {
 		pduel->game_field->core.summon_reserved = pduel->game_field->core.subunits.back();
+		pduel->game_field->core.summon_reserved.arg3 = SUMMON_IN_CHAIN;
 		pduel->game_field->core.subunits.pop_back();
 		pduel->game_field->core.summoning_card = pcard;
 	}
@@ -481,6 +486,7 @@ int32 scriptlib::duel_setm(lua_State *L) {
 	pduel->game_field->mset(playerid, pcard, peffect, ignore_count, min_tribute, zone);
 	if(pduel->game_field->core.current_chain.size()) {
 		pduel->game_field->core.summon_reserved = pduel->game_field->core.subunits.back();
+		pduel->game_field->core.summon_reserved.arg3 = SUMMON_IN_CHAIN;
 		pduel->game_field->core.subunits.pop_back();
 		pduel->game_field->core.summoning_card = pcard;
 	}

--- a/operations.cpp
+++ b/operations.cpp
@@ -1456,7 +1456,7 @@ int32 field::equip(uint16 step, uint8 equip_player, card * equip_card, card * ta
 	}
 	return TRUE;
 }
-int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, uint8 ignore_count, uint8 min_tribute, uint32 zone) {
+int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, uint8 ignore_count, uint8 min_tribute, uint32 zone, uint32 action_type) {
 	switch(step) {
 	case 0: {
 		if(!target->is_summonable_card())
@@ -1956,7 +1956,7 @@ int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, ui
 		process_single_event();
 		raise_event(target, EVENT_SUMMON_SUCCESS, proc, 0, sumplayer, sumplayer, 0);
 		process_instant_event();
-		if(core.current_chain.size() == 0) {
+		if(!action_type) {
 			adjust_all();
 			core.hint_timing[sumplayer] |= TIMING_SUMMON;
 			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, FALSE, 0);
@@ -1966,7 +1966,7 @@ int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, ui
 	}
 	return TRUE;
 }
-int32 field::flip_summon(uint16 step, uint8 sumplayer, card * target) {
+int32 field::flip_summon(uint16 step, uint8 sumplayer, card * target, uint32 action_type) {
 	switch(step) {
 	case 0: {
 		if(target->current.location != LOCATION_MZONE)
@@ -2052,7 +2052,7 @@ int32 field::flip_summon(uint16 step, uint8 sumplayer, card * target) {
 		raise_event(target, EVENT_CHANGE_POS, 0, 0, sumplayer, sumplayer, 0);
 		process_instant_event();
 		adjust_all();
-		if(core.current_chain.size() == 0) {
+		if(!action_type) {
 			core.hint_timing[sumplayer] |= TIMING_FLIPSUMMON;
 			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, FALSE, 0);
 		}
@@ -2061,7 +2061,7 @@ int32 field::flip_summon(uint16 step, uint8 sumplayer, card * target) {
 	}
 	return TRUE;
 }
-int32 field::mset(uint16 step, uint8 setplayer, card* target, effect* proc, uint8 ignore_count, uint8 min_tribute, uint32 zone) {
+int32 field::mset(uint16 step, uint8 setplayer, card* target, effect* proc, uint8 ignore_count, uint8 min_tribute, uint32 zone, uint32 action_type) {
 	switch(step) {
 	case 0: {
 		if(!target->is_summonable_card())
@@ -2389,7 +2389,7 @@ int32 field::mset(uint16 step, uint8 setplayer, card* target, effect* proc, uint
 		adjust_instant();
 		raise_event(target, EVENT_MSET, proc, 0, setplayer, setplayer, 0);
 		process_instant_event();
-		if(core.current_chain.size() == 0) {
+		if(!action_type) {
 			adjust_all();
 			core.hint_timing[setplayer] |= TIMING_MSET;
 			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, FALSE, FALSE);
@@ -2669,7 +2669,7 @@ int32 field::sset_g(uint16 step, uint8 setplayer, uint8 toplayer, group* ptarget
 	}
 	return TRUE;
 }
-int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uint32 summon_type) {
+int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uint32 summon_type, uint32 action_type) {
 	switch(step) {
 	case 0: {
 		effect_set eset;
@@ -2953,7 +2953,7 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		process_single_event();
 		raise_event(target, EVENT_SPSUMMON_SUCCESS, proc, 0, sumplayer, sumplayer, 0);
 		process_instant_event();
-		if(core.current_chain.size() == 0) {
+		if(!action_type) {
 			adjust_all();
 			core.hint_timing[sumplayer] |= TIMING_SPSUMMON;
 			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, FALSE, 0);
@@ -3147,7 +3147,7 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		process_single_event();
 		raise_event(&pgroup->container, EVENT_SPSUMMON_SUCCESS, core.units.begin()->peffect, 0, sumplayer, sumplayer, 0);
 		process_instant_event();
-		if(core.current_chain.size() == 0) {
+		if(!action_type) {
 			adjust_all();
 			core.hint_timing[sumplayer] |= TIMING_SPSUMMON;
 			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, FALSE, 0);

--- a/processor.cpp
+++ b/processor.cpp
@@ -4485,29 +4485,27 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 		return FALSE;
 	}
 	case 11: {
-		for(auto cit = core.leave_confirmed.begin(); cit != core.leave_confirmed.end();) {
-			if(!(*cit)->is_status(STATUS_LEAVE_CONFIRMED))
-				cit = core.leave_confirmed.erase(cit);
-			else
-				++cit;
-		}
-		if(core.leave_confirmed.size())
-			send_to(&core.leave_confirmed, 0, REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
-		return FALSE;
-	}
-	case 12: {
 		core.used_event.splice(core.used_event.end(), core.point_event);
 		pduel->write_buffer8(MSG_CHAIN_END);
-		for(auto& ch_lim_p : core.chain_limit_p)
+		for (auto& ch_lim_p : core.chain_limit_p)
 			luaL_unref(pduel->lua->lua_state, LUA_REGISTRYINDEX, ch_lim_p.function);
 		core.chain_limit_p.clear();
 		core.effect_count_code_chain.clear();
 		reset_chain();
 		if (core.summoning_card)
 			core.subunits.push_back(core.summon_reserved);
-		if (core.effect_damage_step == 1)
-			core.subunits.push_back(core.damage_step_reserved);
 		core.summoning_card = 0;
+		return FALSE;
+	}
+	case 12: {
+		for (auto cit = core.leave_confirmed.begin(); cit != core.leave_confirmed.end();) {
+			if (!(*cit)->is_status(STATUS_LEAVE_CONFIRMED))
+				cit = core.leave_confirmed.erase(cit);
+			else
+				++cit;
+		}
+		if (core.leave_confirmed.size())
+			send_to(&core.leave_confirmed, 0, REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
 		return FALSE;
 	}
 	case 13: {
@@ -4519,6 +4517,8 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 			core.hint_timing[1] |= TIMING_CHAIN_END;
 			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, chainend_arg1, chainend_arg2);
 		}
+		if (core.effect_damage_step == 1)
+			core.subunits.push_back(core.damage_step_reserved);
 		returns.ivalue[0] = TRUE;
 		return TRUE;
 	}

--- a/processor.cpp
+++ b/processor.cpp
@@ -364,14 +364,14 @@ uint32 field::process() {
 		return pduel->message_buffer.size();
 	}
 	case PROCESSOR_SUMMON_RULE: {
-		if (summon(it->step, it->arg1 & 0xff, (card*)it->ptarget, it->peffect, (it->arg1 >> 8) & 0xff, (it->arg1 >> 16) & 0xff, (it->arg1 >> 24) & 0xff))
+		if (summon(it->step, it->arg1 & 0xff, (card*)it->ptarget, it->peffect, (it->arg1 >> 8) & 0xff, (it->arg1 >> 16) & 0xff, (it->arg1 >> 24) & 0xff, it->arg3))
 			core.units.pop_front();
 		else
 			++it->step;
 		return pduel->message_buffer.size();
 	}
 	case PROCESSOR_SPSUMMON_RULE: {
-		if (special_summon_rule(it->step, it->arg1, (card*)it->ptarget, it->arg2))
+		if (special_summon_rule(it->step, it->arg1, (card*)it->ptarget, it->arg2, it->arg3))
 			core.units.pop_front();
 		else
 			++it->step;
@@ -385,14 +385,14 @@ uint32 field::process() {
 		return pduel->message_buffer.size();
 	}
 	case PROCESSOR_FLIP_SUMMON: {
-		if (flip_summon(it->step, it->arg1, (card*)(it->ptarget)))
+		if (flip_summon(it->step, it->arg1, (card*)(it->ptarget), it->arg3))
 			core.units.pop_front();
 		else
 			++it->step;
 		return pduel->message_buffer.size();
 	}
 	case PROCESSOR_MSET: {
-		if (mset(it->step, it->arg1 & 0xff, (card*)it->ptarget, it->peffect, (it->arg1 >> 8) & 0xff, (it->arg1 >> 16) & 0xff, (it->arg1 >> 24) & 0xff))
+		if (mset(it->step, it->arg1 & 0xff, (card*)it->ptarget, it->peffect, (it->arg1 >> 8) & 0xff, (it->arg1 >> 16) & 0xff, (it->arg1 >> 24) & 0xff, it->arg3))
 			core.units.pop_front();
 		else
 			++it->step;
@@ -4480,7 +4480,7 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 		}
 		if(core.summoning_card)
 			core.subunits.push_back(core.summon_reserved);
-		core.summoning_card = 0;
+		core.summoning_card = nullptr;
 		core.units.begin()->step = -1;
 		return FALSE;
 	}
@@ -4494,7 +4494,7 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 		reset_chain();
 		if (core.summoning_card)
 			core.subunits.push_back(core.summon_reserved);
-		core.summoning_card = 0;
+		core.summoning_card = nullptr;
 		return FALSE;
 	}
 	case 12: {

--- a/processor.cpp
+++ b/processor.cpp
@@ -3112,7 +3112,7 @@ int32 field::process_battle_command(uint16 step) {
 		process_single_event();
 		process_instant_event();
 		if(core.effect_damage_step) {
-			core.reserved.ptr1 = core.units.begin()->ptarget;
+			core.damage_step_reserved.ptr1 = core.units.begin()->ptarget;
 			return TRUE;
 		}
 		core.units.begin()->step = 32;
@@ -3297,7 +3297,7 @@ int32 field::process_damage_step(uint16 step, uint32 new_attack) {
 		infos.phase = PHASE_DAMAGE_CAL;
 		add_process(PROCESSOR_BATTLE_COMMAND, 26, 0, 0, 0, 0);
 		core.units.begin()->step = 2;
-		core.reserved = core.units.front();
+		core.damage_step_reserved = core.units.front();
 		return TRUE;
 	}
 	case 2: {
@@ -4479,7 +4479,7 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 			return FALSE;
 		}
 		if(core.summoning_card)
-			core.subunits.push_back(core.reserved);
+			core.subunits.push_back(core.summon_reserved);
 		core.summoning_card = 0;
 		core.units.begin()->step = -1;
 		return FALSE;
@@ -4503,8 +4503,10 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 		core.chain_limit_p.clear();
 		core.effect_count_code_chain.clear();
 		reset_chain();
-		if(core.summoning_card || core.effect_damage_step == 1)
-			core.subunits.push_back(core.reserved);
+		if (core.summoning_card)
+			core.subunits.push_back(core.summon_reserved);
+		if (core.effect_damage_step == 1)
+			core.subunits.push_back(core.damage_step_reserved);
 		core.summoning_card = 0;
 		return FALSE;
 	}


### PR DESCRIPTION
@mercury233 @purerosefallen 
https://github.com/Fluorohydride/ygopro-scripts/pull/2246

Before:
- EVENT_SPSUMMON_SUCCESS of summon in Chain Link 1 and EVENT_CHAIN_END are different timing.
(Break Auxiliary.RegisterMergedDelayedEvent)

- Summon after CL1 card is sent to grave.

After:
- They are the same timing.

- Summon before CL1 card is sent to grave.