### PR TITLE
fix Duel.GetFieldGroupCount

### DIFF
--- a/common.h
+++ b/common.h
@@ -43,7 +43,7 @@ typedef signed char int8;
 #define NULL 0
 #endif
 
-#define CURRENT_RULE	5
+#define CURRENT_RULE	5	//current rule: 5, Master Rule 2020
 
 //Locations
 #define LOCATION_DECK		0x01		//

--- a/field.cpp
+++ b/field.cpp
@@ -1447,7 +1447,7 @@ void field::filter_player_effect(uint8 playerid, uint32 code, effect_set* eset, 
 int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, uint32 location2, group* pgroup, card* pexception, group* pexgroup, uint32 extraargs, card** pret, int32 fcount, int32 is_target) {
 	if(self != 0 && self != 1)
 		return FALSE;
-	int32 count = 0;
+	card_set result;
 	uint32 location = location1;
 	for(uint32 p = 0; p < 2; ++p) {
 		if(location & LOCATION_MZONE) {
@@ -1460,12 +1460,9 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 						*pret = pcard;
 						return TRUE;
 					}
-					++count;
-					if(fcount && count >= fcount)
+					result.insert(pcard);
+					if(fcount && (int32)result.size() >= fcount)
 						return TRUE;
-					if(pgroup) {
-						pgroup->container.insert(pcard);
-					}
 				}
 			}
 		}
@@ -1479,12 +1476,9 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 						*pret = pcard;
 						return TRUE;
 					}
-					++count;
-					if(fcount && count >= fcount)
+					result.insert(pcard);
+					if(fcount && (int32)result.size() >= fcount)
 						return TRUE;
-					if(pgroup) {
-						pgroup->container.insert(pcard);
-					}
 				}
 			}
 		}
@@ -1498,12 +1492,9 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 					*pret = pcard;
 					return TRUE;
 				}
-				++count;
-				if(fcount && count >= fcount)
+				result.insert(pcard);
+				if (fcount && (int32)result.size() >= fcount)
 					return TRUE;
-				if(pgroup) {
-					pgroup->container.insert(pcard);
-				}
 			}
 		}
 		if(location & LOCATION_PZONE) {
@@ -1517,12 +1508,9 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 						*pret = pcard;
 						return TRUE;
 					}
-					++count;
-					if(fcount && count >= fcount)
+					result.insert(pcard);
+					if(fcount && (int32)result.size() >= fcount)
 						return TRUE;
-					if(pgroup) {
-						pgroup->container.insert(pcard);
-					}
 				}
 			}
 		}
@@ -1535,12 +1523,9 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 						*pret = *cit;
 						return TRUE;
 					}
-					++count;
-					if(fcount && count >= fcount)
+					result.insert(*cit);
+					if(fcount && (int32)result.size() >= fcount)
 						return TRUE;
-					if(pgroup) {
-						pgroup->container.insert(*cit);
-					}
 				}
 			}
 		}
@@ -1553,12 +1538,9 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 						*pret = *cit;
 						return TRUE;
 					}
-					++count;
-					if(fcount && count >= fcount)
+					result.insert(*cit);
+					if(fcount && (int32)result.size() >= fcount)
 						return TRUE;
-					if(pgroup) {
-						pgroup->container.insert(*cit);
-					}
 				}
 			}
 		}
@@ -1571,12 +1553,9 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 						*pret = pcard;
 						return TRUE;
 					}
-					++count;
-					if(fcount && count >= fcount)
+					result.insert(pcard);
+					if(fcount &&  (int32)result.size() >= fcount)
 						return TRUE;
-					if(pgroup) {
-						pgroup->container.insert(pcard);
-					}
 				}
 			}
 		}
@@ -1589,12 +1568,9 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 						*pret = *cit;
 						return TRUE;
 					}
-					++count;
-					if(fcount && count >= fcount)
+					result.insert(*cit);
+					if(fcount && (int32)result.size() >= fcount)
 						return TRUE;
-					if(pgroup) {
-						pgroup->container.insert(*cit);
-					}
 				}
 			}
 		}
@@ -1607,18 +1583,17 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 						*pret = *cit;
 						return TRUE;
 					}
-					++count;
-					if(fcount && count >= fcount)
+					result.insert(*cit);
+					if(fcount && (int32)result.size() >= fcount)
 						return TRUE;
-					if(pgroup) {
-						pgroup->container.insert(*cit);
-					}
 				}
 			}
 		}
 		location = location2;
 		self = 1 - self;
 	}
+	if (pgroup)
+		pgroup->container.insert(result.begin(), result.end());
 	return FALSE;
 }
 // Duel.GetFieldGroup(), Duel.GetFieldGroupCount()
@@ -1626,73 +1601,57 @@ int32 field::filter_field_card(uint8 self, uint32 location1, uint32 location2, g
 	if(self != 0 && self != 1)
 		return 0;
 	uint32 location = location1;
-	uint32 count = 0;
+	card_set result;
 	for(uint32 p = 0; p < 2; ++p) {
 		if(location & LOCATION_MZONE) {
 			for(auto& pcard : player[self].list_mzone) {
 				if(pcard && !pcard->get_status(STATUS_SUMMONING | STATUS_SPSUMMON_STEP)) {
-					if(pgroup)
-						pgroup->container.insert(pcard);
-					++count;
+					result.insert(pcard);
 				}
 			}
 		}
 		if(location & LOCATION_SZONE) {
 			for(auto& pcard : player[self].list_szone) {
 				if(pcard) {
-					if(pgroup)
-						pgroup->container.insert(pcard);
-					++count;
+					result.insert(pcard);
 				}
 			}
 		}
 		if(location & LOCATION_FZONE) {
 			card* pcard = player[self].list_szone[5];
 			if(pcard) {
-				if(pgroup)
-					pgroup->container.insert(pcard);
-				++count;
+				result.insert(pcard);
 			}
 		}
 		if(location & LOCATION_PZONE) {
 			for(int32 i = 0; i < 2; ++i) {
 				card* pcard = player[self].list_szone[core.duel_rule >= 4 ? i * 4 : i + 6];
 				if(pcard && pcard->current.pzone) {
-					if(pgroup)
-						pgroup->container.insert(pcard);
-					++count;
+					result.insert(pcard);
 				}
 			}
 		}
 		if(location & LOCATION_HAND) {
-			if(pgroup)
-				pgroup->container.insert(player[self].list_hand.begin(), player[self].list_hand.end());
-			count += (uint32)player[self].list_hand.size();
+			result.insert(player[self].list_hand.begin(), player[self].list_hand.end());
 		}
 		if(location & LOCATION_DECK) {
-			if(pgroup)
-				pgroup->container.insert(player[self].list_main.rbegin(), player[self].list_main.rend());
-			count += (uint32)player[self].list_main.size();
+			result.insert(player[self].list_main.rbegin(), player[self].list_main.rend());
 		}
 		if(location & LOCATION_EXTRA) {
-			if(pgroup)
-				pgroup->container.insert(player[self].list_extra.rbegin(), player[self].list_extra.rend());
-			count += (uint32)player[self].list_extra.size();
+			result.insert(player[self].list_extra.rbegin(), player[self].list_extra.rend());
 		}
 		if(location & LOCATION_GRAVE) {
-			if(pgroup)
-				pgroup->container.insert(player[self].list_grave.rbegin(), player[self].list_grave.rend());
-			count += (uint32)player[self].list_grave.size();
+			result.insert(player[self].list_grave.rbegin(), player[self].list_grave.rend());
 		}
 		if(location & LOCATION_REMOVED) {
-			if(pgroup)
-				pgroup->container.insert(player[self].list_remove.rbegin(), player[self].list_remove.rend());
-			count += (uint32)player[self].list_remove.size();
+			result.insert(player[self].list_remove.rbegin(), player[self].list_remove.rend());
 		}
 		location = location2;
 		self = 1 - self;
 	}
-	return count;
+	if (pgroup)
+		pgroup->container.insert(result.begin(), result.end());
+	return result.size();
 }
 effect* field::is_player_affected_by_effect(uint8 playerid, uint32 code) {
 	auto rg = effects.aura_effect.equal_range(code);

--- a/field.h
+++ b/field.h
@@ -305,7 +305,7 @@ struct processor {
 	int32 spe_effect[2]{};
 	int32 last_select_hint[2]{ 0 };
 	int32 duel_options{ 0 };
-	int32 duel_rule{ CURRENT_RULE };	//current rule: 5, Master Rule 2020
+	int32 duel_rule{ CURRENT_RULE };
 	uint32 copy_reset{ 0 };
 	uint8 copy_reset_count{ 0 };
 	uint32 last_control_changed_id{ 0 };

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2642,7 +2642,7 @@ int32 scriptlib::duel_is_existing_matching_card(lua_State *L) {
 	uint32 location1 = (uint32)lua_tointeger(L, 3);
 	uint32 location2 = (uint32)lua_tointeger(L, 4);
 	uint32 fcount = (uint32)lua_tointeger(L, 5);
-	lua_pushboolean(L, pduel->game_field->filter_matching_card(1, (uint8)self, location1, location2, 0, pexception, pexgroup, extraargs, 0, fcount));
+	lua_pushboolean(L, pduel->game_field->filter_matching_card(1, (uint8)self, location1, location2, 0, pexception, pexgroup, extraargs, nullptr, fcount));
 	return 1;
 }
 /**
@@ -2990,7 +2990,7 @@ int32 scriptlib::duel_get_target_count(lua_State *L) {
 	uint32 location2 = (uint32)lua_tointeger(L, 4);
 	group* pgroup = pduel->new_group();
 	uint32 count = 0;
-	pduel->game_field->filter_matching_card(1, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs, 0, 0, TRUE);
+	pduel->game_field->filter_matching_card(1, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs, nullptr, 0, TRUE);
 	count = (uint32)pgroup->container.size();
 	lua_pushinteger(L, count);
 	return 1;
@@ -3016,7 +3016,7 @@ int32 scriptlib::duel_is_existing_target(lua_State *L) {
 	uint32 location1 = (uint32)lua_tointeger(L, 3);
 	uint32 location2 = (uint32)lua_tointeger(L, 4);
 	uint32 count = (uint32)lua_tointeger(L, 5);
-	lua_pushboolean(L, pduel->game_field->filter_matching_card(1, (uint8)self, location1, location2, 0, pexception, pexgroup, extraargs, 0, count, TRUE));
+	lua_pushboolean(L, pduel->game_field->filter_matching_card(1, (uint8)self, location1, location2, 0, pexception, pexgroup, extraargs, nullptr, count, TRUE));
 	return 1;
 }
 /**
@@ -3048,7 +3048,7 @@ int32 scriptlib::duel_select_target(lua_State *L) {
 	if(pduel->game_field->core.current_chain.size() == 0)
 		return 0;
 	group* pgroup = pduel->new_group();
-	pduel->game_field->filter_matching_card(2, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs, 0, 0, TRUE);
+	pduel->game_field->filter_matching_card(2, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs, nullptr, 0, TRUE);
 	pduel->game_field->core.select_cards.assign(pgroup->container.begin(), pgroup->container.end());
 	pduel->game_field->add_process(PROCESSOR_SELECT_CARD, 0, 0, 0, playerid, min + (max << 16));
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {


### PR DESCRIPTION
# Problem
Duel.GetFieldGroupCount(tp,LOCATION_SZONE+LOCATION_FZONE,0)
It will count the same card twice.
If A has 1 Field Spell and 1 Continuous Spell:
Correct: 2
Now: 3

# Reason
Duel.GetFieldGroup(tp,LOCATION_SZONE+LOCATION_FZONE,0)
It will put the cards in a set.

Duel.GetFieldGroupCount(tp,LOCATION_SZONE+LOCATION_FZONE,0)
It will not put the cards in a set.

# Solution
use set in filter_matching_card, filter_field_card

# Test
Add the following to the operation function of any Continuous Spell X:
```lua
Debug.Message(Duel.GetFieldGroupCount(tp,LOCATION_SZONE+LOCATION_FZONE,0))
Debug.Message(Duel.IsExistingMatchingCard(nil,tp,LOCATION_SZONE+LOCATION_FZONE,0,3,nil))
```

Activate a Field Spell
Acticate X

The result is 
```
3
true
```
in current version.

@mercury233 
@purerosefallen 


