### PR TITLE
update chain_operation_sort

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -16,10 +16,15 @@
 int32 field::field_used_count[32] = {0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5};
 
 bool chain::chain_operation_sort(const chain& c1, const chain& c2) {
-	if (c1.triggering_effect && c2.triggering_effect && c1.triggering_effect->id != c2.triggering_effect->id)
-		return c1.triggering_effect->id < c2.triggering_effect->id;
-	else
-		return c1.chain_id < c2.chain_id;
+	auto e1 = c1.triggering_effect;
+	auto e2 = c2.triggering_effect;
+	if (e1 && e2) {
+		if (e1->handler == e2->handler && e1->description != e2->description)
+			return e1->description < e2->description;
+		if (e1->id != e2->id)
+			return e1->id < e2->id;
+	}
+	return c1.chain_id < c2.chain_id;
 }
 void chain::set_triggering_state(card* pcard) {
 	triggering_controler = pcard->current.controler;


### PR DESCRIPTION
![image](https://github.com/Fluorohydride/ygopro-core/assets/13391795/a6e59f82-9f23-494c-88dc-9f2d254f1297)

Ensure that the order of multiple effects of the same card's options remains consistent each time it is activated.