### PR TITLE
update Card.GetOriginalCode, Card.GetOriginalCodeRule, Card.IsOriginalCodeRule

### DIFF
--- a/card.h
+++ b/card.h
@@ -99,6 +99,12 @@ struct material_info {
 };
 const material_info null_info;
 
+constexpr uint32 CARD_MARINE_DOLPHIN = 78734254;
+constexpr uint32 CARD_TWINKLE_MOSS = 13857930;
+constexpr uint32 CARD_TIMAEUS = 1784686;
+constexpr uint32 CARD_CRITIAS = 11082056;
+constexpr uint32 CARD_HERMOS = 46232525;
+
 class card {
 public:
 	struct effect_relation_hash {
@@ -137,6 +143,8 @@ public:
 		uint8 location{ 0 };
 		uint8 sequence{ 0 };
 	};
+	static const std::unordered_map<uint32, uint32> second_code;
+
 	int32 ref_handle;
 	duel* pduel;
 	card_data data;
@@ -206,7 +214,8 @@ public:
 
 	int32 get_infos(byte* buf, uint32 query_flag, int32 use_cache = TRUE);
 	uint32 get_info_location();
-	uint32 second_code(uint32 code);
+	uint32 get_original_code() const;
+	std::tuple<uint32, uint32> get_original_code_rule() const;
 	uint32 get_code();
 	uint32 get_another_code();
 	int32 is_set_card(uint32 set_code);
@@ -417,10 +426,6 @@ public:
 #define SUMMON_INFO_ATTACK			0x80
 #define SUMMON_INFO_DEFENSE			0x100
 #define SUMMON_INFO_REASON_EFFECT	0x200
-
-//double-name cards
-#define CARD_MARINE_DOLPHIN	78734254
-#define CARD_TWINKLE_MOSS	13857930
 
 #define CARD_ARTWORK_VERSIONS_OFFSET	10
 

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -24,40 +24,29 @@ int32 scriptlib::card_get_code(lua_State *L) {
 	}
 	return 1;
 }
-// GetOriginalCode(): get the original code printed on card
-// return: 1 int
 int32 scriptlib::card_get_origin_code(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	if(pcard->data.alias) {
-		if((pcard->data.alias < pcard->data.code + CARD_ARTWORK_VERSIONS_OFFSET) && (pcard->data.code < pcard->data.alias + CARD_ARTWORK_VERSIONS_OFFSET))
-			lua_pushinteger(L, pcard->data.alias);
-		else
-			lua_pushinteger(L, pcard->data.code);
-	} else
-		lua_pushinteger(L, pcard->data.code);
+	lua_pushinteger(L, pcard->get_original_code());
 	return 1;
 }
-// GetOriginalCodeRule(): get the original code in duel (can be different from printed code)
-// return: 1-2 int
 int32 scriptlib::card_get_origin_code_rule(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	effect_set eset;
-	pcard->filter_effect(EFFECT_ADD_CODE, &eset);
-	if(pcard->data.alias && !eset.size())
-		lua_pushinteger(L, pcard->data.alias);
-	else {
-		lua_pushinteger(L, pcard->data.code);
-		if(eset.size()) {
-			uint32 otcode = eset.get_last()->get_value(pcard);
-			lua_pushinteger(L, otcode);
-			return 2;
-		}
+	auto codes = pcard->get_original_code_rule();
+	uint32 code1 = std::get<0>(codes);
+	uint32 code2 = std::get<1>(codes);
+	if (code2) {
+		lua_pushinteger(L, code1);
+		lua_pushinteger(L, code2);
+		return 2;
 	}
-	return 1;
+	else {
+		lua_pushinteger(L, code1);
+		return 1;
+	}
 }
 int32 scriptlib::card_get_fusion_code(lua_State *L) {
 	check_param_count(L, 1);
@@ -967,19 +956,9 @@ int32 scriptlib::card_is_origin_code_rule(lua_State *L) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	uint32 code1 = 0;
-	uint32 code2 = 0;
-	effect_set eset;
-	pcard->filter_effect(EFFECT_ADD_CODE, &eset);
-	if(pcard->data.alias && !eset.size()){
-		code1 = pcard->data.alias;
-		code2 = 0;
-	}
-	else {
-		code1 = pcard->data.code;
-		if(eset.size())
-			code2 = eset.get_last()->get_value(pcard);
-	}
+	auto codes = pcard->get_original_code_rule();
+	uint32 code1 = std::get<0>(codes);
+	uint32 code2 = std::get<1>(codes);
 	uint32 count = lua_gettop(L) - 1;
 	uint32 result = FALSE;
 	for(uint32 i = 0; i < count; ++i) {

--- a/operations.cpp
+++ b/operations.cpp
@@ -3931,16 +3931,9 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 						pcard->previous.defense = atk_def.second;
 					}
 				} else {
-					effect_set eset;
-					pcard->filter_effect(EFFECT_ADD_CODE, &eset);
-					if(pcard->data.alias && !eset.size())
-						pcard->previous.code = pcard->data.alias;
-					else
-						pcard->previous.code = pcard->data.code;
-					if(eset.size())
-						pcard->previous.code2 = eset.get_last()->get_value(pcard);
-					else
-						pcard->previous.code2 = 0;
+					auto codes = pcard->get_original_code_rule();
+					pcard->previous.code = std::get<0>(codes);
+					pcard->previous.code2 = std::get<1>(codes);
 					pcard->previous.type = pcard->data.type;
 					pcard->previous.level = pcard->data.level;
 					pcard->previous.rank = pcard->data.level;


### PR DESCRIPTION
@mercury233 @purerosefallen 
Simplify `card::get_code()`, `card::get_another_code()`

`card::second_code`
Now cards with 2 original name are checked by looking up this table.

`data.code`
This is the id in card database, which might be an id of alternative artwork.

The types of card id are:
- cards with 2 original name
Lua table id: data.code
code_rule1: data.code
code_rule2: second_code[data.code]

- always treated as X
Lua table id: data.code
code_rule1: data.alias
code_rule2: 0

- alternative artwork
Lua table id: data.alias (The original card)
code_rule1: data.alias
code_rule2: 0

- other
Lua table id: data.code
code_rule1: data.code
code_rule2: 0

The Lua table id: `card::get_original_code()`
code_rule1, code_rule2: `card::get_original_code_rule()`

Now `data.code` is not sent to Lua functions directly.


