### PR TITLE
update Lua interpreter

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3256,8 +3256,8 @@ int32 card::is_spsummonable_card() {
 		pduel->lua->add_param(pduel->game_field->core.reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(pduel->game_field->core.reason_player, PARAM_TYPE_INT);
 		pduel->lua->add_param(SUMMON_TYPE_SPECIAL, PARAM_TYPE_INT);
-		pduel->lua->add_param((void*)0, PARAM_TYPE_INT);
-		pduel->lua->add_param((void*)0, PARAM_TYPE_INT);
+		pduel->lua->add_param(0, PARAM_TYPE_INT);
+		pduel->lua->add_param(0, PARAM_TYPE_INT);
 		if(!eset[i]->check_value_condition(5))
 			return FALSE;
 	}
@@ -3275,8 +3275,8 @@ int32 card::is_fusion_summonable_card(uint32 summon_type) {
 		pduel->lua->add_param(pduel->game_field->core.reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(pduel->game_field->core.reason_player, PARAM_TYPE_INT);
 		pduel->lua->add_param(summon_type, PARAM_TYPE_INT);
-		pduel->lua->add_param((void*)0, PARAM_TYPE_INT);
-		pduel->lua->add_param((void*)0, PARAM_TYPE_INT);
+		pduel->lua->add_param(0, PARAM_TYPE_INT);
+		pduel->lua->add_param(0, PARAM_TYPE_INT);
 		if(!eset[i]->check_value_condition(5))
 			return FALSE;
 	}

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -631,7 +631,7 @@ void* interpreter::get_ref_object(int32 ref_handler) {
 	lua_pop(current_state, 1);
 	return p;
 }
-//Convert a pointer to a lua value, +1 -0
+//push the object onto the stack, +1
 void interpreter::card2value(lua_State* L, card* pcard) {
 	luaL_checkstack(L, 1, nullptr);
 	if (!pcard || pcard->ref_handle == 0)

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -586,7 +586,7 @@ int32 interpreter::call_coroutine(int32 f, uint32 param_count, int32* yield_valu
 #if (LUA_VERSION_NUM >= 504)
 		result = lua_resume(rthread, prev_state, param_count, &nresults);
 #else
-		result = lua_resume(rthread, 0, param_count);
+		result = lua_resume(rthread, prev_state, param_count);
 		nresults = lua_gettop(rthread);
 #endif
 		current_state = prev_state;

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstring>
+#include <utility>
 #include "duel.h"
 #include "group.h"
 #include "card.h"
@@ -581,8 +582,7 @@ int32 interpreter::call_coroutine(int32 f, uint32 param_count, int32* yield_valu
 	push_param(rthread, true);
 	int32 result = 0, nresults = 0;
 	{
-		lua_State* prev_state = current_state;
-		current_state = rthread;
+		auto prev_state = std::exchange(current_state, rthread);
 #if (LUA_VERSION_NUM >= 504)
 		result = lua_resume(rthread, prev_state, param_count, &nresults);
 #else

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -531,7 +531,7 @@ int32 interpreter::get_function_value(int32 f, uint32 param_count, std::vector<i
 	}
 	return is_success;
 }
-int32 interpreter::call_coroutine(int32 f, uint32 param_count, uint32* yield_value, uint16 step) {
+int32 interpreter::call_coroutine(int32 f, uint32 param_count, int32* yield_value, uint16 step) {
 	*yield_value = 0;
 	if (!f) {
 		sprintf(pduel->strbuffer, "\"CallCoroutine\": attempt to call a null function");
@@ -604,7 +604,7 @@ int32 interpreter::call_coroutine(int32 f, uint32 param_count, uint32* yield_val
 		else if (lua_isboolean(rthread, -1))
 			*yield_value = lua_toboolean(rthread, -1);
 		else
-			*yield_value = (uint32)lua_tointeger(rthread, -1);
+			*yield_value = (int32)lua_tointeger(rthread, -1);
 	}
 	auto threadref = it->second.second;
 	coroutines.erase(it);

--- a/interpreter.h
+++ b/interpreter.h
@@ -74,7 +74,7 @@ public:
 	int32 get_operation_value(card* pcard, int32 findex, int32 extraargs);
 	int32 get_function_value(int32 f, uint32 param_count);
 	int32 get_function_value(int32 f, uint32 param_count, std::vector<int32>* result);
-	int32 call_coroutine(int32 f, uint32 param_count, uint32* yield_value, uint16 step);
+	int32 call_coroutine(int32 f, uint32 param_count, int32* yield_value, uint16 step);
 	int32 clone_function_ref(int32 func_ref);
 	void* get_ref_object(int32 ref_handler);
 

--- a/interpreter.h
+++ b/interpreter.h
@@ -39,7 +39,7 @@ public:
 		void* ptr;
 		int32 integer;
 	};
-	using coroutine_map = std::unordered_map<int32, lua_State*>;
+	using coroutine_map = std::unordered_map<int32, std::pair<lua_State*, int32>>;
 	using param_list = std::list<std::pair<lua_param, LuaParamType>>;
 	
 	duel* pduel;

--- a/interpreter.h
+++ b/interpreter.h
@@ -22,10 +22,25 @@ class effect;
 class group;
 class duel;
 
+enum LuaParamType {
+	PARAM_TYPE_INT = 0x01,
+	PARAM_TYPE_STRING = 0x02,
+	PARAM_TYPE_CARD = 0x04,
+	PARAM_TYPE_GROUP = 0x08,
+	PARAM_TYPE_EFFECT = 0x10,
+	PARAM_TYPE_FUNCTION = 0x20,
+	PARAM_TYPE_BOOLEAN = 0x40,
+	PARAM_TYPE_INDEX = 0x80,
+};
+
 class interpreter {
 public:
+	union lua_param {
+		void* ptr;
+		int32 integer;
+	};
 	using coroutine_map = std::unordered_map<int32, lua_State*>;
-	using param_list = std::list<std::pair<void*, uint32>>;
+	using param_list = std::list<std::pair<lua_param, LuaParamType>>;
 	
 	duel* pduel;
 	char msgbuf[64];
@@ -48,8 +63,8 @@ public:
 
 	int32 load_script(const char* script_name);
 	int32 load_card_script(uint32 code);
-	void add_param(void* param, int32 type, bool front = false);
-	void add_param(int32 param, int32 type, bool front = false);
+	void add_param(void* param, LuaParamType type, bool front = false);
+	void add_param(int32 param, LuaParamType type, bool front = false);
 	void push_param(lua_State* L, bool is_coroutine = false);
 	int32 call_function(int32 f, uint32 param_count, int32 ret_count);
 	int32 call_card_function(card* pcard, const char* f, uint32 param_count, int32 ret_count);
@@ -66,7 +81,7 @@ public:
 	static void card2value(lua_State* L, card* pcard);
 	static void group2value(lua_State* L, group* pgroup);
 	static void effect2value(lua_State* L, effect* peffect);
-	static void function2value(lua_State* L, int32 pointer);
+	static void function2value(lua_State* L, int32 func_ref);
 	static int32 get_function_handle(lua_State* L, int32 index);
 	static duel* get_duel_info(lua_State* L);
 
@@ -75,15 +90,6 @@ public:
 		return std::snprintf(buffer, N, format, args...);
 	}
 };
-
-#define	PARAM_TYPE_INT		0x01
-#define	PARAM_TYPE_STRING	0x02
-#define	PARAM_TYPE_CARD		0x04
-#define	PARAM_TYPE_GROUP	0x08
-#define PARAM_TYPE_EFFECT	0x10
-#define	PARAM_TYPE_FUNCTION	0x20
-#define PARAM_TYPE_BOOLEAN	0x40
-#define PARAM_TYPE_INDEX	0x80
 
 #define COROUTINE_FINISH	1
 #define COROUTINE_YIELD		2

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3220,7 +3220,7 @@ int32 scriptlib::duel_select_synchro_material(lua_State *L) {
 	lua_pushvalue(L, 4);
 	lua_pushvalue(L, 2);
 	lua_xmove(L, pduel->lua->lua_state, 3);
-	return lua_yield(L, 3);
+	return lua_yield(L, 0);
 }
 int32 scriptlib::duel_check_synchro_material(lua_State *L) {
 	check_param_count(L, 5);
@@ -3280,7 +3280,7 @@ int32 scriptlib::duel_select_tuner_material(lua_State *L) {
 	lua_pushvalue(L, 5);
 	lua_pushvalue(L, 2);
 	lua_xmove(L, pduel->lua->lua_state, 3);
-	return lua_yield(L, 3);
+	return lua_yield(L, 0);
 }
 int32 scriptlib::duel_check_tuner_material(lua_State *L) {
 	check_param_count(L, 6);

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3219,6 +3219,7 @@ int32 scriptlib::duel_select_synchro_material(lua_State *L) {
 	lua_pushvalue(L, 3);
 	lua_pushvalue(L, 4);
 	lua_pushvalue(L, 2);
+	lua_xmove(L, pduel->lua->lua_state, 3);
 	return lua_yield(L, 3);
 }
 int32 scriptlib::duel_check_synchro_material(lua_State *L) {
@@ -3278,6 +3279,7 @@ int32 scriptlib::duel_select_tuner_material(lua_State *L) {
 	lua_pushvalue(L, 4);
 	lua_pushvalue(L, 5);
 	lua_pushvalue(L, 2);
+	lua_xmove(L, pduel->lua->lua_state, 3);
 	return lua_yield(L, 3);
 }
 int32 scriptlib::duel_check_tuner_material(lua_State *L) {

--- a/operations.cpp
+++ b/operations.cpp
@@ -5316,7 +5316,7 @@ int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, in
 	case 1: {
 		if(returns.ivalue[0] == -1) {
 			lua_pop(pduel->lua->current_state, 3);
-			pduel->lua->add_param((void*)0, PARAM_TYPE_GROUP);
+			pduel->lua->add_param(nullptr, PARAM_TYPE_GROUP);
 			core.limit_tuner = 0;
 			return TRUE;
 		}
@@ -5683,7 +5683,7 @@ int32 field::select_xyz_material(int16 step, uint8 playerid, uint32 lv, card* sc
 	}
 	case 1: {
 		if(returns.ivalue[0] == -1) {
-			pduel->lua->add_param((void*)0, PARAM_TYPE_GROUP);
+			pduel->lua->add_param(nullptr, PARAM_TYPE_GROUP);
 			return TRUE;
 		}
 		int32 pv = 0;
@@ -5850,7 +5850,7 @@ int32 field::select_xyz_material(int16 step, uint8 playerid, uint32 lv, card* sc
 	}
 	case 4: {
 		if(returns.ivalue[0] == -1) {
-			pduel->lua->add_param((void*)0, PARAM_TYPE_GROUP);
+			pduel->lua->add_param(nullptr, PARAM_TYPE_GROUP);
 			return TRUE;
 		}
 		card* pcard = core.select_cards[returns.bvalue[1]];
@@ -5906,7 +5906,7 @@ int32 field::select_xyz_material(int16 step, uint8 playerid, uint32 lv, card* sc
 	}
 	case 6: {
 		if(returns.ivalue[0] == -1) {
-			pduel->lua->add_param((void*)0, PARAM_TYPE_GROUP);
+			pduel->lua->add_param(nullptr, PARAM_TYPE_GROUP);
 			return TRUE;
 		}
 		group* pgroup = pduel->new_group(core.operated_set);
@@ -5930,7 +5930,7 @@ int32 field::select_xyz_material(int16 step, uint8 playerid, uint32 lv, card* sc
 	}
 	case 8: {
 		if(returns.ivalue[0] == -1) {
-			pduel->lua->add_param((void*)0, PARAM_TYPE_GROUP);
+			pduel->lua->add_param(nullptr, PARAM_TYPE_GROUP);
 			return TRUE;
 		}
 		int32 pv = 0;
@@ -6036,7 +6036,7 @@ int32 field::select_xyz_material(int16 step, uint8 playerid, uint32 lv, card* sc
 	}
 	case 22: {
 		if(returns.ivalue[0] == -1) {
-			pduel->lua->add_param((void*)0, PARAM_TYPE_GROUP);
+			pduel->lua->add_param(nullptr, PARAM_TYPE_GROUP);
 			return TRUE;
 		}
 		int32 pv = 0;

--- a/processor.cpp
+++ b/processor.cpp
@@ -758,7 +758,7 @@ int32 field::execute_cost(uint16 step, effect * triggering_effect, uint8 trigger
 	core.reason_effect = triggering_effect;
 	core.reason_player = triggering_player;
 	uint32 count = (uint32)pduel->lua->params.size();
-	uint32 yield_value = 0;
+	int32 yield_value = 0;
 	int32 result = pduel->lua->call_coroutine(triggering_effect->cost, count, &yield_value, step);
 	returns.ivalue[0] = yield_value;
 	if (result == COROUTINE_FINISH || result == COROUTINE_ERROR || result == OPERATION_FAIL) {
@@ -810,7 +810,7 @@ int32 field::execute_operation(uint16 step, effect * triggering_effect, uint8 tr
 	core.reason_effect = triggering_effect;
 	core.reason_player = triggering_player;
 	uint32 count = (uint32)pduel->lua->params.size();
-	uint32 yield_value = 0;
+	int32 yield_value = 0;
 	int32 result = pduel->lua->call_coroutine(triggering_effect->operation, count, &yield_value, step);
 	returns.ivalue[0] = yield_value;
 	if (result == COROUTINE_FINISH || result == COROUTINE_ERROR || result == OPERATION_FAIL) {
@@ -867,7 +867,7 @@ int32 field::execute_target(uint16 step, effect * triggering_effect, uint8 trigg
 	core.reason_effect = triggering_effect;
 	core.reason_player = triggering_player;
 	uint32 count = (uint32)pduel->lua->params.size();
-	uint32 yield_value = 0;
+	int32 yield_value = 0;
 	int32 result = pduel->lua->call_coroutine(triggering_effect->target, count, &yield_value, step);
 	returns.ivalue[0] = yield_value;
 	if (result == COROUTINE_FINISH || result == COROUTINE_ERROR || result == OPERATION_FAIL) {


### PR DESCRIPTION
Fix the following problems of Lua interpreter

## The parameter in `param_list` can be pointer or integer
The parameter should be a union instead of double casting.
Now it is stored in `union lua_param`.

## The Lua thread created by interpreter might be collected by GC
https://www.lua.org/manual/5.4/manual.html#lua_newthread
Threads are subject to garbage collection, like any Lua object. 

https://www.lua.org/manual/5.4/manual.html#2.5
The only guarantees are that Lua will not collect an object that may still be accessed in the normal execution of the program, and it will eventually collect an object that is inaccessible from Lua. (Here, inaccessible from Lua means that neither a variable nor another live object refer to the object.) Because Lua has no knowledge about C code, it never collects objects accessible through the registry (see [§4.3](https://www.lua.org/manual/5.4/manual.html#4.3)), which includes the global environment (see [§2.2](https://www.lua.org/manual/5.4/manual.html#2.2)).

Now the new thread is kept in the registry to avoid GC.

## The yielded state is used again to call another function
https://github.com/ProjectIgnis/EDOPro-Core/commit/7651500e569cddcf6497025f168194d29a7a3ac7

https://www.lua.org/manual/5.4/manual.html#4
As in most C libraries, the Lua API functions do not check their arguments for validity or consistency. However, you can change this behavior by compiling Lua with the macro `LUA_USE_APICHECK` defined. 

If we define the macro `LUA_USE_APICHECK` and build Lua, it will use assertion.

Test:
CL1: Maxx C
CL2: PSY-Framegear Gamma

Resolution:
CL2: PSY-Framegear Gamma
Select a `PSY-Frame Driver`
Try to Special Summon `PSY-Framegear Gamma` 

The process will abort because the thread is not `LUA_OK`.

Lua does not accept using the yielded thread again to call another function.
Therefore, `current_state` should be restored after `lua_resume` returns.

## The parameters pushed by duel_select_synchro_material
duel_select_synchro_material
duel_select_tuner_material
These functions will:
- push the parameters onto the stack of L (`rthread` in interpreter)
- use them in PROCESSOR_SELECT_SYNCHRO / select_synchro_material (step 0 or 1)

Since we have restored the `current_state` after yielding, the parameters should be pushed onto the stack of main thread.
Now they are moved to main thread by lua_xmove.

# Test
This version has been tested by:
- building Lua with macro `LUA_USE_APICHECK`
- dueling with AI Sword Soul, where both players will Synchro Summon repeteadly.

# Reference
https://github.com/ProjectIgnis/EDOPro-Core/blob/master/interpreter.h
https://github.com/ProjectIgnis/EDOPro-Core/blob/master/interpreter.cpp
https://github.com/ProjectIgnis/EDOPro-Core/commit/7651500e569cddcf6497025f168194d29a7a3ac7

# Related issue
https://github.com/Fluorohydride/ygopro-core/pull/417
https://github.com/Fluorohydride/ygopro/issues/2407


@edo9300 
My revision:
https://github.com/ProjectIgnis/EDOPro-Core/blob/bc3e680bb3041e4abda0ef39c3acb9dac64b2757/interpreter.cpp#L523
For basic types and pointers, `std::exchange` might be unnecessary?

@mercury233 
@purerosefallen 
