### PR TITLE
fix: change token type

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -681,6 +681,8 @@ uint32 card::get_type() {
 		temp.type = type;
 	}
 	temp.type = 0xffffffff;
+	if (data.type & TYPE_TOKEN)
+		type |= TYPE_TOKEN;
 	return type;
 }
 uint32 card::get_fusion_type() {

--- a/operations.cpp
+++ b/operations.cpp
@@ -1412,10 +1412,7 @@ int32 field::equip(uint16 step, uint8 equip_player, card * equip_card, card * ta
 			peffect->owner = equip_card;
 			peffect->handler = equip_card;
 			peffect->type = EFFECT_TYPE_SINGLE;
-			if (equip_card_type & TYPE_TOKEN) {
-				peffect->code = EFFECT_CHANGE_TYPE;
-				peffect->value = TYPE_EQUIP + TYPE_SPELL + TYPE_TOKEN;
-			} else if (equip_card_type & TYPE_TRAP) {
+			if (equip_card_type & TYPE_TRAP) {
 				peffect->code = EFFECT_ADD_TYPE;
 				peffect->value = TYPE_EQUIP;
 			} else {


### PR DESCRIPTION
@mercury233 
@purerosefallen 
@465uytrewq 

Ref:
> mail:
Q.
相手の「蛇眼の炎龍」の①の効果で、自分フィールドの幻獣機トークンが永続魔法カード扱いで自分の魔法＆罠ゾーンに置かれました。
その次の自分のターンに、自分フィールドに「幻獣機コンコルーダ」が存在する状態で、自分が「大嵐」を発動した場合、永続魔法カード扱いの幻獣機トークンは破壊されますか？
（永続魔法カード扱いの幻獣機トークンに対しても「幻獣機コンコルーダ」の『このカードがフィールド上に表側表示で存在する限り、自分フィールド上のトークンは戦闘及び効果では破壊されない』効果は適用されますか？）
A.
ご質問の場合、自分の永続魔法カード扱いの「幻獣機トークン」は「大嵐」の効果によって破壊されません。