### PR TITLE
add pendulum summon functions

### DIFF
--- a/card.h
+++ b/card.h
@@ -322,7 +322,7 @@ public:
 	int32 filter_set_procedure(uint8 playerid, effect_set* eset, uint8 ignore_count, uint8 min_tribute, uint32 zone);
 	int32 check_set_procedure(effect* proc, uint8 playerid, uint8 ignore_count, uint8 min_tribute, uint32 zone);
 	void filter_spsummon_procedure(uint8 playerid, effect_set* eset, uint32 summon_type, material_info info = null_info);
-	void filter_spsummon_procedure_g(uint8 playerid, effect_set* eset);
+	void filter_spsummon_procedure_g(uint8 playerid, effect_set* eset, group* mg);
 	effect* is_affected_by_effect(int32 code);
 	effect* is_affected_by_effect(int32 code, card* target);
 	int32 fusion_check(group* fusion_m, card* cg, uint32 chkf, uint8 not_material);
@@ -330,6 +330,7 @@ public:
 	int32 check_fusion_substitute(card* fcard);
 	int32 is_not_tuner(card* scard);
 	int32 is_tuner(card* scard);
+	int32 is_pendulum_summon(uint8 playerid, group* mg);
 
 	int32 check_unique_code(card* pcard);
 	void get_unique_target(card_set* cset, int32 controler, card* icard = nullptr);

--- a/field.cpp
+++ b/field.cpp
@@ -3271,6 +3271,14 @@ int32 field::is_player_can_spsummon_count(uint8 playerid, uint32 count) {
 	}
 	return check_spsummon_counter(playerid, count);
 }
+int32 field::is_player_can_pendulum_summon(uint8 playerid, group* mg) {
+	for(uint8 p = 0; p < 2; ++p) {
+		for(auto& pcard : player[p].list_szone)
+			if(pcard && pcard->current.pzone && pcard->is_pendulum_summon(playerid, mg))
+				return TRUE;
+	}
+	return FALSE;
+}
 int32 field::is_player_can_place_counter(uint8 playerid, card * pcard, uint16 countertype, uint16 count) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_PLACE_COUNTER, &eset);

--- a/field.h
+++ b/field.h
@@ -293,7 +293,7 @@ struct processor {
 	int32 battle_damage[2]{};
 	int32 summon_count[2]{};
 	uint8 extra_summon[2]{};
-	uint8 extra_pendulum_summon[2]{};
+	uint8 default_pendulum_summon[2]{};
 	int32 spe_effect[2]{};
 	int32 duel_options{ 0 };
 	int32 duel_rule{ CURRENT_RULE };	//current rule: 5, Master Rule 2020

--- a/field.h
+++ b/field.h
@@ -293,6 +293,7 @@ struct processor {
 	int32 battle_damage[2]{};
 	int32 summon_count[2]{};
 	uint8 extra_summon[2]{};
+	uint8 extra_pendulum_summon[2]{};
 	int32 spe_effect[2]{};
 	int32 duel_options{ 0 };
 	int32 duel_rule{ CURRENT_RULE };	//current rule: 5, Master Rule 2020

--- a/field.h
+++ b/field.h
@@ -304,6 +304,7 @@ struct processor {
 	uint8 coin_result[MAX_COIN_COUNT]{};
 	int32 coin_count{ 0 };
 	bool is_target_ready{ false };
+	uint32 summon_action_type{ SUMMON_IN_IDLE };
 
 	uint8 to_bp{ FALSE };
 	uint8 to_m2{ FALSE };

--- a/field.h
+++ b/field.h
@@ -285,6 +285,7 @@ struct processor {
 	card* limit_link_card{ nullptr };
 	int32 limit_link_minc{ 0 };
 	int32 limit_link_maxc{ 0 };
+	group* limit_pendulum{ nullptr };
 	uint8 not_material{ FALSE };
 	uint8 attack_cancelable{ FALSE };
 	uint8 attack_rollback{ FALSE };
@@ -485,6 +486,7 @@ public:
 	int32 is_player_can_flipsummon(uint8 playerid, card* pcard);
 	int32 is_player_can_spsummon_monster(uint8 playerid, uint8 toplayer, uint8 sumpos, uint32 sumtype, card_data* pdata);
 	int32 is_player_can_spsummon_count(uint8 playerid, uint32 count);
+	int32 is_player_can_pendulum_summon(uint8 playerid, group* mg);
 	int32 is_player_can_release(uint8 playerid, card* pcard, uint32 reason);
 	int32 is_player_can_place_counter(uint8 playerid, card* pcard, uint16 countertype, uint16 count);
 	int32 is_player_can_remove_counter(uint8 playerid, card* pcard, uint8 s, uint8 o, uint16 countertype, uint16 count, uint32 reason);
@@ -595,6 +597,7 @@ public:
 	int32 sset_g(uint16 step, uint8 setplayer, uint8 toplayer, group* ptarget, uint8 confirm, effect* reason_effect);
 	int32 special_summon_step(uint16 step, group* targets, card* target, uint32 zone);
 	int32 special_summon(uint16 step, effect* reason_effect, uint8 reason_player, group* targets, uint32 zone);
+	int32 pendulum_summon(uint16 step, uint8 playerid, group* mg);
 	int32 destroy_replace(uint16 step, group* targets, card* target, uint8 battle);
 	int32 destroy(uint16 step, group* targets, effect* reason_effect, uint32 reason, uint8 reason_player);
 	int32 release_replace(uint16 step, group* targets, card* target);
@@ -764,6 +767,7 @@ public:
 #define PROCESSOR_SSET				65
 #define PROCESSOR_SPSUMMON_STEP		66
 #define PROCESSOR_SSET_G			67
+#define PROCESSOR_PENDULUM_SUMMON	68
 #define PROCESSOR_DRAW				70
 #define PROCESSOR_DAMAGE			71  //arg1: arguments, arg2: arguments, arg3: arguments
 #define PROCESSOR_RECOVER			72  //arg1: arguments, arg2: arguments, arg3: arguments

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -438,7 +438,7 @@ int32 scriptlib::duel_pendulum_summon(lua_State *L) {
 		pendulum_group = pduel->new_group(pgroup->container);
 		pendulum_group->is_readonly = 1;
 	}
-	pduel->game_field->add_process(PROCESSOR_PENDULUM_SUMMON, 0, NULL, pendulum_group, playerid, 0);
+	pduel->game_field->add_process(PROCESSOR_PENDULUM_SUMMON, 0, nullptr, pendulum_group, playerid, 0);
 	return lua_yield(L, 0);
 }
 int32 scriptlib::duel_link_summon(lua_State *L) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3630,6 +3630,14 @@ int32 scriptlib::duel_remove_overlay_card(lua_State *L) {
 		return 1;
 	});
 }
+int32 scriptlib::duel_is_summon_in_chain(lua_State *L) {
+	duel* pduel = interpreter::get_duel_info(L);
+	if(pduel->game_field->core.summon_action_type == SUMMON_IN_CHAIN)
+		lua_pushboolean(L, 1);
+	else
+		lua_pushboolean(L, 0);
+	return 1;
+}
 int32 scriptlib::duel_hint(lua_State * L) {
 	check_param_count(L, 3);
 	int32 htype = (int32)lua_tointeger(L, 1);
@@ -4893,6 +4901,7 @@ static const struct luaL_Reg duellib[] = {
 	{ "GetOverlayCount", scriptlib::duel_get_overlay_count },
 	{ "CheckRemoveOverlayCard", scriptlib::duel_check_remove_overlay_card },
 	{ "RemoveOverlayCard", scriptlib::duel_remove_overlay_card },
+	{ "IsSummonInChain", scriptlib::duel_is_summon_in_chain },
 	{ "Hint", scriptlib::duel_hint },
 	{ "HintSelection", scriptlib::duel_hint_selection },
 	{ "SelectEffectYesNo", scriptlib::duel_select_effect_yesno },

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3649,7 +3649,7 @@ int32 scriptlib::duel_remove_overlay_card(lua_State *L) {
 		return 1;
 	});
 }
-int32 scriptlib::duel_default_pendulum_summoned(lua_State *L) {
+int32 scriptlib::duel_use_default_pendulum_summon(lua_State *L) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	int32 playerid = (int32)lua_tointeger(L, 1);
@@ -4961,7 +4961,7 @@ static const struct luaL_Reg duellib[] = {
 	{ "GetOverlayCount", scriptlib::duel_get_overlay_count },
 	{ "CheckRemoveOverlayCard", scriptlib::duel_check_remove_overlay_card },
 	{ "RemoveOverlayCard", scriptlib::duel_remove_overlay_card },
-	{ "DefaultPendulumSummoned", scriptlib::duel_default_pendulum_summoned },
+	{ "UseDefaultPendulumSummon", scriptlib::duel_use_default_pendulum_summon },
 	{ "IsSummonInChain", scriptlib::duel_is_summon_in_chain },
 	{ "Hint", scriptlib::duel_hint },
 	{ "HintSelection", scriptlib::duel_hint_selection },

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3649,14 +3649,14 @@ int32 scriptlib::duel_remove_overlay_card(lua_State *L) {
 		return 1;
 	});
 }
-int32 scriptlib::duel_set_additional_pendulum_summon(lua_State *L) {
+int32 scriptlib::duel_default_pendulum_summoned(lua_State *L) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	int32 playerid = (int32)lua_tointeger(L, 1);
 	if(playerid != 0 && playerid != 1)
 		return 0;
 	duel* pduel = interpreter::get_duel_info(L);
-	pduel->game_field->core.extra_pendulum_summon[playerid] = TRUE;
+	pduel->game_field->core.default_pendulum_summon[playerid] = TRUE;
 	return 0;
 }
 int32 scriptlib::duel_is_summon_in_chain(lua_State *L) {
@@ -4510,7 +4510,7 @@ int32 scriptlib::duel_is_player_can_additional_summon(lua_State * L) {
 		lua_pushboolean(L, 0);
 	return 1;
 }
-int32 scriptlib::duel_is_player_can_additional_pendulum_summon(lua_State * L) {
+int32 scriptlib::duel_is_player_default_pendulum_summoned(lua_State * L) {
 	check_param_count(L, 1);
 	int32 playerid = (int32)lua_tointeger(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -4518,7 +4518,7 @@ int32 scriptlib::duel_is_player_can_additional_pendulum_summon(lua_State * L) {
 		return 1;
 	}
 	duel* pduel = interpreter::get_duel_info(L);
-	if(pduel->game_field->core.extra_pendulum_summon[playerid] == 0)
+	if(pduel->game_field->core.default_pendulum_summon[playerid])
 		lua_pushboolean(L, 1);
 	else
 		lua_pushboolean(L, 0);
@@ -4961,7 +4961,7 @@ static const struct luaL_Reg duellib[] = {
 	{ "GetOverlayCount", scriptlib::duel_get_overlay_count },
 	{ "CheckRemoveOverlayCard", scriptlib::duel_check_remove_overlay_card },
 	{ "RemoveOverlayCard", scriptlib::duel_remove_overlay_card },
-	{ "SetAdditionalPendulumSummon", scriptlib::duel_set_additional_pendulum_summon },
+	{ "DefaultPendulumSummoned", scriptlib::duel_default_pendulum_summoned },
 	{ "IsSummonInChain", scriptlib::duel_is_summon_in_chain },
 	{ "Hint", scriptlib::duel_hint },
 	{ "HintSelection", scriptlib::duel_hint_selection },
@@ -5004,7 +5004,7 @@ static const struct luaL_Reg duellib[] = {
 	{ "IsPlayerCanSendtoGrave", scriptlib::duel_is_player_can_send_to_grave },
 	{ "IsPlayerCanSendtoDeck", scriptlib::duel_is_player_can_send_to_deck },
 	{ "IsPlayerCanAdditionalSummon", scriptlib::duel_is_player_can_additional_summon },
-	{ "IsPlayerCanAdditionalPendulumSummon", scriptlib::duel_is_player_can_additional_pendulum_summon },
+	{ "IsPlayerDefaultPendulumSummoned", scriptlib::duel_is_player_default_pendulum_summoned },
 	{ "IsChainNegatable", scriptlib::duel_is_chain_negatable },
 	{ "IsChainDisablable", scriptlib::duel_is_chain_disablable },
 	{ "IsChainDisabled", scriptlib::duel_is_chain_disabled },

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3649,6 +3649,16 @@ int32 scriptlib::duel_remove_overlay_card(lua_State *L) {
 		return 1;
 	});
 }
+int32 scriptlib::duel_set_additional_pendulum_summon(lua_State *L) {
+	check_action_permission(L);
+	check_param_count(L, 1);
+	int32 playerid = (int32)lua_tointeger(L, 1);
+	if(playerid != 0 && playerid != 1)
+		return 0;
+	duel* pduel = interpreter::get_duel_info(L);
+	pduel->game_field->core.extra_pendulum_summon[playerid] = TRUE;
+	return 0;
+}
 int32 scriptlib::duel_is_summon_in_chain(lua_State *L) {
 	duel* pduel = interpreter::get_duel_info(L);
 	if(pduel->game_field->core.summon_action_type == SUMMON_IN_CHAIN)
@@ -4500,6 +4510,20 @@ int32 scriptlib::duel_is_player_can_additional_summon(lua_State * L) {
 		lua_pushboolean(L, 0);
 	return 1;
 }
+int32 scriptlib::duel_is_player_can_additional_pendulum_summon(lua_State * L) {
+	check_param_count(L, 1);
+	int32 playerid = (int32)lua_tointeger(L, 1);
+	if(playerid != 0 && playerid != 1) {
+		lua_pushboolean(L, 0);
+		return 1;
+	}
+	duel* pduel = interpreter::get_duel_info(L);
+	if(pduel->game_field->core.extra_pendulum_summon[playerid] == 0)
+		lua_pushboolean(L, 1);
+	else
+		lua_pushboolean(L, 0);
+	return 1;
+}
 int32 scriptlib::duel_is_chain_negatable(lua_State * L) {
 	check_param_count(L, 1);
 	lua_pushboolean(L, 1);
@@ -4937,6 +4961,7 @@ static const struct luaL_Reg duellib[] = {
 	{ "GetOverlayCount", scriptlib::duel_get_overlay_count },
 	{ "CheckRemoveOverlayCard", scriptlib::duel_check_remove_overlay_card },
 	{ "RemoveOverlayCard", scriptlib::duel_remove_overlay_card },
+	{ "SetAdditionalPendulumSummon", scriptlib::duel_set_additional_pendulum_summon },
 	{ "IsSummonInChain", scriptlib::duel_is_summon_in_chain },
 	{ "Hint", scriptlib::duel_hint },
 	{ "HintSelection", scriptlib::duel_hint_selection },
@@ -4979,6 +5004,7 @@ static const struct luaL_Reg duellib[] = {
 	{ "IsPlayerCanSendtoGrave", scriptlib::duel_is_player_can_send_to_grave },
 	{ "IsPlayerCanSendtoDeck", scriptlib::duel_is_player_can_send_to_deck },
 	{ "IsPlayerCanAdditionalSummon", scriptlib::duel_is_player_can_additional_summon },
+	{ "IsPlayerCanAdditionalPendulumSummon", scriptlib::duel_is_player_can_additional_pendulum_summon },
 	{ "IsChainNegatable", scriptlib::duel_is_chain_negatable },
 	{ "IsChainDisablable", scriptlib::duel_is_chain_disablable },
 	{ "IsChainDisabled", scriptlib::duel_is_chain_disabled },

--- a/operations.cpp
+++ b/operations.cpp
@@ -2668,6 +2668,7 @@ int32 field::sset_g(uint16 step, uint8 setplayer, uint8 toplayer, group* ptarget
 int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uint32 summon_type, uint32 action_type) {
 	switch(step) {
 	case 0: {
+		core.summon_action_type = action_type;
 		effect_set eset;
 		material_info info;
 		info.limit_tuner = core.limit_tuner;
@@ -2683,8 +2684,10 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		info.limit_link_maxc = core.limit_link_maxc;
 		target->filter_spsummon_procedure(sumplayer, &eset, summon_type, info);
 		target->filter_spsummon_procedure_g(sumplayer, &eset);
-		if(!eset.size())
+		if(!eset.size()) {
+			core.summon_action_type = SUMMON_IN_IDLE;
 			return TRUE;
+		}
 		core.select_effects.clear();
 		core.select_options.clear();
 		for(int32 i = 0; i < eset.size(); ++i) {
@@ -2734,8 +2737,10 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		return FALSE;
 	}
 	case 2: {
-		if(!returns.ivalue[0])
+		if(!returns.ivalue[0]) {
+			core.summon_action_type = SUMMON_IN_IDLE;
 			return TRUE;
+		}
 		effect_set eset;
 		target->filter_effect(EFFECT_SPSUMMON_COST, &eset);
 		if(eset.size()) {
@@ -2954,6 +2959,7 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 			core.hint_timing[sumplayer] |= TIMING_SPSUMMON;
 			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, FALSE, 0);
 		}
+		core.summon_action_type = SUMMON_IN_IDLE;
 		return TRUE;
 	}
 	case 20: {
@@ -2999,8 +3005,10 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 	}
 	case 22: {
 		group* pgroup = core.units.begin()->ptarget;
-		if(pgroup->container.size() == 0)
+		if(pgroup->container.size() == 0) {
+			core.summon_action_type = SUMMON_IN_IDLE;
 			return TRUE;
+		}
 		core.phase_action = TRUE;
 		pgroup->it = pgroup->container.begin();
 		return FALSE;
@@ -3104,6 +3112,7 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 				core.units.begin()->ptr1 = 0;
 			}
 			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, FALSE, 0);
+			core.summon_action_type = SUMMON_IN_IDLE;
 			return TRUE;
 		}
 		return FALSE;
@@ -3156,6 +3165,7 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 			core.hint_timing[sumplayer] |= TIMING_SPSUMMON;
 			add_process(PROCESSOR_POINT_EVENT, 0, 0, 0, FALSE, 0);
 		}
+		core.summon_action_type = SUMMON_IN_IDLE;
 		return TRUE;
 	}
 	}

--- a/processor.cpp
+++ b/processor.cpp
@@ -419,6 +419,13 @@ uint32 field::process() {
 			++it->step;
 		return pduel->message_buffer.size();
 	}
+	case PROCESSOR_PENDULUM_SUMMON: {
+		if (pendulum_summon(it->step, it->arg1, it->ptarget)) {
+			core.units.pop_front();
+		} else
+			++it->step;
+		return pduel->message_buffer.size();
+	}
 	case PROCESSOR_DRAW	: {
 		if (draw(it->step, it->peffect, it->arg1, (it->arg2 >> 4) & 0xf, (it->arg2) & 0xf, it->arg3))
 			core.units.pop_front();

--- a/processor.cpp
+++ b/processor.cpp
@@ -3702,7 +3702,7 @@ int32 field::process_turn(uint16 step, uint8 turn_player) {
 			core.battled_count[p] = 0;
 			core.summon_count[p] = 0;
 			core.extra_summon[p] = 0;
-			core.extra_pendulum_summon[p] = 0;
+			core.default_pendulum_summon[p] = 0;
 			core.spsummon_once_map[p].clear();
 		}
 		for(auto& peffect : effects.rechargeable)

--- a/processor.cpp
+++ b/processor.cpp
@@ -3702,6 +3702,7 @@ int32 field::process_turn(uint16 step, uint8 turn_player) {
 			core.battled_count[p] = 0;
 			core.summon_count[p] = 0;
 			core.extra_summon[p] = 0;
+			core.extra_pendulum_summon[p] = 0;
 			core.spsummon_once_map[p].clear();
 		}
 		for(auto& peffect : effects.rechargeable)

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -566,6 +566,7 @@ public:
 	static int32 duel_get_overlay_count(lua_State *L);
 	static int32 duel_check_remove_overlay_card(lua_State *L);
 	static int32 duel_remove_overlay_card(lua_State *L);
+	static int32 duel_set_additional_pendulum_summon(lua_State *L);
 	static int32 duel_is_summon_in_chain(lua_State *L);
 
 	static int32 duel_hint(lua_State *L);
@@ -610,6 +611,7 @@ public:
 	static int32 duel_is_player_can_send_to_grave(lua_State *L);
 	static int32 duel_is_player_can_send_to_deck(lua_State *L);
 	static int32 duel_is_player_can_additional_summon(lua_State *L);
+	static int32 duel_is_player_can_additional_pendulum_summon(lua_State *L);
 	static int32 duel_is_chain_negatable(lua_State *L);
 	static int32 duel_is_chain_disablable(lua_State *L);
 	static int32 duel_is_chain_disabled(lua_State *L);

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -565,6 +565,7 @@ public:
 	static int32 duel_get_overlay_count(lua_State *L);
 	static int32 duel_check_remove_overlay_card(lua_State *L);
 	static int32 duel_remove_overlay_card(lua_State *L);
+	static int32 duel_is_summon_in_chain(lua_State *L);
 
 	static int32 duel_hint(lua_State *L);
 	static int32 duel_hint_selection(lua_State *L);

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -566,7 +566,7 @@ public:
 	static int32 duel_get_overlay_count(lua_State *L);
 	static int32 duel_check_remove_overlay_card(lua_State *L);
 	static int32 duel_remove_overlay_card(lua_State *L);
-	static int32 duel_default_pendulum_summoned(lua_State *L);
+	static int32 duel_use_default_pendulum_summon(lua_State *L);
 	static int32 duel_is_summon_in_chain(lua_State *L);
 
 	static int32 duel_hint(lua_State *L);

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -566,7 +566,7 @@ public:
 	static int32 duel_get_overlay_count(lua_State *L);
 	static int32 duel_check_remove_overlay_card(lua_State *L);
 	static int32 duel_remove_overlay_card(lua_State *L);
-	static int32 duel_set_additional_pendulum_summon(lua_State *L);
+	static int32 duel_default_pendulum_summoned(lua_State *L);
 	static int32 duel_is_summon_in_chain(lua_State *L);
 
 	static int32 duel_hint(lua_State *L);
@@ -611,7 +611,7 @@ public:
 	static int32 duel_is_player_can_send_to_grave(lua_State *L);
 	static int32 duel_is_player_can_send_to_deck(lua_State *L);
 	static int32 duel_is_player_can_additional_summon(lua_State *L);
-	static int32 duel_is_player_can_additional_pendulum_summon(lua_State *L);
+	static int32 duel_is_player_default_pendulum_summoned(lua_State *L);
 	static int32 duel_is_chain_negatable(lua_State *L);
 	static int32 duel_is_chain_disablable(lua_State *L);
 	static int32 duel_is_chain_disabled(lua_State *L);

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -411,6 +411,7 @@ public:
 	static int32 duel_special_summon_rule(lua_State *L);
 	static int32 duel_synchro_summon(lua_State *L);
 	static int32 duel_xyz_summon(lua_State *L);
+	static int32 duel_pendulum_summon(lua_State *L);
 	static int32 duel_link_summon(lua_State *L);
 	static int32 duel_setm(lua_State *L);
 	static int32 duel_sets(lua_State *L);
@@ -602,6 +603,7 @@ public:
 	static int32 duel_is_player_can_flipsummon(lua_State *L);
 	static int32 duel_is_player_can_spsummon_monster(lua_State *L);
 	static int32 duel_is_player_can_spsummon_count(lua_State *L);
+	static int32 duel_is_player_can_pendulum_summon(lua_State *L);
 	static int32 duel_is_player_can_release(lua_State *L);
 	static int32 duel_is_player_can_remove(lua_State *L);
 	static int32 duel_is_player_can_send_to_hand(lua_State *L);


### PR DESCRIPTION
Add these functions:

```lua
---Check if action_type is SUMMON_IN_CHAIN.
---@return boolean
function Duel.IsSummonInChain() end

---Check player can pendulum summon.
---@return boolean
---@param player integer
---@param summon_group? Group|nil default: nil
function Duel.IsPlayerCanPendulumSummon(player,summon_group) end

---player pendulum summon summon_group.
---@param player integer
---@param summon_group Group|nil
function Duel.PendulumSummon(player,summon_group) end

---Check if player pendulum summoned by rule.
---(not use EFFECT_EXTRA_PENDULUM_SUMMON.)
---@param player integer
function Duel.IsPlayerDefaultPendulumSummoned(player) end

---player pendulum summoned by rule.
---@param player integer
function Duel.UseDefaultPendulumSummon(player) end
```