### PR TITLE
 add Card.IsTextMention 

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -589,6 +589,12 @@ int32 card::is_special_summon_set_card(uint32 set_code) {
 	}
 	return FALSE;
 }
+int32 card::is_text_mention(uint32 code) {
+	if (::is_mention(data.code, code))
+		return TRUE;
+	else
+		return FALSE;
+}
 uint32 card::get_type() {
 	if(assume_type == ASSUME_TYPE)
 		return assume_value;

--- a/card.h
+++ b/card.h
@@ -225,6 +225,7 @@ public:
 	int32 is_fusion_set_card(uint32 set_code);
 	int32 is_link_set_card(uint32 set_code);
 	int32 is_special_summon_set_card(uint32 set_code);
+	int32 is_text_mention(uint32 code);
 	uint32 get_type();
 	uint32 get_fusion_type();
 	uint32 get_synchro_type();

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -252,6 +252,14 @@ int32 scriptlib::card_is_special_summon_set_card(lua_State *L) {
 	lua_pushboolean(L, result);
 	return 1;
 }
+int32 scriptlib::card_is_text_mention(lua_State* L) {
+	check_param_count(L, 2);
+	check_param(L, PARAM_TYPE_CARD, 1);
+	card* pcard = *(card**)lua_touserdata(L, 1);
+	uint32 code = (uint32)lua_tointeger(L, 2);
+	lua_pushboolean(L, pcard->is_text_mention(code));
+	return 1;
+}
 int32 scriptlib::card_get_type(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
@@ -3379,6 +3387,7 @@ static const struct luaL_Reg cardlib[] = {
 	{ "IsFusionSetCard", scriptlib::card_is_fusion_set_card },
 	{ "IsLinkSetCard", scriptlib::card_is_link_set_card },
 	{ "IsSpecialSummonSetCard", scriptlib::card_is_special_summon_set_card },
+	{ "IsTextMention", scriptlib::card_is_text_mention },
 	{ "GetType", scriptlib::card_get_type },
 	{ "GetOriginalType", scriptlib::card_get_origin_type },
 	{ "GetFusionType", scriptlib::card_get_fusion_type },

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -18,6 +18,7 @@
 static script_reader sreader = default_script_reader;
 static card_reader creader = default_card_reader;
 static message_handler mhandler = default_message_handler;
+static mention_handler thandler = default_mention_handler;
 static byte buffer[0x20000];
 static std::set<duel*> duel_set;
 
@@ -30,6 +31,9 @@ extern "C" DECL_DLLEXPORT void set_card_reader(card_reader f) {
 extern "C" DECL_DLLEXPORT void set_message_handler(message_handler f) {
 	mhandler = f;
 }
+extern "C" DECL_DLLEXPORT void set_mention_handler(mention_handler f) {
+	thandler = f;
+}
 byte* read_script(const char* script_name, int* len) {
 	return sreader(script_name, len);
 }
@@ -38,6 +42,9 @@ uint32 read_card(uint32 code, card_data* data) {
 }
 uint32 handle_message(void* pduel, uint32 msg_type) {
 	return mhandler((intptr_t)pduel, msg_type);
+}
+bool is_mention(uint32 text_code, uint32 name_code) {
+	return thandler(text_code, name_code);
 }
 byte* default_script_reader(const char* script_name, int* slen) {
 	FILE *fp;
@@ -56,6 +63,9 @@ uint32 default_card_reader(uint32 code, card_data* data) {
 }
 uint32 default_message_handler(intptr_t pduel, uint32 message_type) {
 	return 0;
+}
+bool default_mention_handler(uint32 text_code, uint32 name_code) {
+	return false;
 }
 extern "C" DECL_DLLEXPORT intptr_t create_duel(uint_fast32_t seed) {
 	duel* pduel = new duel();

--- a/ocgapi.h
+++ b/ocgapi.h
@@ -29,14 +29,17 @@ class interpreter;
 typedef byte* (*script_reader)(const char*, int*);
 typedef uint32 (*card_reader)(uint32, card_data*);
 typedef uint32 (*message_handler)(intptr_t, uint32);
+typedef bool (*mention_handler)(uint32, uint32);
 
 extern "C" DECL_DLLEXPORT void set_script_reader(script_reader f);
 extern "C" DECL_DLLEXPORT void set_card_reader(card_reader f);
 extern "C" DECL_DLLEXPORT void set_message_handler(message_handler f);
+extern "C" DECL_DLLEXPORT void set_mention_handler(mention_handler f);
 
 byte* read_script(const char* script_name, int* len);
 uint32 read_card(uint32 code, card_data* data);
 uint32 handle_message(void* pduel, uint32 message_type);
+bool is_mention(uint32 text_code, uint32 name_code);
 
 extern "C" DECL_DLLEXPORT intptr_t create_duel(uint_fast32_t seed);
 extern "C" DECL_DLLEXPORT void start_duel(intptr_t pduel, int32 options);
@@ -57,5 +60,6 @@ extern "C" DECL_DLLEXPORT int32 preload_script(intptr_t pduel, const char* scrip
 byte* default_script_reader(const char* script_name, int* len);
 uint32 default_card_reader(uint32 code, card_data* data);
 uint32 default_message_handler(intptr_t pduel, uint32 msg_type);
+bool default_mention_handler(uint32 text_code, uint32 name_code);
 
 #endif /* OCGAPI_H_ */

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -35,6 +35,7 @@ public:
 	static int32 card_is_fusion_set_card(lua_State *L);
 	static int32 card_is_link_set_card(lua_State *L);
 	static int32 card_is_special_summon_set_card(lua_State *L);
+	static int32 card_is_text_mention(lua_State* L);
 	static int32 card_get_type(lua_State *L);
 	static int32 card_get_origin_type(lua_State *L);
 	static int32 card_get_fusion_type(lua_State *L);


### PR DESCRIPTION
@mercury233 @purerosefallen 
ocgapi:
new API
```cpp
extern "C" DECL_DLLEXPORT void set_mention_handler(mention_handler f);
//Set the mention_handler.
```

```cpp
bool mention_handler(uint32 text_code, uint32 name_code)
//Check if the text of `text_code` mentions the name of `name_code`.
```

new function:
```cpp
bool is_mention(uint32 text_code, uint32 name_code) {
	return thandler(text_code, name_code);
}
```

new Lua function
```lua
---Check if the text of this card mentions the name of `code`.
---@return boolean
---@param code integer
function Card.IsTextMention (code) end
```

It is the basic version.
It can only check the card name which is NOT a setname.
The card name which is also a setname can be checked by the old `Auxiliary.IsCodeListed`.
