### PR TITLE
fix: select max capped at SIZE_RETURN_VALUE - 1

### DIFF
--- a/common.h
+++ b/common.h
@@ -30,6 +30,7 @@ typedef signed char int8;
 #define TRUE 1
 #define FALSE 0
 #define SIZE_MESSAGE_BUFFER 0x2000
+#define SIZE_RETURN_VALUE 64
 
 #define PROCESSOR_BUFFER_LEN	0x0fffffff
 #define PROCESSOR_FLAG			0xf0000000

--- a/common.h
+++ b/common.h
@@ -30,7 +30,7 @@ typedef signed char int8;
 #define TRUE 1
 #define FALSE 0
 #define SIZE_MESSAGE_BUFFER 0x2000
-#define SIZE_RETURN_VALUE 64
+#define SIZE_RETURN_VALUE 128
 
 #define PROCESSOR_BUFFER_LEN	0x0fffffff
 #define PROCESSOR_FLAG			0xf0000000

--- a/duel.cpp
+++ b/duel.cpp
@@ -140,7 +140,7 @@ void duel::set_responsei(uint32 resp) {
 	game_field->returns.ivalue[0] = resp;
 }
 void duel::set_responseb(byte* resp) {
-	std::memcpy(game_field->returns.bvalue, resp, 64);
+	std::memcpy(game_field->returns.bvalue, resp, SIZE_RETURN_VALUE);
 }
 int32 duel::get_next_integer(int32 l, int32 h) {
 	if (game_field->core.duel_options & DUEL_OLD_REPLAY) {

--- a/field.h
+++ b/field.h
@@ -155,11 +155,14 @@ struct processor_unit {
 	int32 value3{ 0 };
 	int32 value4{ 0 };
 };
+constexpr int SIZE_SVALUE = SIZE_RETURN_VALUE / 2;
+constexpr int SIZE_IVALUE = SIZE_RETURN_VALUE / 4;
+constexpr int SIZE_LVALUE = SIZE_RETURN_VALUE / 8;
 union return_value {
-	int8 bvalue[64];
-	int16 svalue[32];
-	int32 ivalue[16];
-	int64 lvalue[8];
+	int8 bvalue[SIZE_RETURN_VALUE];
+	int16 svalue[SIZE_SVALUE];
+	int32 ivalue[SIZE_IVALUE];
+	int64 lvalue[SIZE_LVALUE];
 };
 struct processor {
 	using effect_vector = std::vector<effect*>;

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2528,9 +2528,9 @@ int32 scriptlib::card_is_chain_attackable(lua_State *L) {
 		lua_pushboolean(L, 0);
 		return 1;
 	}
-	pduel->game_field->core.select_cards.clear();
-	pduel->game_field->get_attack_target(attacker, &pduel->game_field->core.select_cards, TRUE);
-	if(pduel->game_field->core.select_cards.size() == 0 && (monsteronly || attacker->direct_attackable == 0))
+	field::card_vector cv;
+	pduel->game_field->get_attack_target(attacker, &cv, TRUE);
+	if(cv.size() == 0 && (monsteronly || attacker->direct_attackable == 0))
 		lua_pushboolean(L, 0);
 	else
 		lua_pushboolean(L, 1);

--- a/playerop.cpp
+++ b/playerop.cpp
@@ -226,8 +226,11 @@ int32 field::select_card(uint16 step, uint8 playerid, uint8 cancelable, uint8 mi
 		returns.bvalue[0] = 0;
 		if(max == 0 || core.select_cards.empty())
 			return TRUE;
-		if(max > 127)
-			max = 127;
+		std::sort(core.select_cards.begin(), core.select_cards.end(), card::card_operation_sort);
+		if (core.select_cards.size() > UINT8_MAX)
+			core.select_cards.resize(UINT8_MAX);
+		if (max > SIZE_RETURN_VALUE - 1)
+			max = SIZE_RETURN_VALUE - 1;
 		if(max > core.select_cards.size())
 			max = (uint8)core.select_cards.size();
 		if(min > max)
@@ -245,7 +248,6 @@ int32 field::select_card(uint16 step, uint8 playerid, uint8 cancelable, uint8 mi
 		pduel->write_buffer8(min);
 		pduel->write_buffer8(max);
 		pduel->write_buffer8((uint8)core.select_cards.size());
-		std::sort(core.select_cards.begin(), core.select_cards.end(), card::card_operation_sort);
 		for(auto& pcard : core.select_cards) {
 			pduel->write_buffer32(pcard->data.code);
 			pduel->write_buffer32(pcard->get_info_location());
@@ -282,6 +284,11 @@ int32 field::select_unselect_card(uint16 step, uint8 playerid, uint8 cancelable,
 				returns.bvalue[i + 1] = i;
 			return TRUE;
 		}
+		std::sort(core.select_cards.begin(), core.select_cards.end(), card::card_operation_sort);
+		if (core.select_cards.size() > UINT8_MAX)
+			core.select_cards.resize(UINT8_MAX);
+		if (core.unselect_cards.size() > UINT8_MAX)
+			core.unselect_cards.resize(UINT8_MAX);
 		pduel->write_buffer8(MSG_SELECT_UNSELECT_CARD);
 		pduel->write_buffer8(playerid);
 		pduel->write_buffer8(finishable);
@@ -289,7 +296,6 @@ int32 field::select_unselect_card(uint16 step, uint8 playerid, uint8 cancelable,
 		pduel->write_buffer8(min);
 		pduel->write_buffer8(max);
 		pduel->write_buffer8((uint8)core.select_cards.size());
-		std::sort(core.select_cards.begin(), core.select_cards.end(), card::card_operation_sort);
 		for(auto& pcard : core.select_cards) {
 			pduel->write_buffer32(pcard->data.code);
 			pduel->write_buffer32(pcard->get_info_location());
@@ -311,7 +317,7 @@ int32 field::select_unselect_card(uint16 step, uint8 playerid, uint8 cancelable,
 			pduel->write_buffer8(MSG_RETRY);
 			return FALSE;
 		}
-		uint8 m = (uint8)core.select_cards.size() + (uint8)core.unselect_cards.size();
+		int32 m = core.select_cards.size() + core.unselect_cards.size();
 		uint8 v = returns.bvalue[1];
 		if(v < 0 || v >= m) {
 			pduel->write_buffer8(MSG_RETRY);
@@ -495,6 +501,9 @@ int32 field::select_tribute(uint16 step, uint8 playerid, uint8 cancelable, uint8
 		returns.bvalue[0] = 0;
 		if(max == 0 || core.select_cards.empty())
 			return TRUE;
+		std::sort(core.select_cards.begin(), core.select_cards.end(), card::card_operation_sort);
+		if (core.select_cards.size() > UINT8_MAX)
+			core.select_cards.resize(UINT8_MAX);
 		uint8 tm = 0;
 		for(auto& pcard : core.select_cards)
 			tm += pcard->release_param;
@@ -511,7 +520,6 @@ int32 field::select_tribute(uint16 step, uint8 playerid, uint8 cancelable, uint8
 		pduel->write_buffer8(min);
 		pduel->write_buffer8(max);
 		pduel->write_buffer8((uint8)core.select_cards.size());
-		std::sort(core.select_cards.begin(), core.select_cards.end(), card::card_operation_sort);
 		for(auto& pcard : core.select_cards) {
 			pduel->write_buffer32(pcard->data.code);
 			pduel->write_buffer8(pcard->current.controler);
@@ -591,7 +599,7 @@ int32 field::select_counter(uint16 step, uint8 playerid, uint16 countertype, uin
 		return FALSE;
 	} else {
 		uint16 ct = 0;
-		for(uint32 i = 0; i < core.select_cards.size(); ++i) {
+		for(int32 i = 0; i < (int32)core.select_cards.size(); ++i) {
 			if(core.select_cards[i]->get_counter(countertype) < returns.svalue[i]) {
 				pduel->write_buffer8(MSG_RETRY);
 				return FALSE;
@@ -620,6 +628,11 @@ int32 field::select_with_sum_limit(int16 step, uint8 playerid, int32 acc, int32 
 		returns.bvalue[0] = 0;
 		if(core.select_cards.empty())
 			return TRUE;
+		std::sort(core.select_cards.begin(), core.select_cards.end(), card::card_operation_sort);
+		if (core.select_cards.size() > UINT8_MAX)
+			core.select_cards.resize(UINT8_MAX);
+		if (core.must_select_cards.size() > UINT8_MAX)
+			core.must_select_cards.resize(UINT8_MAX);
 		pduel->write_buffer8(MSG_SELECT_SUM);
 		if(max)
 			pduel->write_buffer8(0);
@@ -640,7 +653,6 @@ int32 field::select_with_sum_limit(int16 step, uint8 playerid, int32 acc, int32 
 			pduel->write_buffer32(pcard->sum_param);
 		}
 		pduel->write_buffer8((uint8)core.select_cards.size());
-		std::sort(core.select_cards.begin(), core.select_cards.end(), card::card_operation_sort);
 		for(auto& pcard : core.select_cards) {
 			pduel->write_buffer32(pcard->data.code);
 			pduel->write_buffer8(pcard->current.controler);
@@ -723,6 +735,8 @@ int32 field::sort_card(int16 step, uint8 playerid) {
 		}
 		if(core.select_cards.empty())
 			return TRUE;
+		if (core.select_cards.size() > UINT8_MAX)
+			core.select_cards.resize(UINT8_MAX);
 		pduel->write_buffer8(MSG_SORT_CARD);
 		pduel->write_buffer8(playerid);
 		pduel->write_buffer8((uint8)core.select_cards.size());


### PR DESCRIPTION
Selecting more than 64 cards will crash after #449.
It is because there is only 63 slots in `return_value`.
