### PR TITLE
do not load script for normal monsters

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -431,10 +431,7 @@ uint32 card::get_info_location() {
 }
 // get the printed code on card
 uint32 card::get_original_code() const {
-	if (data.is_alternative())
-		return data.alias;
-	else
-		return data.code;
+	return data.get_original_code();
 }
 // get the original code in duel (can be different from printed code)
 std::tuple<uint32, uint32> card::get_original_code_rule() const {

--- a/card.cpp
+++ b/card.cpp
@@ -1979,7 +1979,7 @@ void card::remove_effect(effect* peffect, effect_container::iterator it) {
 	}
 	if (peffect->is_flag(EFFECT_FLAG_INITIAL) && peffect->copy_id && is_status(STATUS_EFFECT_REPLACED)) {
 		set_status(STATUS_EFFECT_REPLACED, FALSE);
-		if (!(data.type & TYPE_NORMAL) || (data.type & TYPE_PENDULUM)) {
+		if (interpreter::is_load_script(data)) {
 			set_status(STATUS_INITIALIZING, TRUE);
 			pduel->lua->add_param(this, PARAM_TYPE_CARD);
 			pduel->lua->call_card_function(this, "initial_effect", 1, 0);

--- a/card_data.h
+++ b/card_data.h
@@ -67,6 +67,10 @@ struct card_data {
 		for (int i = ctr; i < SIZE_SETCODE; ++i)
 			setcode[i] = 0;
 	}
+
+	uint32 get_original_code() const {
+		return is_alternative() ? alias : code;
+	}
 };
 
 #endif /* CARD_DATA_H_ */

--- a/effect.h
+++ b/effect.h
@@ -213,10 +213,10 @@ enum effect_flag2 : uint32 {
 	EFFECT_FLAG2_WICKED					= 0x0004,
 	EFFECT_FLAG2_OPTION					= 0x0008,
 };
-inline effect_flag operator|(effect_flag flag1, effect_flag flag2)
-{
+constexpr effect_flag operator|(effect_flag flag1, effect_flag flag2) {
 	return static_cast<effect_flag>(static_cast<uint32>(flag1) | static_cast<uint32>(flag2));
 }
+constexpr uint32 INTERNAL_FLAGS = EFFECT_FLAG_INITIAL | EFFECT_FLAG_FUNC_VALUE | EFFECT_FLAG_COUNT_LIMIT | EFFECT_FLAG_FIELD_ONLY | EFFECT_FLAG_ABSOLUTE_TARGET;
 //========== Codes ==========
 #define EFFECT_IMMUNE_EFFECT			1	//
 #define EFFECT_DISABLE					2	//

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -55,10 +55,7 @@ int32 interpreter::register_card(card *pcard) {
 	pcard->ref_handle = luaL_ref(lua_state, LUA_REGISTRYINDEX);				//-1
 	//some userdata may be created in script like token so use current_state
 	lua_rawgeti(current_state, LUA_REGISTRYINDEX, pcard->ref_handle);	//+1 userdata
-	if(pcard->data.is_alternative())
-		load_card_script(pcard->data.alias);
-	else
-		load_card_script(pcard->data.code);
+	load_card_script(pcard->data.get_original_code());
 	//stack: table cxxx, userdata
 	//set metatable of pointer to base script
 	lua_setmetatable(current_state, -2);	//-1
@@ -297,7 +294,7 @@ int32 interpreter::call_function(int32 f, uint32 param_count, int32 ret_count) {
 }
 int32 interpreter::call_card_function(card* pcard, const char* f, uint32 param_count, int32 ret_count) {
 	if (param_count != params.size()) {
-		sprintf(pduel->strbuffer, "\"CallCardFunction\"(c%d.%s): incorrect parameter count", pcard->data.code, f);
+		sprintf(pduel->strbuffer, "\"CallCardFunction\"(c%d.%s): incorrect parameter count", pcard->data.get_original_code(), f);
 		handle_message(pduel, 1);
 		params.clear();
 		return OPERATION_FAIL;
@@ -306,7 +303,7 @@ int32 interpreter::call_card_function(card* pcard, const char* f, uint32 param_c
 	luaL_checkstack(current_state, 1, nullptr);
 	lua_getfield(current_state, -1, f);
 	if (!lua_isfunction(current_state, -1)) {
-		sprintf(pduel->strbuffer, "\"CallCardFunction\"(c%d.%s): attempt to call an error function", pcard->data.code, f);
+		sprintf(pduel->strbuffer, "\"CallCardFunction\"(c%d.%s): attempt to call an error function", pcard->data.get_original_code(), f);
 		handle_message(pduel, 1);
 		lua_pop(current_state, 2);
 		params.clear();

--- a/interpreter.h
+++ b/interpreter.h
@@ -23,7 +23,7 @@ class effect;
 class group;
 class duel;
 
-enum LuaParamType {
+enum LuaParamType : int32 {
 	PARAM_TYPE_INT = 0x01,
 	PARAM_TYPE_STRING = 0x02,
 	PARAM_TYPE_CARD = 0x04,

--- a/interpreter.h
+++ b/interpreter.h
@@ -18,6 +18,7 @@
 #include <cstdio>
 
 class card;
+struct card_data;
 class effect;
 class group;
 class duel;
@@ -84,6 +85,7 @@ public:
 	static void function2value(lua_State* L, int32 func_ref);
 	static int32 get_function_handle(lua_State* L, int32 index);
 	static duel* get_duel_info(lua_State* L);
+	static bool is_load_script(card_data data);
 
 	template <size_t N, typename... TR>
 	static int sprintf(char (&buffer)[N], const char* format, TR... args) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -4248,8 +4248,7 @@ int32 scriptlib::duel_is_player_can_draw(lua_State * L) {
 	if(count == 0)
 		lua_pushboolean(L, pduel->game_field->is_player_can_draw(playerid));
 	else
-		lua_pushboolean(L, pduel->game_field->is_player_can_draw(playerid)
-		                && (pduel->game_field->player[playerid].list_main.size() >= count));
+		lua_pushboolean(L, (int)(pduel->game_field->is_player_can_draw(playerid) && (pduel->game_field->player[playerid].list_main.size() >= count)));
 	return 1;
 }
 int32 scriptlib::duel_is_player_can_discard_deck(lua_State * L) {

--- a/libeffect.cpp
+++ b/libeffect.cpp
@@ -169,7 +169,7 @@ int32 scriptlib::effect_set_property(lua_State *L) {
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
 	uint32 v1 = (uint32)lua_tointeger(L, 2);
 	uint32 v2 = (uint32)lua_tointeger(L, 3);
-	peffect->flag[0] = (peffect->flag[0] & 0x4f) | (v1 & ~0x4f);
+	peffect->flag[0] = (peffect->flag[0] & INTERNAL_FLAGS) | (v1 & ~INTERNAL_FLAGS);
 	peffect->flag[1] = v2;
 	return 0;
 }

--- a/scriptlib.cpp
+++ b/scriptlib.cpp
@@ -8,6 +8,7 @@
 #include "duel.h"
 
 static int32 check_data_type(lua_State* L, int32 index, const char* tname) {
+	luaL_checkstack(L, 2, nullptr);
 	int32 result = FALSE;
 	if(lua_getmetatable(L, index)) {
 		lua_getglobal(L, tname);
@@ -20,6 +21,7 @@ static int32 check_data_type(lua_State* L, int32 index, const char* tname) {
 int32 scriptlib::check_param(lua_State* L, int32 param_type, int32 index, int32 retfalse) {
 	switch (param_type) {
 	case PARAM_TYPE_CARD: {
+		luaL_checkstack(L, 1, nullptr);
 		int32 result = FALSE;
 		if(lua_isuserdata(L, index) && lua_getmetatable(L, index)) {
 			result = check_data_type(L, -1, "Card");


### PR DESCRIPTION
# current_state 
revert to normal assign
std::exchange() will make Read/Write in finding all references unclear, and it might be unnecessary for pointer type.

# scope operator
Add scope operator to ocgapi function call to avoid any potential conflict.

# normal monsters
スケープ・ゴート
Scapegoat
73915051

73915052
Sheep Token

Before:
It will try to load script file `c73915052.lua`.
It will run the script and load into c73915052 table if it finds one.
But it will not run `c73915052.initial_effect`.

`utility.lua` and other scripts use some function names as an interface.
Therefore, loading unnecessary functions might cause some problems.

Now:
For `TYPE_NORMAL AND NOT TYPE_PENDULUM` cards, ygopro will not load the script file.

Test:
Add c73915052.lua
```lua
local s,id,o=GetID()
function s.zw_equip_monster(c,tp,tc)
end
Debug.Message(c73915052.zw_equip_monster)
```
Activating Scapegoat

The debug message shows that a function is added to c73915052 table.

@mercury233 
@purerosefallen 
