### PR TITLE
fix Duel.ChainAttack

### DIFF
--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2430,8 +2430,12 @@ int32 scriptlib::duel_disable_attack(lua_State *L) {
 }
 int32 scriptlib::duel_chain_attack(lua_State *L) {
 	duel* pduel = interpreter::get_duel_info(L);
+	card* attacker = pduel->game_field->core.attacker;
+	if(!attacker || !attacker->is_affect_by_effect(pduel->game_field->core.reason_effect)) {
+		return 0;
+	}
 	pduel->game_field->core.chain_attack = TRUE;
-	pduel->game_field->core.chain_attacker_id = pduel->game_field->core.attacker->fieldid;
+	pduel->game_field->core.chain_attacker_id = attacker->fieldid;
 	if(lua_gettop(L) > 0) {
 		check_param(L, PARAM_TYPE_CARD, 1);
 		pduel->game_field->core.chain_attack_target = *(card**) lua_touserdata(L, 1);


### PR DESCRIPTION
fix https://github.com/Fluorohydride/ygopro-scripts/pull/2376
fix crash when calling it without attack monster

>Q.
「禁じられた聖槍」の効果を適用した自分の「白闘気海豚」攻撃のダメージステップが終了した時、「白の輪廻」の効果を発動して攻撃を続けることはできますか？
A.
一例として、「禁じられた聖槍」の効果が適用された自分の「白闘気海豚」で相手の直接攻撃した場合としてご案内いたします。
この場合、ダメージステップ終了時に「白の輪廻」の『②』の効果を発動することはできますが、「白闘気海豚」で再度攻撃することはできません。
 