### PR TITLE
change counter_map to std::map<uint16, uint16>

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2160,17 +2160,13 @@ void card::reset(uint32 id, uint32 reset_type) {
 					++cmit;
 					continue;
 				}
-				if(cmit->second > 0) {
-					pduel->write_buffer8(MSG_REMOVE_COUNTER);
-					pduel->write_buffer16(cmit->first);
-					pduel->write_buffer8(current.controler);
-					pduel->write_buffer8(current.location);
-					pduel->write_buffer8(current.sequence);
-					pduel->write_buffer16(cmit->second);
-					cmit = counters.erase(cmit);
-				}
-				else
-					++cmit;
+				pduel->write_buffer8(MSG_REMOVE_COUNTER);
+				pduel->write_buffer16(cmit->first);
+				pduel->write_buffer8(current.controler);
+				pduel->write_buffer8(current.location);
+				pduel->write_buffer8(current.sequence);
+				pduel->write_buffer16(cmit->second);
+				cmit = counters.erase(cmit);
 			}
 		}
 		if(id & RESET_TURN_SET) {

--- a/card.cpp
+++ b/card.cpp
@@ -1998,7 +1998,7 @@ void card::remove_effect(effect* peffect, effect_container::iterator it) {
 		pduel->game_field->effects.cheff.erase(peffect);
 	if(peffect->is_flag(EFFECT_FLAG_COUNT_LIMIT))
 		pduel->game_field->effects.rechargeable.erase(peffect);
-	if(((peffect->code & 0xf0000) == EFFECT_COUNTER_PERMIT) && (peffect->type & EFFECT_TYPE_SINGLE)) {
+	if(peffect->get_code_type() == CODE_COUNTER && (peffect->code & 0xf0000) == EFFECT_COUNTER_PERMIT && (peffect->type & EFFECT_TYPE_SINGLE)) {
 		auto cmit = counters.find(peffect->code & 0xffff);
 		if(cmit != counters.end()) {
 			pduel->write_buffer8(MSG_REMOVE_COUNTER);
@@ -2370,7 +2370,9 @@ int32 card::add_counter(uint8 playerid, uint16 countertype, uint16 count, uint8 
 			limit = eset.get_last()->get_value();
 		if(limit) {
 			int32 mcount = limit - get_counter(cttype);
-			if (mcount > 0 && pcount > mcount)
+			if (mcount < 0)
+				mcount = 0;
+			if (pcount > mcount)
 				pcount = mcount;
 		}
 	}

--- a/card.h
+++ b/card.h
@@ -119,7 +119,7 @@ public:
 	using effect_indexer = std::unordered_map<effect*, effect_container::iterator>;
 	using effect_relation = std::unordered_set<std::pair<effect*, uint16>, effect_relation_hash>;
 	using relation_map = std::unordered_map<card*, uint32>;
-	using counter_map = std::map<uint16, std::array<uint16, 2>>;
+	using counter_map = std::map<uint16, uint16>;
 	using effect_count = std::map<uint32, int32>;
 	class attacker_map : public std::unordered_map<uint16, std::pair<card*, uint32>> {
 	public:

--- a/effect.cpp
+++ b/effect.cpp
@@ -847,7 +847,7 @@ uint32 effect::get_active_type() {
 	} else
 		return owner->get_type();
 }
-int32 effect::get_code_type() {
+int32 effect::get_code_type() const {
 	// start from the highest bit
 	if (code & 0xf0000000)
 		return CODE_CUSTOM;

--- a/effect.h
+++ b/effect.h
@@ -110,7 +110,7 @@ public:
 	void set_activate_location();
 	void set_active_type();
 	uint32 get_active_type();
-	int32 get_code_type();
+	int32 get_code_type() const;
 
 	bool is_flag(effect_flag flag) const {
 		return !!(this->flag[0] & flag);

--- a/field.h
+++ b/field.h
@@ -161,7 +161,7 @@ constexpr int SIZE_IVALUE = SIZE_RETURN_VALUE / 4;
 constexpr int SIZE_LVALUE = SIZE_RETURN_VALUE / 8;
 union return_value {
 	int8 bvalue[SIZE_RETURN_VALUE];
-	int16 svalue[SIZE_SVALUE];
+	uint16 svalue[SIZE_SVALUE];
 	int32 ivalue[SIZE_IVALUE];
 	int64 lvalue[SIZE_LVALUE];
 };

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2879,7 +2879,7 @@ int32 scriptlib::card_remove_counter(lua_State *L) {
 			pduel->write_buffer8(pcard->current.controler);
 			pduel->write_buffer8(pcard->current.location);
 			pduel->write_buffer8(pcard->current.sequence);
-			pduel->write_buffer16(cmit.second[0] + cmit.second[1]);
+			pduel->write_buffer16(cmit.second);
 		}
 		pcard->counters.clear();
 		return 0;

--- a/libdebug.cpp
+++ b/libdebug.cpp
@@ -128,16 +128,9 @@ int32 scriptlib::debug_pre_add_counter(lua_State *L) {
 	uint32 countertype = (uint32)lua_tointeger(L, 2);
 	uint32 count = (uint32)lua_tointeger(L, 3);
 	uint16 cttype = countertype;
-	auto pr = pcard->counters.emplace(cttype, card::counter_map::mapped_type());
+	auto pr = pcard->counters.emplace(cttype, 0);
 	auto cmit = pr.first;
-	if(pr.second) {
-		cmit->second[0] = 0;
-		cmit->second[1] = 0;
-	}
-	if(countertype & COUNTER_WITHOUT_PERMIT)
-		cmit->second[0] += count;
-	else
-		cmit->second[1] += count;
+	cmit->second += count;
 	return 0;
 }
 int32 scriptlib::debug_reload_field_begin(lua_State *L) {

--- a/operations.cpp
+++ b/operations.cpp
@@ -710,7 +710,7 @@ int32 field::remove_counter(uint16 step, uint32 reason, card* pcard, uint8 rplay
 		core.select_effects.clear();
 		if((pcard && pcard->get_counter(countertype) >= count) || (!pcard && get_field_counter(rplayer, s, o, countertype))) {
 			core.select_options.push_back(10);
-			core.select_effects.push_back(0);
+			core.select_effects.push_back(nullptr);
 		}
 		auto pr = effects.continuous_effect.equal_range(EFFECT_RCOUNTER_REPLACE + countertype);
 		tevent e;
@@ -733,7 +733,7 @@ int32 field::remove_counter(uint16 step, uint32 reason, card* pcard, uint8 rplay
 			return TRUE;
 		if(core.select_options.size() == 1)
 			returns.ivalue[0] = 0;
-		else if(core.select_effects[0] == 0 && core.select_effects.size() == 2)
+		else if(core.select_effects[0] == nullptr && core.select_effects.size() == 2)
 			add_process(PROCESSOR_SELECT_EFFECTYN, 0, 0, (group*)core.select_effects[1]->handler, rplayer, 220);
 		else
 			add_process(PROCESSOR_SELECT_OPTION, 0, 0, 0, rplayer, 0);

--- a/playerop.cpp
+++ b/playerop.cpp
@@ -606,7 +606,7 @@ int32 field::select_counter(uint16 step, uint8 playerid, uint16 countertype, uin
 		}
 		return FALSE;
 	} else {
-		uint16 ct = 0;
+		int32 ct = 0;
 		for(int32 i = 0; i < (int32)core.select_cards.size(); ++i) {
 			if(core.select_cards[i]->get_counter(countertype) < returns.svalue[i]) {
 				pduel->write_buffer8(MSG_RETRY);


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=23486&keyword=&tag=-1&request_locale=ja

# counter map
counters with `COUNTER_WITHOUT_PERMIT`:
- It can be put on any monster.
- It remains on the card when the card is negated.

ordinary counters:
- It can only be put on the monster with a `EFFECT_COUNTER_PERMIT` effect.
- It is removed when the card is negated.

Now temporary/permanent counter is determined by counter type.
Keeping an array for every counter type is unnecessary.

# change returns.svalue to uint16
The number of counter is `uint16` (0~65535), and `returns.svalue` should be the same.

@mercury233 
@purerosefallen 

