### PR TITLE
Update effect::is_can_be_forbidden

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -43,8 +43,6 @@ int32 effect::is_self_destroy_related() {
 int32 effect::is_can_be_forbidden() {
 	if (is_flag(EFFECT_FLAG_CANNOT_DISABLE) && !is_flag(EFFECT_FLAG_CANNOT_NEGATE))
 		return FALSE;
-	if (code == EFFECT_CHANGE_CODE)
-		return FALSE;
 	return TRUE;
 }
 // check if a single/field/equip effect is available


### PR DESCRIPTION
>ただし、「[赤しゃりの軍貫](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17428)」を宣言して発動した「[禁止令](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4968)」の効果が適用されている場合には、デッキに存在する「[赤しゃりの軍貫](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17428)」の効果は適用されず、カード名は「[赤しゃりの軍貫](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17428)」として扱われますので、「[赤しゃりの軍貫](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=17428)」を宣言して「[抹殺の指名者](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=14627)」を発動できます。
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23637&keyword=&tag=-1&request_locale=ja

