### PR TITLE
fix Card.IsFusionSummonableCard

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3312,6 +3312,8 @@ int32 card::is_spsummonable_card() {
 int32 card::is_fusion_summonable_card(uint32 summon_type) {
 	if(!(data.type & TYPE_FUSION))
 		return FALSE;
+	if((data.type & TYPE_PENDULUM) && current.location == LOCATION_EXTRA && (current.position & POS_FACEUP))
+		return FALSE;
 	summon_type |= SUMMON_TYPE_FUSION;
 	effect_set eset;
 	filter_effect(EFFECT_SPSUMMON_CONDITION, &eset);


### PR DESCRIPTION
fix: _Future Fusion_ can select face-up fusion monster because of `Card.IsFusionSummonableCard` returned true.

> mail:
> Q.
> 「未来融合－フューチャー・フュージョン」の①の効果でお互いに確認する融合モンスターとして、「ペンデュラム・フュージョン」の効果で融合召喚された後にエクストラデッキに表側表示で加わっている「聖菓使クーベル」を選ぶ事はできますか？
> A.
> 「未来融合－フューチャー・フュージョン」の『①』の効果処理として、**エクストラデッキに表側表示で存在する「聖菓使クーベル」を確認することはできません**。