### PR TITLE
update jobs.run to node20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: GitHub Release
       if: github.event_name == 'push'
-      uses: marvinpinto/action-automatic-releases@latest
+      uses: salix5/action-automatic-releases@node20
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"


### PR DESCRIPTION
@mercury233 
https://github.com/Fluorohydride/ygopro-core/actions/runs/8564662109
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: marvinpinto/action-automatic-releases@latest. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

> The following actions uses node12 which is deprecated and will be forced to run on node16: marvinpinto/action-automatic-releases@latest. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions
https://github.com/salix5/action-automatic-releases/commit/75f1a65738686fd56793b41982fd0ed01cc8e96c


Test result:
https://github.com/salix5/ygopro-core/actions/runs/8579378868