### PR TITLE
fix reason check in field::send_to(uint16 step

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -3906,7 +3906,7 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 			uint8 dest = pcard->sendto_param.location;
 			if(!(reason & REASON_RULE) &&
 			        (pcard->get_status(STATUS_SUMMONING | STATUS_SPSUMMON_STEP)
-			         || (!(pcard->current.reason & (REASON_COST | REASON_SUMMON | REASONS_PROCEDURE)) && !pcard->is_affect_by_effect(pcard->current.reason_effect))
+			         || ((pcard->current.reason & REASON_EFFECT) && !pcard->is_affect_by_effect(pcard->current.reason_effect))
 			         || (dest == LOCATION_HAND && !pcard->is_capable_send_to_hand(core.reason_player))
 			         || (dest == LOCATION_DECK && !pcard->is_capable_send_to_deck(core.reason_player, send_activating))
 			         || (dest == LOCATION_REMOVED && !pcard->is_removeable(core.reason_player, pcard->sendto_param.position, reason))
@@ -3926,6 +3926,7 @@ int32 field::send_to(uint16 step, group * targets, effect * reason_effect, uint3
 		return FALSE;
 	}
 	case 1: {
+		// the entrance of release, destroy
 		for(auto& pcard : targets->container) {
 			add_process(PROCESSOR_SENDTO_REPLACE, 0, nullptr, targets, 0, 0, 0, 0, pcard);
 		}


### PR DESCRIPTION
#334 
#516 

As we have seen before, dividing the reason into effect/cost is not enough.

The reason for release now:
- `REASON_ACTION`
"This card cannot declare an attack unless"... (Panther Warrior)

- `REASON_COST`
The card is released by the cost of effect activation.
Prohibited by `Ritual Beast Ulti-Reirautari`.

- `REASON_EFFECT`
The card is released by effect. (Ritual Summon)

- `REASON_MAINTENANCE`
The maintenance cost. (Aerial Recharge)

- `REASON_SPSUMMON`
The card is released by the Special Summon procedure. (Blue-Eyes Toon Dragon)

- `REASON_SUMMON`
The card is released by Tribute Summon.

- `REASON_RULE`
The card is is released by non-effect actions.  (痛み分け/Share the Pain)

They should be applied to `Duel.Sendto*`, as @465uytrewq suggested in https://github.com/Fluorohydride/ygopro-scripts/pull/2366 .

Now it will check `pcard->is_affect_by_effect` only when the move is marked by `REASON_EFFECT`.

Test script:
```lua
--[[message #580]]
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(16886617,0,0,LOCATION_HAND,0,POS_FACEDOWN)
Debug.AddCard(72270339,0,0,LOCATION_HAND,1,POS_FACEDOWN)

Debug.AddCard(27240101,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK)
Debug.AddCard(27240101,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK)

Debug.AddCard(66570171,0,0,LOCATION_DECK,0,POS_FACEDOWN)
Debug.AddCard(40044918,0,0,LOCATION_DECK,1,POS_FACEDOWN)
Debug.AddCard(66570171,0,0,LOCATION_DECK,2,POS_FACEDOWN)

Debug.AddCard(66570171,1,1,LOCATION_DECK,0,POS_FACEDOWN)
Debug.AddCard(40044918,1,1,LOCATION_DECK,1,POS_FACEDOWN)
Debug.AddCard(27660735,1,1,LOCATION_DECK,2,POS_FACEDOWN)

Debug.ReloadFieldEnd()
--aux.BeginPuzzle()

```

@mercury233 
@purerosefallen 