### PR TITLE
fix EVENT_REMOVE

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -4324,7 +4324,7 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 				tograve.insert(pcard);
 				raise_single_event(pcard, 0, EVENT_TO_GRAVE, pcard->current.reason_effect, pcard->current.reason, pcard->current.reason_player, 0, 0);
 			}
-			if(nloc == LOCATION_REMOVED || ((pcard->data.type & TYPE_TOKEN) && pcard->sendto_param.location == LOCATION_REMOVED)) {
+			if(nloc == LOCATION_REMOVED) {
 				remove.insert(pcard);
 				raise_single_event(pcard, 0, EVENT_REMOVE, pcard->current.reason_effect, pcard->current.reason, pcard->current.reason_player, 0, 0);
 			}


### PR DESCRIPTION
fix: if token(s) was banished, `EVENT_REMOVE` is called.

> _Soul Absorption_
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=75&keyword=&tag=-1
> 「羊トークン」などのモンスタートークンが「[邪帝ガイウス](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=7516)」の効果の対象となる場合、**フィールドを離れる時点で消滅する事となり、結果的にカードが除外された事にはなりません**。
> 
> したがって、質問の状況の場合、**「[魂吸収](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=5850)」の効果は発動しません**。
> 
> _Fish Rain_
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9786
> ■「オイスタートークン」等のトークンが除外された場合には、**フィールド上から"除外"されずに"消滅"しているため、このカードを発動する事ができません**。
> 
> _Swordsoul Supreme Sovereign - Chengying_
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=16528
> _Ixeep, Omen of the Ghoti_
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=18036
> _Icejade Gymir Aegirine_
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=18183
> ■**モンスタートークンが除外された場合には発動できません**。
> 
> _The Abyss Dragon Swordsoul_
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=18150
> ■表示形式やどこから除外されたのかを問わず、モンスターであるカードが除外され、表側で除外されているモンスターになった場合に発動できます。（魔法・罠カードとして扱われているモンスターカードが除外された場合、モンスターカードが裏側で除外された場合、**トークンが除外された場合には発動できません**。）
> 
> _New World - Amritara_
> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=18842
> ■自分フィールドのモンスターが破壊され、そのカードが墓地へ送られた場合または除外された場合に発動できます。（モンスターとして扱われている魔法・罠カードが破壊された場合でも発動できますが、**モンスタートークンが破壊された場合には発動できません**。）