### PR TITLE
fix buffer read/write

### DIFF
--- a/buffer.h
+++ b/buffer.h
@@ -4,44 +4,34 @@
 #include <cstring>
 #include <vector>
 
-template<typename T>
-inline T buffer_read(unsigned char*& p) {
-	T ret{};
-	std::memcpy(&ret, p, sizeof(T));
-	p += sizeof(T);
-	return ret;
-}
-inline void buffer_read_array(unsigned char*& p, void* dest, int size) {
-	if (size <= 0)
-		return;
+inline void buffer_read_block(unsigned char*& p, void* dest, size_t size) {
 	std::memcpy(dest, p, size);
 	p += size;
 }
-
 template<typename T>
-inline void buffer_write(unsigned char*& p, T value) {
-	std::memcpy(p, &value, sizeof(T));
-	p += sizeof(T);
+inline T buffer_read(unsigned char*& p) {
+	T ret{};
+	buffer_read_block(p, &ret, sizeof(T));
+	return ret;
 }
-inline void buffer_write_array(unsigned char*& p, const void* src, int size) {
-	if (size <= 0)
-		return;
+
+inline void buffer_write_block(unsigned char*& p, const void* src, size_t size) {
 	std::memcpy(p, src, size);
 	p += size;
 }
-
 template<typename T>
-inline void vector_write(std::vector<unsigned char>& buffer, T value) {
-	const auto len = buffer.size();
-	buffer.resize(len + sizeof(T));
-	std::memcpy(&buffer[len], &value, sizeof(T));
+inline void buffer_write(unsigned char*& p, T value) {
+	buffer_write_block(p, &value,sizeof(T));
 }
-inline void vector_write_array(std::vector<unsigned char>& buffer, const void* src, int size) {
-	if (size <= 0)
-		return;
+
+inline void vector_write_block(std::vector<unsigned char>& buffer, const void* src, size_t size) {
 	const auto len = buffer.size();
 	buffer.resize(len + size);
 	std::memcpy(&buffer[len], src, size);
+}
+template<typename T>
+inline void vector_write(std::vector<unsigned char>& buffer, T value) {
+	vector_write_block(buffer, &value, sizeof(T));
 }
 
 #endif //BUFFER_H

--- a/buffer.h
+++ b/buffer.h
@@ -2,6 +2,7 @@
 #define BUFFER_H
 
 #include <cstring>
+#include <vector>
 
 namespace Buffer {
 	template<typename T>
@@ -23,11 +24,24 @@ namespace Buffer {
 		std::memcpy(p, &value, sizeof(T));
 		p += sizeof(T);
 	}
-	inline void write_array(unsigned char*& p, void* src, int size) {
+	template<typename T>
+	inline void write(std::vector<unsigned char>& buffer, T value) {
+		const auto len = buffer.size();
+		buffer.resize(len + sizeof(T));
+		std::memcpy(&buffer[len], &value, sizeof(T));
+	}
+	inline void write_array(unsigned char*& p, const void* src, int size) {
 		if (size <= 0)
 			return;
 		std::memcpy(p, src, size);
 		p += size;
+	}
+	inline void write_array(std::vector<unsigned char>& buffer, const void* src, int size) {
+		if (size <= 0)
+			return;
+		const auto len = buffer.size();
+		buffer.resize(len + size);
+		std::memcpy(&buffer[len], src, size);
 	}
 }
 

--- a/buffer.h
+++ b/buffer.h
@@ -4,45 +4,44 @@
 #include <cstring>
 #include <vector>
 
-namespace Buffer {
-	template<typename T>
-	inline T read(unsigned char*& p) {
-		T ret = 0;
-		std::memcpy(&ret, p, sizeof(T));
-		p += sizeof(T);
-		return ret;
-	}
-	inline void read_array(unsigned char*& p, void* dest, int size) {
-		if (size <= 0)
-			return;
-		std::memcpy(dest, p, size);
-		p += size;
-	}
+template<typename T>
+inline T buffer_read(unsigned char*& p) {
+	T ret = 0;
+	std::memcpy(&ret, p, sizeof(T));
+	p += sizeof(T);
+	return ret;
+}
+inline void buffer_read_array(unsigned char*& p, void* dest, int size) {
+	if (size <= 0)
+		return;
+	std::memcpy(dest, p, size);
+	p += size;
+}
 
-	template<typename T>
-	inline void write(unsigned char*& p, T value) {
-		std::memcpy(p, &value, sizeof(T));
-		p += sizeof(T);
-	}
-	template<typename T>
-	inline void write(std::vector<unsigned char>& buffer, T value) {
-		const auto len = buffer.size();
-		buffer.resize(len + sizeof(T));
-		std::memcpy(&buffer[len], &value, sizeof(T));
-	}
-	inline void write_array(unsigned char*& p, const void* src, int size) {
-		if (size <= 0)
-			return;
-		std::memcpy(p, src, size);
-		p += size;
-	}
-	inline void write_array(std::vector<unsigned char>& buffer, const void* src, int size) {
-		if (size <= 0)
-			return;
-		const auto len = buffer.size();
-		buffer.resize(len + size);
-		std::memcpy(&buffer[len], src, size);
-	}
+template<typename T>
+inline void buffer_write(unsigned char*& p, T value) {
+	std::memcpy(p, &value, sizeof(T));
+	p += sizeof(T);
+}
+inline void buffer_write_array(unsigned char*& p, const void* src, int size) {
+	if (size <= 0)
+		return;
+	std::memcpy(p, src, size);
+	p += size;
+}
+
+template<typename T>
+inline void vector_write(std::vector<unsigned char>& buffer, T value) {
+	const auto len = buffer.size();
+	buffer.resize(len + sizeof(T));
+	std::memcpy(&buffer[len], &value, sizeof(T));
+}
+inline void vector_write_array(std::vector<unsigned char>& buffer, const void* src, int size) {
+	if (size <= 0)
+		return;
+	const auto len = buffer.size();
+	buffer.resize(len + size);
+	std::memcpy(&buffer[len], src, size);
 }
 
 #endif //BUFFER_H

--- a/buffer.h
+++ b/buffer.h
@@ -1,0 +1,12 @@
+#ifndef BUFFER_H
+#define BUFFER_H
+
+#include <cstring>
+
+template<typename T>
+inline void write_byte_buffer(unsigned char*& p, T value) {
+	std::memcpy(p, &value, sizeof(T));
+	p += sizeof(T);
+}
+
+#endif //BUFFER_H

--- a/buffer.h
+++ b/buffer.h
@@ -6,7 +6,7 @@
 
 template<typename T>
 inline T buffer_read(unsigned char*& p) {
-	T ret = 0;
+	T ret{};
 	std::memcpy(&ret, p, sizeof(T));
 	p += sizeof(T);
 	return ret;

--- a/buffer.h
+++ b/buffer.h
@@ -3,10 +3,32 @@
 
 #include <cstring>
 
-template<typename T>
-inline void write_byte_buffer(unsigned char*& p, T value) {
-	std::memcpy(p, &value, sizeof(T));
-	p += sizeof(T);
+namespace Buffer {
+	template<typename T>
+	inline T read(unsigned char*& p) {
+		T ret = 0;
+		std::memcpy(&ret, p, sizeof(T));
+		p += sizeof(T);
+		return ret;
+	}
+	inline void read_array(unsigned char*& p, void* dest, int size) {
+		if (size <= 0)
+			return;
+		std::memcpy(dest, p, size);
+		p += size;
+	}
+
+	template<typename T>
+	inline void write(unsigned char*& p, T value) {
+		std::memcpy(p, &value, sizeof(T));
+		p += sizeof(T);
+	}
+	inline void write_array(unsigned char*& p, void* src, int size) {
+		if (size <= 0)
+			return;
+		std::memcpy(p, src, size);
+		p += size;
+	}
 }
 
 #endif //BUFFER_H

--- a/card.cpp
+++ b/card.cpp
@@ -149,7 +149,7 @@ card::card(duel* pd) {
 inline void update_cache(uint32& tdata, uint32& cache, byte*& p, uint32& query_flag, const uint32 flag) {
 	if (tdata != cache) {
 		cache = tdata;
-		write_byte_buffer(p, tdata);
+		Buffer::write(p, tdata);
 	}
 	else
 		query_flag &= ~flag;
@@ -167,11 +167,11 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 	//first 8 bytes: data length, query flag
 	p += 8;
 	if (query_flag & QUERY_CODE) {
-		write_byte_buffer(p, data.code);
+		Buffer::write(p, data.code);
 	}
 	if (query_flag & QUERY_POSITION) {
 		uint32 tdata = get_info_location();
-		write_byte_buffer(p, tdata);
+		Buffer::write(p, tdata);
 		if (q_cache.info_location != tdata) {
 			q_cache.clear_cache();
 			q_cache.info_location = tdata;
@@ -181,52 +181,52 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 	if(!use_cache) {
 		if (query_flag & QUERY_ALIAS) {
 			uint32 tdata = get_code();
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 			q_cache.current_code = tdata;
 		}
 		if (query_flag & QUERY_TYPE) {
 			uint32 tdata = get_type();
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 			q_cache.type = tdata;
 		}
 		if (query_flag & QUERY_LEVEL) {
 			uint32 tdata = get_level();
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 			q_cache.level = tdata;
 		}
 		if (query_flag & QUERY_RANK) {
 			uint32 tdata = get_rank();
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 			q_cache.rank = tdata;
 		}
 		if (query_flag & QUERY_ATTRIBUTE) {
 			uint32 tdata = get_attribute();
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 			q_cache.attribute = tdata;
 		}
 		if (query_flag & QUERY_RACE) {
 			uint32 tdata = get_race();
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 			q_cache.race = tdata;
 		}
 		if (query_flag & QUERY_ATTACK) {
-			write_byte_buffer(p, atk_def.first);
+			Buffer::write(p, atk_def.first);
 			q_cache.attack = atk_def.first;
 		}
 		if (query_flag & QUERY_DEFENSE) {
-			write_byte_buffer(p, atk_def.second);
+			Buffer::write(p, atk_def.second);
 			q_cache.defense = atk_def.second;
 		}
 		if (query_flag & QUERY_BASE_ATTACK) {
-			write_byte_buffer(p, base_atk_def.first);
+			Buffer::write(p, base_atk_def.first);
 			q_cache.base_attack = base_atk_def.first;
 		}
 		if (query_flag & QUERY_BASE_DEFENSE) {
-			write_byte_buffer(p, base_atk_def.second);
+			Buffer::write(p, base_atk_def.second);
 			q_cache.base_defense = base_atk_def.second;
 		}
 		if (query_flag & QUERY_REASON) {
-			write_byte_buffer(p, current.reason);
+			Buffer::write(p, current.reason);
 			q_cache.reason = current.reason;
 		}
 	}
@@ -258,7 +258,7 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 		if((query_flag & QUERY_ATTACK)) {
 			if (atk_def.first != q_cache.attack) {
 				q_cache.attack = atk_def.first;
-				write_byte_buffer(p, atk_def.first);
+				Buffer::write(p, atk_def.first);
 			}
 			else
 				query_flag &= ~QUERY_ATTACK;
@@ -266,7 +266,7 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 		if((query_flag & QUERY_DEFENSE)) {
 			if (atk_def.second != q_cache.defense) {
 				q_cache.defense = atk_def.second;
-				write_byte_buffer(p, atk_def.second);
+				Buffer::write(p, atk_def.second);
 			}
 			else
 				query_flag &= ~QUERY_DEFENSE;
@@ -274,7 +274,7 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 		if((query_flag & QUERY_BASE_ATTACK)) {
 			if (base_atk_def.first != q_cache.base_attack) {
 				q_cache.base_attack = base_atk_def.first;
-				write_byte_buffer(p, base_atk_def.first);
+				Buffer::write(p, base_atk_def.first);
 			}
 			else
 				query_flag &= ~QUERY_BASE_ATTACK;
@@ -282,7 +282,7 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 		if((query_flag & QUERY_BASE_DEFENSE)) {
 			if (base_atk_def.second != q_cache.base_defense) {
 				q_cache.base_defense = base_atk_def.second;
-				write_byte_buffer(p, base_atk_def.second);
+				Buffer::write(p, base_atk_def.second);
 			}
 			else
 				query_flag &= ~QUERY_BASE_DEFENSE;
@@ -294,45 +294,45 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 	}
 	if (query_flag & QUERY_REASON_CARD) {
 		uint32 tdata = current.reason_card ? current.reason_card->get_info_location() : 0;
-		write_byte_buffer(p, tdata);
+		Buffer::write(p, tdata);
 	}
 	if(query_flag & QUERY_EQUIP_CARD) {
 		if (equiping_target) {
 			uint32 tdata = equiping_target->get_info_location();
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 		}
 		else
 			query_flag &= ~QUERY_EQUIP_CARD;
 	}
 	if(query_flag & QUERY_TARGET_CARD) {
-		write_byte_buffer(p, (int32)effect_target_cards.size());
+		Buffer::write(p, (int32)effect_target_cards.size());
 		for (auto& pcard : effect_target_cards) {
 			uint32 tdata = pcard->get_info_location();
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 		}
 	}
 	if(query_flag & QUERY_OVERLAY_CARD) {
-		write_byte_buffer(p, (int32)xyz_materials.size());
+		Buffer::write(p, (int32)xyz_materials.size());
 		for (auto& xcard : xyz_materials) {
-			write_byte_buffer(p, xcard->data.code);
+			Buffer::write(p, xcard->data.code);
 		}
 	}
 	if(query_flag & QUERY_COUNTERS) {
-		write_byte_buffer(p, (int32)counters.size());
+		Buffer::write(p, (int32)counters.size());
 		for (const auto& cmit : counters) {
 			int32 tdata = cmit.first + ((cmit.second[0] + cmit.second[1]) << 16);
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 		}
 	}
 	if (query_flag & QUERY_OWNER) {
 		int32 tdata = owner;
-		write_byte_buffer(p, tdata);
+		Buffer::write(p, tdata);
 	}
 	if(query_flag & QUERY_STATUS) {
 		uint32 tdata = status & (STATUS_DISABLED | STATUS_FORBIDDEN | STATUS_PROC_COMPLETE);
 		if(!use_cache || (tdata != q_cache.status)) {
 			q_cache.status = tdata;
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 		}
 		else
 			query_flag &= ~QUERY_STATUS;
@@ -340,20 +340,20 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 	if(!use_cache) {
 		if (query_flag & QUERY_LSCALE) {
 			uint32 tdata = get_lscale();
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 			q_cache.lscale = tdata;
 		}
 		if (query_flag & QUERY_RSCALE) {
 			uint32 tdata = get_rscale();
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 			q_cache.rscale = tdata;
 		}
 		if(query_flag & QUERY_LINK) {
 			uint32 tdata = get_link();
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 			q_cache.link = tdata;
 			tdata = get_link_marker();
-			write_byte_buffer(p, tdata);
+			Buffer::write(p, tdata);
 			q_cache.link_marker = tdata;
 		}
 	}
@@ -371,17 +371,17 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 			uint32 link_marker = get_link_marker();
 			if((link != q_cache.link) || (link_marker != q_cache.link_marker)) {
 				q_cache.link = link;
-				write_byte_buffer(p, link);
+				Buffer::write(p, link);
 				q_cache.link_marker = link_marker;
-				write_byte_buffer(p, link_marker);
+				Buffer::write(p, link_marker);
 			}
 			else
 				query_flag &= ~QUERY_LINK;
 		}
 	}
 	byte* finalize = buf;
-	write_byte_buffer(finalize, (int32)(p - buf));
-	write_byte_buffer(finalize, query_flag);
+	Buffer::write(finalize, (int32)(p - buf));
+	Buffer::write(finalize, query_flag);
 	return (int32)(p - buf);
 }
 uint32 card::get_info_location() {

--- a/card.cpp
+++ b/card.cpp
@@ -149,7 +149,7 @@ card::card(duel* pd) {
 inline void update_cache(uint32& tdata, uint32& cache, byte*& p, uint32& query_flag, const uint32 flag) {
 	if (tdata != cache) {
 		cache = tdata;
-		buffer_write(p, tdata);
+		buffer_write<uint32_t>(p, tdata);
 	}
 	else
 		query_flag &= ~flag;
@@ -167,11 +167,11 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 	//first 8 bytes: data length, query flag
 	p += 8;
 	if (query_flag & QUERY_CODE) {
-		buffer_write(p, data.code);
+		buffer_write<uint32_t>(p, data.code);
 	}
 	if (query_flag & QUERY_POSITION) {
 		uint32 tdata = get_info_location();
-		buffer_write(p, tdata);
+		buffer_write<uint32_t>(p, tdata);
 		if (q_cache.info_location != tdata) {
 			q_cache.clear_cache();
 			q_cache.info_location = tdata;
@@ -181,52 +181,52 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 	if(!use_cache) {
 		if (query_flag & QUERY_ALIAS) {
 			uint32 tdata = get_code();
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 			q_cache.current_code = tdata;
 		}
 		if (query_flag & QUERY_TYPE) {
 			uint32 tdata = get_type();
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 			q_cache.type = tdata;
 		}
 		if (query_flag & QUERY_LEVEL) {
 			uint32 tdata = get_level();
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 			q_cache.level = tdata;
 		}
 		if (query_flag & QUERY_RANK) {
 			uint32 tdata = get_rank();
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 			q_cache.rank = tdata;
 		}
 		if (query_flag & QUERY_ATTRIBUTE) {
 			uint32 tdata = get_attribute();
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 			q_cache.attribute = tdata;
 		}
 		if (query_flag & QUERY_RACE) {
 			uint32 tdata = get_race();
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 			q_cache.race = tdata;
 		}
 		if (query_flag & QUERY_ATTACK) {
-			buffer_write(p, atk_def.first);
+			buffer_write<int32_t>(p, atk_def.first);
 			q_cache.attack = atk_def.first;
 		}
 		if (query_flag & QUERY_DEFENSE) {
-			buffer_write(p, atk_def.second);
+			buffer_write<int32_t>(p, atk_def.second);
 			q_cache.defense = atk_def.second;
 		}
 		if (query_flag & QUERY_BASE_ATTACK) {
-			buffer_write(p, base_atk_def.first);
+			buffer_write<int32_t>(p, base_atk_def.first);
 			q_cache.base_attack = base_atk_def.first;
 		}
 		if (query_flag & QUERY_BASE_DEFENSE) {
-			buffer_write(p, base_atk_def.second);
+			buffer_write<int32_t>(p, base_atk_def.second);
 			q_cache.base_defense = base_atk_def.second;
 		}
 		if (query_flag & QUERY_REASON) {
-			buffer_write(p, current.reason);
+			buffer_write<uint32_t>(p, current.reason);
 			q_cache.reason = current.reason;
 		}
 	}
@@ -258,7 +258,7 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 		if((query_flag & QUERY_ATTACK)) {
 			if (atk_def.first != q_cache.attack) {
 				q_cache.attack = atk_def.first;
-				buffer_write(p, atk_def.first);
+				buffer_write<int32_t>(p, atk_def.first);
 			}
 			else
 				query_flag &= ~QUERY_ATTACK;
@@ -266,7 +266,7 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 		if((query_flag & QUERY_DEFENSE)) {
 			if (atk_def.second != q_cache.defense) {
 				q_cache.defense = atk_def.second;
-				buffer_write(p, atk_def.second);
+				buffer_write<int32_t>(p, atk_def.second);
 			}
 			else
 				query_flag &= ~QUERY_DEFENSE;
@@ -274,7 +274,7 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 		if((query_flag & QUERY_BASE_ATTACK)) {
 			if (base_atk_def.first != q_cache.base_attack) {
 				q_cache.base_attack = base_atk_def.first;
-				buffer_write(p, base_atk_def.first);
+				buffer_write<int32_t>(p, base_atk_def.first);
 			}
 			else
 				query_flag &= ~QUERY_BASE_ATTACK;
@@ -282,7 +282,7 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 		if((query_flag & QUERY_BASE_DEFENSE)) {
 			if (base_atk_def.second != q_cache.base_defense) {
 				q_cache.base_defense = base_atk_def.second;
-				buffer_write(p, base_atk_def.second);
+				buffer_write<int32_t>(p, base_atk_def.second);
 			}
 			else
 				query_flag &= ~QUERY_BASE_DEFENSE;
@@ -294,45 +294,45 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 	}
 	if (query_flag & QUERY_REASON_CARD) {
 		uint32 tdata = current.reason_card ? current.reason_card->get_info_location() : 0;
-		buffer_write(p, tdata);
+		buffer_write<uint32_t>(p, tdata);
 	}
 	if(query_flag & QUERY_EQUIP_CARD) {
 		if (equiping_target) {
 			uint32 tdata = equiping_target->get_info_location();
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 		}
 		else
 			query_flag &= ~QUERY_EQUIP_CARD;
 	}
 	if(query_flag & QUERY_TARGET_CARD) {
-		buffer_write(p, (int32)effect_target_cards.size());
+		buffer_write<int32_t>(p, (int32_t)effect_target_cards.size());
 		for (auto& pcard : effect_target_cards) {
 			uint32 tdata = pcard->get_info_location();
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 		}
 	}
 	if(query_flag & QUERY_OVERLAY_CARD) {
-		buffer_write(p, (int32)xyz_materials.size());
+		buffer_write<int32_t>(p, (int32_t)xyz_materials.size());
 		for (auto& xcard : xyz_materials) {
-			buffer_write(p, xcard->data.code);
+			buffer_write<uint32_t>(p, xcard->data.code);
 		}
 	}
 	if(query_flag & QUERY_COUNTERS) {
-		buffer_write(p, (int32)counters.size());
+		buffer_write<int32_t>(p, (int32_t)counters.size());
 		for (const auto& cmit : counters) {
 			int32 tdata = cmit.first + ((cmit.second[0] + cmit.second[1]) << 16);
-			buffer_write(p, tdata);
+			buffer_write<int32_t>(p, tdata);
 		}
 	}
 	if (query_flag & QUERY_OWNER) {
 		int32 tdata = owner;
-		buffer_write(p, tdata);
+		buffer_write<int32_t>(p, tdata);
 	}
 	if(query_flag & QUERY_STATUS) {
 		uint32 tdata = status & (STATUS_DISABLED | STATUS_FORBIDDEN | STATUS_PROC_COMPLETE);
 		if(!use_cache || (tdata != q_cache.status)) {
 			q_cache.status = tdata;
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 		}
 		else
 			query_flag &= ~QUERY_STATUS;
@@ -340,20 +340,20 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 	if(!use_cache) {
 		if (query_flag & QUERY_LSCALE) {
 			uint32 tdata = get_lscale();
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 			q_cache.lscale = tdata;
 		}
 		if (query_flag & QUERY_RSCALE) {
 			uint32 tdata = get_rscale();
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 			q_cache.rscale = tdata;
 		}
 		if(query_flag & QUERY_LINK) {
 			uint32 tdata = get_link();
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 			q_cache.link = tdata;
 			tdata = get_link_marker();
-			buffer_write(p, tdata);
+			buffer_write<uint32_t>(p, tdata);
 			q_cache.link_marker = tdata;
 		}
 	}
@@ -371,17 +371,17 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 			uint32 link_marker = get_link_marker();
 			if((link != q_cache.link) || (link_marker != q_cache.link_marker)) {
 				q_cache.link = link;
-				buffer_write(p, link);
+				buffer_write<uint32_t>(p, link);
 				q_cache.link_marker = link_marker;
-				buffer_write(p, link_marker);
+				buffer_write<uint32_t>(p, link_marker);
 			}
 			else
 				query_flag &= ~QUERY_LINK;
 		}
 	}
 	byte* finalize = buf;
-	buffer_write(finalize, (int32)(p - buf));
-	buffer_write(finalize, query_flag);
+	buffer_write<int32_t>(finalize, p - buf);
+	buffer_write<uint32_t>(finalize, query_flag);
 	return (int32)(p - buf);
 }
 uint32 card::get_info_location() {

--- a/card.cpp
+++ b/card.cpp
@@ -149,7 +149,7 @@ card::card(duel* pd) {
 inline void update_cache(uint32& tdata, uint32& cache, byte*& p, uint32& query_flag, const uint32 flag) {
 	if (tdata != cache) {
 		cache = tdata;
-		Buffer::write(p, tdata);
+		buffer_write(p, tdata);
 	}
 	else
 		query_flag &= ~flag;
@@ -167,11 +167,11 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 	//first 8 bytes: data length, query flag
 	p += 8;
 	if (query_flag & QUERY_CODE) {
-		Buffer::write(p, data.code);
+		buffer_write(p, data.code);
 	}
 	if (query_flag & QUERY_POSITION) {
 		uint32 tdata = get_info_location();
-		Buffer::write(p, tdata);
+		buffer_write(p, tdata);
 		if (q_cache.info_location != tdata) {
 			q_cache.clear_cache();
 			q_cache.info_location = tdata;
@@ -181,52 +181,52 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 	if(!use_cache) {
 		if (query_flag & QUERY_ALIAS) {
 			uint32 tdata = get_code();
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 			q_cache.current_code = tdata;
 		}
 		if (query_flag & QUERY_TYPE) {
 			uint32 tdata = get_type();
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 			q_cache.type = tdata;
 		}
 		if (query_flag & QUERY_LEVEL) {
 			uint32 tdata = get_level();
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 			q_cache.level = tdata;
 		}
 		if (query_flag & QUERY_RANK) {
 			uint32 tdata = get_rank();
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 			q_cache.rank = tdata;
 		}
 		if (query_flag & QUERY_ATTRIBUTE) {
 			uint32 tdata = get_attribute();
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 			q_cache.attribute = tdata;
 		}
 		if (query_flag & QUERY_RACE) {
 			uint32 tdata = get_race();
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 			q_cache.race = tdata;
 		}
 		if (query_flag & QUERY_ATTACK) {
-			Buffer::write(p, atk_def.first);
+			buffer_write(p, atk_def.first);
 			q_cache.attack = atk_def.first;
 		}
 		if (query_flag & QUERY_DEFENSE) {
-			Buffer::write(p, atk_def.second);
+			buffer_write(p, atk_def.second);
 			q_cache.defense = atk_def.second;
 		}
 		if (query_flag & QUERY_BASE_ATTACK) {
-			Buffer::write(p, base_atk_def.first);
+			buffer_write(p, base_atk_def.first);
 			q_cache.base_attack = base_atk_def.first;
 		}
 		if (query_flag & QUERY_BASE_DEFENSE) {
-			Buffer::write(p, base_atk_def.second);
+			buffer_write(p, base_atk_def.second);
 			q_cache.base_defense = base_atk_def.second;
 		}
 		if (query_flag & QUERY_REASON) {
-			Buffer::write(p, current.reason);
+			buffer_write(p, current.reason);
 			q_cache.reason = current.reason;
 		}
 	}
@@ -258,7 +258,7 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 		if((query_flag & QUERY_ATTACK)) {
 			if (atk_def.first != q_cache.attack) {
 				q_cache.attack = atk_def.first;
-				Buffer::write(p, atk_def.first);
+				buffer_write(p, atk_def.first);
 			}
 			else
 				query_flag &= ~QUERY_ATTACK;
@@ -266,7 +266,7 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 		if((query_flag & QUERY_DEFENSE)) {
 			if (atk_def.second != q_cache.defense) {
 				q_cache.defense = atk_def.second;
-				Buffer::write(p, atk_def.second);
+				buffer_write(p, atk_def.second);
 			}
 			else
 				query_flag &= ~QUERY_DEFENSE;
@@ -274,7 +274,7 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 		if((query_flag & QUERY_BASE_ATTACK)) {
 			if (base_atk_def.first != q_cache.base_attack) {
 				q_cache.base_attack = base_atk_def.first;
-				Buffer::write(p, base_atk_def.first);
+				buffer_write(p, base_atk_def.first);
 			}
 			else
 				query_flag &= ~QUERY_BASE_ATTACK;
@@ -282,7 +282,7 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 		if((query_flag & QUERY_BASE_DEFENSE)) {
 			if (base_atk_def.second != q_cache.base_defense) {
 				q_cache.base_defense = base_atk_def.second;
-				Buffer::write(p, base_atk_def.second);
+				buffer_write(p, base_atk_def.second);
 			}
 			else
 				query_flag &= ~QUERY_BASE_DEFENSE;
@@ -294,45 +294,45 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 	}
 	if (query_flag & QUERY_REASON_CARD) {
 		uint32 tdata = current.reason_card ? current.reason_card->get_info_location() : 0;
-		Buffer::write(p, tdata);
+		buffer_write(p, tdata);
 	}
 	if(query_flag & QUERY_EQUIP_CARD) {
 		if (equiping_target) {
 			uint32 tdata = equiping_target->get_info_location();
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 		}
 		else
 			query_flag &= ~QUERY_EQUIP_CARD;
 	}
 	if(query_flag & QUERY_TARGET_CARD) {
-		Buffer::write(p, (int32)effect_target_cards.size());
+		buffer_write(p, (int32)effect_target_cards.size());
 		for (auto& pcard : effect_target_cards) {
 			uint32 tdata = pcard->get_info_location();
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 		}
 	}
 	if(query_flag & QUERY_OVERLAY_CARD) {
-		Buffer::write(p, (int32)xyz_materials.size());
+		buffer_write(p, (int32)xyz_materials.size());
 		for (auto& xcard : xyz_materials) {
-			Buffer::write(p, xcard->data.code);
+			buffer_write(p, xcard->data.code);
 		}
 	}
 	if(query_flag & QUERY_COUNTERS) {
-		Buffer::write(p, (int32)counters.size());
+		buffer_write(p, (int32)counters.size());
 		for (const auto& cmit : counters) {
 			int32 tdata = cmit.first + ((cmit.second[0] + cmit.second[1]) << 16);
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 		}
 	}
 	if (query_flag & QUERY_OWNER) {
 		int32 tdata = owner;
-		Buffer::write(p, tdata);
+		buffer_write(p, tdata);
 	}
 	if(query_flag & QUERY_STATUS) {
 		uint32 tdata = status & (STATUS_DISABLED | STATUS_FORBIDDEN | STATUS_PROC_COMPLETE);
 		if(!use_cache || (tdata != q_cache.status)) {
 			q_cache.status = tdata;
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 		}
 		else
 			query_flag &= ~QUERY_STATUS;
@@ -340,20 +340,20 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 	if(!use_cache) {
 		if (query_flag & QUERY_LSCALE) {
 			uint32 tdata = get_lscale();
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 			q_cache.lscale = tdata;
 		}
 		if (query_flag & QUERY_RSCALE) {
 			uint32 tdata = get_rscale();
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 			q_cache.rscale = tdata;
 		}
 		if(query_flag & QUERY_LINK) {
 			uint32 tdata = get_link();
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 			q_cache.link = tdata;
 			tdata = get_link_marker();
-			Buffer::write(p, tdata);
+			buffer_write(p, tdata);
 			q_cache.link_marker = tdata;
 		}
 	}
@@ -371,17 +371,17 @@ int32 card::get_infos(byte* buf, uint32 query_flag, int32 use_cache) {
 			uint32 link_marker = get_link_marker();
 			if((link != q_cache.link) || (link_marker != q_cache.link_marker)) {
 				q_cache.link = link;
-				Buffer::write(p, link);
+				buffer_write(p, link);
 				q_cache.link_marker = link_marker;
-				Buffer::write(p, link_marker);
+				buffer_write(p, link_marker);
 			}
 			else
 				query_flag &= ~QUERY_LINK;
 		}
 	}
 	byte* finalize = buf;
-	Buffer::write(finalize, (int32)(p - buf));
-	Buffer::write(finalize, query_flag);
+	buffer_write(finalize, (int32)(p - buf));
+	buffer_write(finalize, query_flag);
 	return (int32)(p - buf);
 }
 uint32 card::get_info_location() {

--- a/duel.cpp
+++ b/duel.cpp
@@ -115,7 +115,7 @@ void duel::restore_assumes() {
 	assumes.clear();
 }
 void duel::write_buffer(const void* data, int size) {
-	vector_write_array(message_buffer, data, size);
+	vector_write_block(message_buffer, data, size);
 }
 void duel::write_buffer32(uint32 value) {
 	vector_write<uint32_t>(message_buffer, value);

--- a/duel.cpp
+++ b/duel.cpp
@@ -115,16 +115,16 @@ void duel::restore_assumes() {
 	assumes.clear();
 }
 void duel::write_buffer(const void* data, int size) {
-	Buffer::write_array(message_buffer, data, size);
+	vector_write_array(message_buffer, data, size);
 }
 void duel::write_buffer32(uint32 value) {
-	Buffer::write(message_buffer, value);
+	vector_write(message_buffer, value);
 }
 void duel::write_buffer16(uint16 value) {
-	Buffer::write(message_buffer, value);
+	vector_write(message_buffer, value);
 }
 void duel::write_buffer8(uint8 value) {
-	Buffer::write(message_buffer, value);
+	vector_write(message_buffer, value);
 }
 void duel::clear_buffer() {
 	message_buffer.clear();

--- a/duel.cpp
+++ b/duel.cpp
@@ -118,13 +118,13 @@ void duel::write_buffer(const void* data, int size) {
 	vector_write_array(message_buffer, data, size);
 }
 void duel::write_buffer32(uint32 value) {
-	vector_write(message_buffer, value);
+	vector_write<uint32_t>(message_buffer, value);
 }
 void duel::write_buffer16(uint16 value) {
-	vector_write(message_buffer, value);
+	vector_write<uint16_t>(message_buffer, value);
 }
 void duel::write_buffer8(uint8 value) {
-	vector_write(message_buffer, value);
+	vector_write<unsigned char>(message_buffer, value);
 }
 void duel::clear_buffer() {
 	message_buffer.clear();

--- a/duel.cpp
+++ b/duel.cpp
@@ -13,14 +13,7 @@
 #include "effect.h"
 #include "group.h"
 #include "ocgapi.h"
-
-inline void write_buffer_vector(std::vector<byte>& buffer, const void* data, int size) {
-	if (size > 0) {
-		const auto len = buffer.size();
-		buffer.resize(len + size);
-		std::memcpy(&buffer[len], data, size);
-	}
-}
+#include "buffer.h"
 
 duel::duel() {
 	lua = new interpreter(this);
@@ -122,16 +115,16 @@ void duel::restore_assumes() {
 	assumes.clear();
 }
 void duel::write_buffer(const void* data, int size) {
-	write_buffer_vector(message_buffer, data, size);
+	Buffer::write_array(message_buffer, data, size);
 }
 void duel::write_buffer32(uint32 value) {
-	write_buffer(&value, sizeof(value));
+	Buffer::write(message_buffer, value);
 }
 void duel::write_buffer16(uint16 value) {
-	write_buffer(&value, sizeof(value));
+	Buffer::write(message_buffer, value);
 }
 void duel::write_buffer8(uint8 value) {
-	write_buffer(&value, sizeof(value));
+	Buffer::write(message_buffer, value);
 }
 void duel::clear_buffer() {
 	message_buffer.clear();

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -207,7 +207,7 @@ extern "C" DECL_DLLEXPORT int32 query_card(intptr_t pduel, uint8 playerid, uint8
 		return pcard->get_infos(buf, query_flag, use_cache);
 	}
 	else {
-		buffer_write(buf, LEN_EMPTY);
+		buffer_write<int32_t>(buf, LEN_EMPTY);
 		return LEN_EMPTY;
 	}
 }
@@ -254,7 +254,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(intptr_t pduel, uint8 playerid,
 				int32 clen = pcard->get_infos(p, query_flag, use_cache);
 				p += clen;
 			} else {
-				buffer_write(p, LEN_EMPTY);
+				buffer_write<int32_t>(p, LEN_EMPTY);
 			}
 		}
 	}
@@ -264,7 +264,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(intptr_t pduel, uint8 playerid,
 				int32 clen = pcard->get_infos(p, query_flag, use_cache);
 				p += clen;
 			} else {
-				buffer_write(p, LEN_EMPTY);
+				buffer_write<int32_t>(p, LEN_EMPTY);
 			}
 		}
 	}
@@ -296,7 +296,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_info(intptr_t pduel, byte* buf) {
 	*p++ = ptduel->game_field->core.duel_rule;
 	for(int playerid = 0; playerid < 2; ++playerid) {
 		auto& player = ptduel->game_field->player[playerid];
-		buffer_write(p, player.lp);
+		buffer_write<int32_t>(p, player.lp);
 		for(auto& pcard : player.list_mzone) {
 			if(pcard) {
 				*p++ = 1;
@@ -324,12 +324,12 @@ extern "C" DECL_DLLEXPORT int32 query_field_info(intptr_t pduel, byte* buf) {
 	*p++ = (uint8)ptduel->game_field->core.current_chain.size();
 	for(const auto& ch : ptduel->game_field->core.current_chain) {
 		effect* peffect = ch.triggering_effect;
-		buffer_write(p, peffect->get_handler()->data.code);
-		buffer_write(p, peffect->get_handler()->get_info_location());
+		buffer_write<uint32_t>(p, peffect->get_handler()->data.code);
+		buffer_write<uint32_t>(p, peffect->get_handler()->get_info_location());
 		*p++ = ch.triggering_controler;
 		*p++ = (uint8)ch.triggering_location;
 		*p++ = ch.triggering_sequence;
-		buffer_write(p, peffect->description);
+		buffer_write<uint32_t>(p, peffect->description);
 	}
 	return (int32)(p - buf);
 }

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -207,7 +207,7 @@ extern "C" DECL_DLLEXPORT int32 query_card(intptr_t pduel, uint8 playerid, uint8
 		return pcard->get_infos(buf, query_flag, use_cache);
 	}
 	else {
-		write_byte_buffer(buf, LEN_EMPTY);
+		Buffer::write(buf, LEN_EMPTY);
 		return LEN_EMPTY;
 	}
 }
@@ -254,7 +254,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(intptr_t pduel, uint8 playerid,
 				int32 clen = pcard->get_infos(p, query_flag, use_cache);
 				p += clen;
 			} else {
-				write_byte_buffer(p, LEN_EMPTY);
+				Buffer::write(p, LEN_EMPTY);
 			}
 		}
 	}
@@ -264,7 +264,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(intptr_t pduel, uint8 playerid,
 				int32 clen = pcard->get_infos(p, query_flag, use_cache);
 				p += clen;
 			} else {
-				write_byte_buffer(p, LEN_EMPTY);
+				Buffer::write(p, LEN_EMPTY);
 			}
 		}
 	}
@@ -296,7 +296,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_info(intptr_t pduel, byte* buf) {
 	*p++ = ptduel->game_field->core.duel_rule;
 	for(int playerid = 0; playerid < 2; ++playerid) {
 		auto& player = ptduel->game_field->player[playerid];
-		write_byte_buffer(p, player.lp);
+		Buffer::write(p, player.lp);
 		for(auto& pcard : player.list_mzone) {
 			if(pcard) {
 				*p++ = 1;
@@ -324,12 +324,12 @@ extern "C" DECL_DLLEXPORT int32 query_field_info(intptr_t pduel, byte* buf) {
 	*p++ = (uint8)ptduel->game_field->core.current_chain.size();
 	for(const auto& ch : ptduel->game_field->core.current_chain) {
 		effect* peffect = ch.triggering_effect;
-		write_byte_buffer(p, peffect->get_handler()->data.code);
-		write_byte_buffer(p, peffect->get_handler()->get_info_location());
+		Buffer::write(p, peffect->get_handler()->data.code);
+		Buffer::write(p, peffect->get_handler()->get_info_location());
 		*p++ = ch.triggering_controler;
 		*p++ = (uint8)ch.triggering_location;
 		*p++ = ch.triggering_sequence;
-		write_byte_buffer(p, peffect->description);
+		Buffer::write(p, peffect->description);
 	}
 	return (int32)(p - buf);
 }

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -206,7 +206,8 @@ extern "C" DECL_DLLEXPORT int32 query_card(intptr_t pduel, uint8 playerid, uint8
 		return pcard->get_infos(buf, query_flag, use_cache);
 	}
 	else {
-		*((int32*)buf) = LEN_EMPTY;
+		constexpr int32 len = LEN_EMPTY;
+		std::memcpy(buf, &len, sizeof len);
 		return LEN_EMPTY;
 	}
 }
@@ -253,7 +254,8 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(intptr_t pduel, uint8 playerid,
 				int32 clen = pcard->get_infos(p, query_flag, use_cache);
 				p += clen;
 			} else {
-				*((int32*)p) = LEN_EMPTY;
+				constexpr int32 len = LEN_EMPTY;
+				std::memcpy(p, &len, sizeof len);
 				p += LEN_EMPTY;
 			}
 		}
@@ -264,7 +266,8 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(intptr_t pduel, uint8 playerid,
 				int32 clen = pcard->get_infos(p, query_flag, use_cache);
 				p += clen;
 			} else {
-				*((int32*)p) = LEN_EMPTY;
+				constexpr int32 len = LEN_EMPTY;
+				std::memcpy(p, &len, sizeof len);
 				p += LEN_EMPTY;
 			}
 		}
@@ -297,8 +300,9 @@ extern "C" DECL_DLLEXPORT int32 query_field_info(intptr_t pduel, byte* buf) {
 	*p++ = ptduel->game_field->core.duel_rule;
 	for(int playerid = 0; playerid < 2; ++playerid) {
 		auto& player = ptduel->game_field->player[playerid];
-		*((int*)p) = player.lp;
-		p += 4;
+		const auto lp = player.lp;
+		std::memcpy(p, &lp, sizeof lp);
+		p += sizeof lp;
 		for(auto& pcard : player.list_mzone) {
 			if(pcard) {
 				*p++ = 1;
@@ -326,15 +330,18 @@ extern "C" DECL_DLLEXPORT int32 query_field_info(intptr_t pduel, byte* buf) {
 	*p++ = (uint8)ptduel->game_field->core.current_chain.size();
 	for(const auto& ch : ptduel->game_field->core.current_chain) {
 		effect* peffect = ch.triggering_effect;
-		*((int*)p) = peffect->get_handler()->data.code;
-		p += 4;
-		*((int*)p) = peffect->get_handler()->get_info_location();
-		p += 4;
+		const auto code = peffect->get_handler()->data.code;
+		std::memcpy(p, &code, sizeof code);
+		p += sizeof code;
+		const auto info = peffect->get_handler()->get_info_location();
+		std::memcpy(p, &info, sizeof info);
+		p += sizeof info;
 		*p++ = ch.triggering_controler;
 		*p++ = (uint8)ch.triggering_location;
 		*p++ = ch.triggering_sequence;
-		*((int*)p) = peffect->description;
-		p += 4;
+		const auto desc = peffect->description;
+		std::memcpy(p, &desc, sizeof desc);
+		p += sizeof desc;
 	}
 	return (int32)(p - buf);
 }

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -13,6 +13,7 @@
 #include "effect.h"
 #include "field.h"
 #include "interpreter.h"
+#include "buffer.h"
 #include <set>
 
 static script_reader sreader = default_script_reader;
@@ -206,8 +207,7 @@ extern "C" DECL_DLLEXPORT int32 query_card(intptr_t pduel, uint8 playerid, uint8
 		return pcard->get_infos(buf, query_flag, use_cache);
 	}
 	else {
-		constexpr int32 len = LEN_EMPTY;
-		std::memcpy(buf, &len, sizeof len);
+		write_byte_buffer(buf, LEN_EMPTY);
 		return LEN_EMPTY;
 	}
 }
@@ -254,9 +254,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(intptr_t pduel, uint8 playerid,
 				int32 clen = pcard->get_infos(p, query_flag, use_cache);
 				p += clen;
 			} else {
-				constexpr int32 len = LEN_EMPTY;
-				std::memcpy(p, &len, sizeof len);
-				p += LEN_EMPTY;
+				write_byte_buffer(p, LEN_EMPTY);
 			}
 		}
 	}
@@ -266,9 +264,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(intptr_t pduel, uint8 playerid,
 				int32 clen = pcard->get_infos(p, query_flag, use_cache);
 				p += clen;
 			} else {
-				constexpr int32 len = LEN_EMPTY;
-				std::memcpy(p, &len, sizeof len);
-				p += LEN_EMPTY;
+				write_byte_buffer(p, LEN_EMPTY);
 			}
 		}
 	}
@@ -300,9 +296,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_info(intptr_t pduel, byte* buf) {
 	*p++ = ptduel->game_field->core.duel_rule;
 	for(int playerid = 0; playerid < 2; ++playerid) {
 		auto& player = ptduel->game_field->player[playerid];
-		const auto lp = player.lp;
-		std::memcpy(p, &lp, sizeof lp);
-		p += sizeof lp;
+		write_byte_buffer(p, player.lp);
 		for(auto& pcard : player.list_mzone) {
 			if(pcard) {
 				*p++ = 1;
@@ -330,18 +324,12 @@ extern "C" DECL_DLLEXPORT int32 query_field_info(intptr_t pduel, byte* buf) {
 	*p++ = (uint8)ptduel->game_field->core.current_chain.size();
 	for(const auto& ch : ptduel->game_field->core.current_chain) {
 		effect* peffect = ch.triggering_effect;
-		const auto code = peffect->get_handler()->data.code;
-		std::memcpy(p, &code, sizeof code);
-		p += sizeof code;
-		const auto info = peffect->get_handler()->get_info_location();
-		std::memcpy(p, &info, sizeof info);
-		p += sizeof info;
+		write_byte_buffer(p, peffect->get_handler()->data.code);
+		write_byte_buffer(p, peffect->get_handler()->get_info_location());
 		*p++ = ch.triggering_controler;
 		*p++ = (uint8)ch.triggering_location;
 		*p++ = ch.triggering_sequence;
-		const auto desc = peffect->description;
-		std::memcpy(p, &desc, sizeof desc);
-		p += sizeof desc;
+		write_byte_buffer(p, peffect->description);
 	}
 	return (int32)(p - buf);
 }

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -207,7 +207,7 @@ extern "C" DECL_DLLEXPORT int32 query_card(intptr_t pduel, uint8 playerid, uint8
 		return pcard->get_infos(buf, query_flag, use_cache);
 	}
 	else {
-		Buffer::write(buf, LEN_EMPTY);
+		buffer_write(buf, LEN_EMPTY);
 		return LEN_EMPTY;
 	}
 }
@@ -254,7 +254,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(intptr_t pduel, uint8 playerid,
 				int32 clen = pcard->get_infos(p, query_flag, use_cache);
 				p += clen;
 			} else {
-				Buffer::write(p, LEN_EMPTY);
+				buffer_write(p, LEN_EMPTY);
 			}
 		}
 	}
@@ -264,7 +264,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(intptr_t pduel, uint8 playerid,
 				int32 clen = pcard->get_infos(p, query_flag, use_cache);
 				p += clen;
 			} else {
-				Buffer::write(p, LEN_EMPTY);
+				buffer_write(p, LEN_EMPTY);
 			}
 		}
 	}
@@ -296,7 +296,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_info(intptr_t pduel, byte* buf) {
 	*p++ = ptduel->game_field->core.duel_rule;
 	for(int playerid = 0; playerid < 2; ++playerid) {
 		auto& player = ptduel->game_field->player[playerid];
-		Buffer::write(p, player.lp);
+		buffer_write(p, player.lp);
 		for(auto& pcard : player.list_mzone) {
 			if(pcard) {
 				*p++ = 1;
@@ -324,12 +324,12 @@ extern "C" DECL_DLLEXPORT int32 query_field_info(intptr_t pduel, byte* buf) {
 	*p++ = (uint8)ptduel->game_field->core.current_chain.size();
 	for(const auto& ch : ptduel->game_field->core.current_chain) {
 		effect* peffect = ch.triggering_effect;
-		Buffer::write(p, peffect->get_handler()->data.code);
-		Buffer::write(p, peffect->get_handler()->get_info_location());
+		buffer_write(p, peffect->get_handler()->data.code);
+		buffer_write(p, peffect->get_handler()->get_info_location());
 		*p++ = ch.triggering_controler;
 		*p++ = (uint8)ch.triggering_location;
 		*p++ = ch.triggering_sequence;
-		Buffer::write(p, peffect->description);
+		buffer_write(p, peffect->description);
 	}
 	return (int32)(p - buf);
 }


### PR DESCRIPTION
https://gist.github.com/shafik/848ae25ee209f698763cffee272a58f8
According to the strict aliasing rule, we should not cast a pointer should to another type and dereference.
It can be done by `memcpy`.

C++14
3.10, paragraph 10
> If a program attempts to access the stored value of an object through a glvalue of other than one of the
following types the behavior is undefined:
—(10.1) the dynamic type of the object,
—(10.2) a cv-qualified version of the dynamic type of the object,
—(10.3) a type similar (as defined in 4.4) to the dynamic type of the object,
—(10.4) a type that is the signed or unsigned type corresponding to the dynamic type of the object,
—(10.5) a type that is the signed or unsigned type corresponding to a cv-qualified version of the dynamic type
of the object,
—(10.6) an aggregate or union type that includes one of the aforementioned types among its elements or non-
static data members (including, recursively, an element or non-static data member of a subaggregate
or contained union),
—(10.7) a type that is a (possibly cv-qualified) base class type of the dynamic type of the object,
—(10.8) a char or unsigned char type.


Add `buffer.h`


Reference:
https://github.com/edo9300/edopro/blame/master/gframe/bufferio.h