### PR TITLE
update CheckReleaseGroupEx and so on

### DIFF
--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2664,58 +2664,56 @@ int32 scriptlib::duel_get_release_group_count(lua_State *L) {
 	return 1;
 }
 int32 scriptlib::duel_check_release_group(lua_State *L) {
-	const int32 must_param = 5;
+	const int32 must_param = 4;
 	check_param_count(L, must_param);
-	uint32 reason = (uint32)lua_tointeger(L, 1);
-	int32 playerid = (int32)lua_tointeger(L, 2);
+	int32 playerid = (int32)lua_tointeger(L, 1);
 	if(playerid != 0 && playerid != 1)
 		return 0;
 	int32 use_con = FALSE;
-	if(!lua_isnil(L, 3)) {
-		check_param(L, PARAM_TYPE_FUNCTION, 3);
+	if(!lua_isnil(L, 2)) {
+		check_param(L, PARAM_TYPE_FUNCTION, 2);
 		use_con = TRUE;
 	}
-	uint32 fcount = (uint32)lua_tointeger(L, 4);
+	uint32 fcount = (uint32)lua_tointeger(L, 3);
 	card* pexception = nullptr;
 	group *pexgroup = nullptr;
+	if(check_param(L, PARAM_TYPE_CARD, 4, TRUE))
+		pexception = *(card**) lua_touserdata(L, 4);
+	else if(check_param(L, PARAM_TYPE_GROUP, 4, TRUE))
+		pexgroup = *(group**) lua_touserdata(L, 4);
+	uint32 extraargs = lua_gettop(L) - must_param;
+	duel* pduel = interpreter::get_duel_info(L);
+	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, FALSE, 2, extraargs, pexception, pexgroup, REASON_COST);
+	pduel->game_field->core.must_select_cards.clear();
+	lua_pushboolean(L, result);
+	return 1;
+}
+int32 scriptlib::duel_select_release_group(lua_State *L) {
+	const int32 must_param = 5;
+	check_action_permission(L);
+	check_param_count(L, must_param);
+	int32 playerid = (int32)lua_tointeger(L, 1);
+	if(playerid != 0 && playerid != 1)
+		return 0;
+	int32 use_con = FALSE;
+	if(!lua_isnil(L, 2)) {
+		check_param(L, PARAM_TYPE_FUNCTION, 2);
+		use_con = TRUE;
+	}
+	uint32 min = (uint32)lua_tointeger(L, 3);
+	uint32 max = (uint32)lua_tointeger(L, 4);
+	card* pexception = 0;
+	group* pexgroup = 0;
 	if(check_param(L, PARAM_TYPE_CARD, 5, TRUE))
 		pexception = *(card**) lua_touserdata(L, 5);
 	else if(check_param(L, PARAM_TYPE_GROUP, 5, TRUE))
 		pexgroup = *(group**) lua_touserdata(L, 5);
 	uint32 extraargs = lua_gettop(L) - must_param;
 	duel* pduel = interpreter::get_duel_info(L);
-	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, FALSE, 3, extraargs, pexception, pexgroup, reason);
-	pduel->game_field->core.must_select_cards.clear();
-	lua_pushboolean(L, result);
-	return 1;
-}
-int32 scriptlib::duel_select_release_group(lua_State *L) {
-	const int32 must_param = 6;
-	check_action_permission(L);
-	check_param_count(L, must_param);
-	uint32 reason = (uint32)lua_tointeger(L, 1);
-	int32 playerid = (int32)lua_tointeger(L, 2);
-	if(playerid != 0 && playerid != 1)
-		return 0;
-	int32 use_con = FALSE;
-	if(!lua_isnil(L, 3)) {
-		check_param(L, PARAM_TYPE_FUNCTION, 3);
-		use_con = TRUE;
-	}
-	uint32 min = (uint32)lua_tointeger(L, 4);
-	uint32 max = (uint32)lua_tointeger(L, 5);
-	card* pexception = 0;
-	group* pexgroup = 0;
-	if(check_param(L, PARAM_TYPE_CARD, 6, TRUE))
-		pexception = *(card**) lua_touserdata(L, 6);
-	else if(check_param(L, PARAM_TYPE_GROUP, 6, TRUE))
-		pexgroup = *(group**) lua_touserdata(L, 6);
-	uint32 extraargs = lua_gettop(L) - must_param;
-	duel* pduel = interpreter::get_duel_info(L);
 	pduel->game_field->core.release_cards.clear();
 	pduel->game_field->core.release_cards_ex.clear();
 	pduel->game_field->core.release_cards_ex_oneof.clear();
-	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_con, FALSE, 3, extraargs, pexception, pexgroup, reason);
+	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_con, FALSE, 2, extraargs, pexception, pexgroup, REASON_COST);
 	pduel->game_field->add_process(PROCESSOR_SELECT_RELEASE, 0, 0, 0, playerid, (max << 16) + min);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
@@ -2729,58 +2727,60 @@ int32 scriptlib::duel_select_release_group(lua_State *L) {
 	});
 }
 int32 scriptlib::duel_check_release_group_ex(lua_State *L) {
-	const int32 must_param = 5;
+	const int32 must_param = 6;
 	check_param_count(L, must_param);
-	uint32 reason = (uint32)lua_tointeger(L, 1);
-	int32 playerid = (int32)lua_tointeger(L, 2);
+	int32 playerid = (int32)lua_tointeger(L, 1);
 	if(playerid != 0 && playerid != 1)
 		return 0;
 	int32 use_con = FALSE;
-	if(!lua_isnil(L, 3)) {
-		check_param(L, PARAM_TYPE_FUNCTION, 3);
+	if(!lua_isnil(L, 2)) {
+		check_param(L, PARAM_TYPE_FUNCTION, 2);
 		use_con = TRUE;
 	}
-	uint32 fcount = (uint32)lua_tointeger(L, 4);
+	uint32 fcount = (uint32)lua_tointeger(L, 3);
+	uint32 reason = (uint32)lua_tointeger(L, 4);
+	int32 use_hand = lua_toboolean(L, 5);
 	card* pexception = nullptr;
 	group *pexgroup = nullptr;
-	if(check_param(L, PARAM_TYPE_CARD, 5, TRUE))
-		pexception = *(card**) lua_touserdata(L, 5);
-	else if(check_param(L, PARAM_TYPE_GROUP, 5, TRUE))
-		pexgroup = *(group**) lua_touserdata(L, 5);
-	uint32 extraargs = lua_gettop(L) - must_param;
-	duel* pduel = interpreter::get_duel_info(L);
-	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, TRUE, 3, extraargs, pexception, pexgroup, reason);
-	pduel->game_field->core.must_select_cards.clear();
-	lua_pushboolean(L, result);
-	return 1;
-}
-int32 scriptlib::duel_select_release_group_ex(lua_State *L) {
-	const int32 must_param = 6;
-	check_action_permission(L);
-	check_param_count(L, must_param);
-	uint32 reason = (uint32)lua_tointeger(L, 1);
-	int32 playerid = (int32)lua_tointeger(L, 2);
-	if(playerid != 0 && playerid != 1)
-		return 0;
-	int32 use_con = FALSE;
-	if(!lua_isnil(L, 3)) {
-		check_param(L, PARAM_TYPE_FUNCTION, 3);
-		use_con = TRUE;
-	}
-	uint32 min = (uint32)lua_tointeger(L, 4);
-	uint32 max = (uint32)lua_tointeger(L, 5);
-	card* pexception = 0;
-	group* pexgroup = 0;
 	if(check_param(L, PARAM_TYPE_CARD, 6, TRUE))
 		pexception = *(card**) lua_touserdata(L, 6);
 	else if(check_param(L, PARAM_TYPE_GROUP, 6, TRUE))
 		pexgroup = *(group**) lua_touserdata(L, 6);
 	uint32 extraargs = lua_gettop(L) - must_param;
 	duel* pduel = interpreter::get_duel_info(L);
+	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, use_hand, 2, extraargs, pexception, pexgroup, reason);
+	pduel->game_field->core.must_select_cards.clear();
+	lua_pushboolean(L, result);
+	return 1;
+}
+int32 scriptlib::duel_select_release_group_ex(lua_State *L) {
+	const int32 must_param = 7;
+	check_action_permission(L);
+	check_param_count(L, must_param);
+	int32 playerid = (int32)lua_tointeger(L, 1);
+	if(playerid != 0 && playerid != 1)
+		return 0;
+	int32 use_con = FALSE;
+	if(!lua_isnil(L, 2)) {
+		check_param(L, PARAM_TYPE_FUNCTION, 2);
+		use_con = TRUE;
+	}
+	uint32 min = (uint32)lua_tointeger(L, 3);
+	uint32 max = (uint32)lua_tointeger(L, 4);
+	uint32 reason = (uint32)lua_tointeger(L, 5);
+	int32 use_hand = lua_toboolean(L, 6);
+	card* pexception = 0;
+	group* pexgroup = 0;
+	if(check_param(L, PARAM_TYPE_CARD, 7, TRUE))
+		pexception = *(card**) lua_touserdata(L, 7);
+	else if(check_param(L, PARAM_TYPE_GROUP, 7, TRUE))
+		pexgroup = *(group**) lua_touserdata(L, 7);
+	uint32 extraargs = lua_gettop(L) - must_param;
+	duel* pduel = interpreter::get_duel_info(L);
 	pduel->game_field->core.release_cards.clear();
 	pduel->game_field->core.release_cards_ex.clear();
 	pduel->game_field->core.release_cards_ex_oneof.clear();
-	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_con, TRUE, 3, extraargs, pexception, pexgroup, reason);
+	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_con, use_hand, 2, extraargs, pexception, pexgroup, reason);
 	pduel->game_field->add_process(PROCESSOR_SELECT_RELEASE, 0, 0, 0, playerid, (max << 16) + min);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;


### PR DESCRIPTION
Change the syntax of https://github.com/Fluorohydride/ygopro-core/pull/516 

Change `Duel.CheckReleaseGroup` and `Duel.SelectReleaseGroup` back to the former syntax, remove the `reason` param added in #516, make `REASON_COST` as the reason.

Change `Duel.CheckReleaseGroupEx` to
```Duel.CheckReleaseGroupEx(player,f,count,reason,use_hand,ex,...)```
Change `Duel.SelectReleaseGroupEx` to
```Duel.SelectReleaseGroupEx(player,f,min,max,reason,use_hand,ex,...)```

If the reason of release is not Cost, it should use `Duel.CheckReleaseGroupEx` , which can set reason.

Former we use `Duel.CheckReleaseGroupEx` for checking monster zone + hand, now it requires `use_hand` param to be true.
