### PR TITLE
Rebase next branch

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -4565,9 +4565,9 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 			}
 		} else if(pzone && location == LOCATION_SZONE && (target->data.type & TYPE_PENDULUM)) {
 			uint32 flag = 0;
-			if(is_location_useable(playerid, LOCATION_PZONE, 0))
+			if (is_location_useable(playerid, LOCATION_PZONE, 0) && (zone & 0x1))
 				flag |= 0x100U << get_pzone_sequence(0);
-			if(is_location_useable(playerid, LOCATION_PZONE, 1))
+			if (is_location_useable(playerid, LOCATION_PZONE, 1) && (zone & 0x2))
 				flag |= 0x100U << get_pzone_sequence(1);
 			if(!flag) {
 				core.units.begin()->step = 3;

--- a/operations.cpp
+++ b/operations.cpp
@@ -4565,6 +4565,9 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 			}
 		} else if(pzone && location == LOCATION_SZONE && (target->data.type & TYPE_PENDULUM)) {
 			uint32 flag = 0;
+			zone &= 0x3;
+			if (!zone)
+				zone = 0x3;
 			if (is_location_useable(playerid, LOCATION_PZONE, 0) && (zone & 0x1))
 				flag |= 0x100U << get_pzone_sequence(0);
 			if (is_location_useable(playerid, LOCATION_PZONE, 1) && (zone & 0x2))


### PR DESCRIPTION
Test:
#658 

----
Merged:
#555
修正：Duel.SendtoDeck改成可以移動發動中的魔法陷阱卡

#557 
修正：衍生物被除外時不會觸發`EVENT_REMOVE`

#558
修正：衍生物無論變成何種類型都會保留衍生物類型

#560 
修正：同時選擇最多127張卡

#561 
修正：Duel.AnnounceNumber超過255個選項會下修到上限255個

#563 
修正：異圖ID現在是 X+1, X+2, ..., X+19

#565 
修正：EVENT_DESTROYED, EVENT_BATTLE_DESTROYED的rp改成傷害計算的控制者

#548
修正：新增`STATUS_FLIP_SUMMON_DISABLED`（反轉召喚無效），從場上送去墓地

#562 
新增：Duel.IsChainSolving
