### PR TITLE
fix struct card_sort::operator()

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -23,9 +23,7 @@ const std::unordered_map<uint32, uint32> card::second_code = {
 	{CARD_HERMOS, 10000070u}
 };
 
-bool card_sort::operator()(void* const & p1, void* const & p2) const {
-	card* c1 = (card*)p1;
-	card* c2 = (card*)p2;
+bool card_sort::operator()(card* const& c1, card* const& c2) const {
 	return c1->cardid < c2->cardid;
 }
 bool card_state::is_location(int32 loc) const {

--- a/card.h
+++ b/card.h
@@ -11,6 +11,7 @@
 #include "common.h"
 #include "effectset.h"
 #include "card_data.h"
+#include "sort.h"
 #include <set>
 #include <map>
 #include <unordered_set>

--- a/common.h
+++ b/common.h
@@ -42,9 +42,6 @@ typedef signed char int8;
 #ifndef NULL
 #define NULL 0
 #endif
-struct card_sort {
-	bool operator()(void* const & c1, void* const & c2) const;
-};
 
 #define CURRENT_RULE	5
 

--- a/duel.h
+++ b/duel.h
@@ -9,6 +9,7 @@
 #define DUEL_H_
 
 #include "common.h"
+#include "sort.h"
 #include "mtrandom.h"
 #include <set>
 #include <unordered_set>

--- a/group.h
+++ b/group.h
@@ -9,6 +9,7 @@
 #define GROUP_H_
 
 #include "common.h"
+#include "sort.h"
 #include <set>
 #include <list>
 

--- a/sort.h
+++ b/sort.h
@@ -1,0 +1,10 @@
+#ifndef SORT_H_
+#define SORT_H_
+
+class card;
+
+struct card_sort {
+	bool operator()(card* const& c1, card* const& c2) const;
+};
+
+#endif /* SORT_H_ */


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/container/set
```cpp
template<
    class Key,
    class Compare = std::less<Key>,
    class Allocator = std::allocator<Key>
> class set;
```

https://en.cppreference.com/w/cpp/utility/functional/less
```cpp
constexpr bool operator()( const T& lhs, const T& rhs ) const;
```

# Problem
The signature of `card_sort` should be:
```cpp
bool operator()(card* const& c1, card* const& c2) const;
```

# Solution
It is put in a new file `sort.h`, which contains the declaration of incomplete type `card`.

@mercury233 
@purerosefallen 