### PR TITLE
fix deck sequence on swap_deck_and_grave

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -1091,6 +1091,7 @@ void field::swap_deck_and_grave(uint8 playerid) {
 	}
 	player[playerid].list_extra.insert(player[playerid].list_extra.end() - player[playerid].extra_p_count, ex.begin(), ex.end());
 	reset_sequence(playerid, LOCATION_GRAVE);
+	reset_sequence(playerid, LOCATION_DECK);
 	reset_sequence(playerid, LOCATION_EXTRA);
 	pduel->write_buffer8(MSG_SWAP_GRAVE_DECK);
 	pduel->write_buffer8(playerid);


### PR DESCRIPTION
After doing `SwapDeckAndGrave` to the deck, it was relying on `shuffle(playerid, LOCATION_DECK)` to reset the sequence of the cards in deck, but if `DUEL_PSEUDO_SHUFFLE` is set, the reset part will be skipped, and the sequence will be wrong.

replay: [deck sequence2.zip](https://github.com/Fluorohydride/ygopro-core/files/15209436/deck.sequence2.zip)
