### PR TITLE
fix special summon reason effect

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -3155,6 +3155,7 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		return FALSE;
 	}
 	case 29: {
+		effect* peffect = core.units.begin()->peffect;
 		group* pgroup = core.units.begin()->ptarget;
 		pduel->write_buffer8(MSG_SPSUMMONED);
 		set_spsummon_counter(sumplayer);
@@ -3163,14 +3164,14 @@ int32 field::special_summon_rule(uint16 step, uint8 sumplayer, card* target, uin
 		for(auto& pcard : pgroup->container) {
 			if(pcard->spsummon_code)
 				spsummon_once_set.insert(pcard->spsummon_code);
-			pcard->set_special_summon_status(pcard->current.reason_effect);
+			pcard->set_special_summon_status(peffect);
 		}
 		for(auto& cit : spsummon_once_set)
 			++core.spsummon_once_map[sumplayer][cit];
 		for(auto& pcard : pgroup->container)
-			raise_single_event(pcard, 0, EVENT_SPSUMMON_SUCCESS, pcard->current.reason_effect, 0, pcard->current.reason_player, pcard->summon_player, 0);
+			raise_single_event(pcard, 0, EVENT_SPSUMMON_SUCCESS, peffect, 0, sumplayer, pcard->summon_player, 0);
 		process_single_event();
-		raise_event(&pgroup->container, EVENT_SPSUMMON_SUCCESS, core.units.begin()->peffect, 0, sumplayer, sumplayer, 0);
+		raise_event(&pgroup->container, EVENT_SPSUMMON_SUCCESS, peffect, 0, sumplayer, sumplayer, 0);
 		process_instant_event();
 		if(action_type == SUMMON_IN_IDLE) {
 			adjust_all();
@@ -3366,9 +3367,9 @@ int32 field::special_summon(uint16 step, effect* reason_effect, uint8 reason_pla
 		pduel->write_buffer8(MSG_SPSUMMONED);
 		for(auto& pcard : targets->container) {
 			check_card_counter(pcard, ACTIVITY_SPSUMMON, pcard->summon_player);
-			pcard->set_special_summon_status(pcard->current.reason_effect);
+			pcard->set_special_summon_status(reason_effect);
 			if(!(pcard->current.position & POS_FACEDOWN))
-				raise_single_event(pcard, 0, EVENT_SPSUMMON_SUCCESS, pcard->current.reason_effect, 0, pcard->current.reason_player, pcard->summon_player, 0);
+				raise_single_event(pcard, 0, EVENT_SPSUMMON_SUCCESS, reason_effect, 0, reason_player, pcard->summon_player, 0);
 			int32 summontype = pcard->summon_info & (SUMMON_VALUE_MAIN_TYPE | SUMMON_VALUE_SUB_TYPE);
 			int32 custom_type = pcard->summon_info & SUMMON_VALUE_CUSTOM_TYPE;
 			if(summontype && pcard->material_cards.size() && custom_type != SUMMON_VALUE_FUTURE_FUSION) {
@@ -3382,7 +3383,7 @@ int32 field::special_summon(uint16 step, effect* reason_effect, uint8 reason_pla
 				else if(summontype == SUMMON_TYPE_LINK)
 					matreason = REASON_LINK;
 				for(auto& mcard : pcard->material_cards)
-					raise_single_event(mcard, &targets->container, EVENT_BE_MATERIAL, pcard->current.reason_effect, matreason, pcard->current.reason_player, pcard->summon_player, 0);
+					raise_single_event(mcard, &targets->container, EVENT_BE_MATERIAL, reason_effect, matreason, reason_player, pcard->summon_player, 0);
 				raise_event(&(pcard->material_cards), EVENT_BE_MATERIAL, reason_effect, matreason, reason_player, pcard->summon_player, 0);
 			}
 		}


### PR DESCRIPTION
If a monster is sent to grave immediately after being summoned (Burning Abyss, Advanced Crystal Beast), its `current.reason_effect` will be the effect that send it to grave.
So `pcard->set_special_summon_status(pcard->current.reason_effect);` will be wrong.
And it will crash on `EFFECT_SELF_TOGRAVE` without https://github.com/Fluorohydride/ygopro-core/pull/566 .