### PR TITLE
fix special summon status of trap monster

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2531,7 +2531,7 @@ void card::set_special_summon_status(effect* peffect) {
 	}
 	card* pcard = peffect->get_handler();
 	auto cait = pduel->game_field->core.current_chain.rbegin();
-	if(!(peffect->type & 0x7f0) || pcard->is_has_relation(*cait)) {
+	if(!(peffect->type & 0x7f0) || (pcard->is_has_relation(*cait) && !(pcard->get_type() & TYPE_TRAPMONSTER))) {
 		spsummon.code = pcard->get_code();
 		spsummon.code2 = pcard->get_another_code();
 		spsummon.type = pcard->get_type();


### PR DESCRIPTION
Fix summoning trap monster can trigger the effect of _Granguignol the Dusk Dragon_