### PR TITLE
add Card.GetPreviousOverlayCountOnField

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -143,6 +143,7 @@ card::card(duel* pd) {
 	assume_type = 0;
 	assume_value = 0;
 	spsummon_code = 0;
+	xyz_materials_previous_count_onfield = 0;
 	current.controler = PLAYER_NONE;
 }
 inline void update_cache(uint32& tdata, uint32& cache, int32*& p, uint32& query_flag, const uint32 flag) {

--- a/card.h
+++ b/card.h
@@ -198,6 +198,7 @@ public:
 	card_set effect_target_owner;
 	card_set effect_target_cards;
 	card_vector xyz_materials;
+	int32 xyz_materials_previous_count_onfield;
 	effect_container single_effect;
 	effect_container field_effect;
 	effect_container equip_effect;

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -742,6 +742,13 @@ int32 scriptlib::card_get_previous_defense_onfield(lua_State *L) {
 	lua_pushinteger(L, pcard->previous.defense);
 	return 1;
 }
+int32 scriptlib::card_get_previous_overlay_count_onfield(lua_State *L) {
+	check_param_count(L, 1);
+	check_param(L, PARAM_TYPE_CARD, 1);
+	card* pcard = *(card**) lua_touserdata(L, 1);
+	lua_pushinteger(L, pcard->xyz_materials_previous_count_onfield);
+	return 1;
+}
 int32 scriptlib::card_get_owner(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
@@ -3434,6 +3441,7 @@ static const struct luaL_Reg cardlib[] = {
 	{ "GetPreviousRaceOnField", scriptlib::card_get_previous_race_onfield },
 	{ "GetPreviousAttackOnField", scriptlib::card_get_previous_attack_onfield },
 	{ "GetPreviousDefenseOnField", scriptlib::card_get_previous_defense_onfield },
+	{ "GetPreviousOverlayCountOnField", scriptlib::card_get_previous_overlay_count_onfield },
 	{ "GetOwner", scriptlib::card_get_owner },
 	{ "GetControler", scriptlib::card_get_controler },
 	{ "GetPreviousControler", scriptlib::card_get_previous_controler },

--- a/operations.cpp
+++ b/operations.cpp
@@ -4364,8 +4364,11 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 				raise_single_event(pcard, 0, EVENT_DESTROYED, pcard->current.reason_effect, pcard->current.reason, pcard->current.reason_player, 0, 0);
 			}
 			if(pcard->xyz_materials.size()) {
+				pcard->xyz_materials_previous_count_onfield = pcard->xyz_materials.size();
 				for(auto& mcard : pcard->xyz_materials)
 					overlays.insert(mcard);
+			} else {
+				pcard->xyz_materials_previous_count_onfield = 0;
 			}
 			raise_single_event(pcard, 0, EVENT_MOVE, pcard->current.reason_effect, pcard->current.reason, pcard->current.reason_player, 0, 0);
 		}
@@ -4696,7 +4699,7 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 		target->set_status(STATUS_LEAVE_CONFIRMED, FALSE);
 		pduel->write_buffer32(target->get_info_location());
 		pduel->write_buffer32(target->current.reason);
-		if((target->current.location != LOCATION_MZONE)) {
+		if(target->current.location != LOCATION_MZONE) {
 			if(target->equiping_cards.size()) {
 				destroy(&target->equiping_cards, 0, REASON_LOST_TARGET + REASON_RULE, PLAYER_NONE);
 				for(auto csit = target->equiping_cards.begin(); csit != target->equiping_cards.end();) {
@@ -4705,9 +4708,12 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 				}
 			}
 			if(target->xyz_materials.size()) {
+				target->xyz_materials_previous_count_onfield = target->xyz_materials.size();
 				card_set overlays;
 				overlays.insert(target->xyz_materials.begin(), target->xyz_materials.end());
 				send_to(&overlays, 0, REASON_LOST_OVERLAY + REASON_RULE, PLAYER_NONE, PLAYER_NONE, LOCATION_GRAVE, 0, POS_FACEUP);
+			} else {
+				target->xyz_materials_previous_count_onfield = 0;
 			}
 		}
 		if((target->previous.location == LOCATION_SZONE) && target->equiping_target)

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -90,6 +90,7 @@ public:
 	static int32 card_get_previous_race_onfield(lua_State *L);
 	static int32 card_get_previous_attack_onfield(lua_State *L);
 	static int32 card_get_previous_defense_onfield(lua_State *L);
+	static int32 card_get_previous_overlay_count_onfield(lua_State *L);
 	static int32 card_get_owner(lua_State *L);
 	static int32 card_get_controler(lua_State *L);
 	static int32 card_get_previous_controler(lua_State *L);


### PR DESCRIPTION
_`send_to` send card to grave before removing overlay cards, so the `previous` `card_state` can't be used_