### PR TITLE
use ref in PROCESSOR_SELECT_SYNCHRO

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1584,7 +1584,7 @@ void card::xyz_overlay(card_set* materials) {
 	if(materials->size() == 0)
 		return;
 	card_set des, leave_grave, leave_deck;
-	field::card_vector cv;
+	card_vector cv;
 	for(auto& pcard : *materials)
 		cv.push_back(pcard);
 	std::sort(cv.begin(), cv.end(), card::card_operation_sort);

--- a/card.h
+++ b/card.h
@@ -25,6 +25,7 @@ class group;
 struct chain;
 
 using card_set = std::set<card*, card_sort>;
+using card_vector = std::vector<card*>;
 
 struct card_state {
 	uint32 code{ 0 };
@@ -115,7 +116,6 @@ public:
 			return std::hash<uint16>()(v.second);
 		}
 	};
-	using card_vector = std::vector<card*>;
 	using effect_container = std::multimap<uint32, effect*>;
 	using effect_indexer = std::unordered_map<effect*, effect_container::iterator>;
 	using effect_relation = std::unordered_set<std::pair<effect*, uint16>, effect_relation_hash>;

--- a/card.h
+++ b/card.h
@@ -24,6 +24,8 @@ class effect;
 class group;
 struct chain;
 
+using card_set = std::set<card*, card_sort>;
+
 struct card_state {
 	uint32 code{ 0 };
 	uint32 code2{ 0 };
@@ -115,7 +117,6 @@ public:
 	};
 	using card_vector = std::vector<card*>;
 	using effect_container = std::multimap<uint32, effect*>;
-	using card_set = std::set<card*, card_sort>;
 	using effect_indexer = std::unordered_map<effect*, effect_container::iterator>;
 	using effect_relation = std::unordered_set<std::pair<effect*, uint16>, effect_relation_hash>;
 	using relation_map = std::unordered_map<card*, uint32>;

--- a/duel.h
+++ b/duel.h
@@ -20,9 +20,10 @@ class effect;
 class field;
 class interpreter;
 
+using card_set = std::set<card*, card_sort>;
+
 class duel {
 public:
-	using card_set = std::set<card*, card_sort>;
 	char strbuffer[256];
 	std::vector<byte> message_buffer;
 	interpreter* lua;

--- a/effect.cpp
+++ b/effect.cpp
@@ -738,6 +738,9 @@ void effect::get_value(effect* peffect, uint32 extraargs, std::vector<int32>* re
 		result->push_back((int32)value);
 	}
 }
+int32 effect::get_integer_value() {
+	return is_flag(EFFECT_FLAG_FUNC_VALUE) ? 0 : value;
+}
 int32 effect::check_value_condition(uint32 extraargs) {
 	if(is_flag(EFFECT_FLAG_FUNC_VALUE)) {
 		pduel->lua->add_param(this, PARAM_TYPE_EFFECT, TRUE);

--- a/effect.h
+++ b/effect.h
@@ -97,6 +97,7 @@ public:
 	void get_value(uint32 extraargs, std::vector<int32>* result);
 	void get_value(card* pcard, uint32 extraargs, std::vector<int32>* result);
 	void get_value(effect* peffect, uint32 extraargs, std::vector<int32>* result);
+	int32 get_integer_value();
 	int32 check_value_condition(uint32 extraargs = 0);
 	void* get_label_object();
 	int32 get_speed();

--- a/field.cpp
+++ b/field.cpp
@@ -2528,14 +2528,14 @@ void field::get_synchro_material(uint8 playerid, card_set* material, effect* tun
 int32 field::check_synchro_material(lua_State* L, card* pcard, int32 findex1, int32 findex2, int32 min, int32 max, card* smat, group* mg) {
 	if(mg) {
 		for(auto& tuner : mg->container) {
-			if(check_tuner_material(L, pcard, tuner, findex1, findex2, min, max, smat, mg))
+			if(check_tuner_material(L, pcard, tuner, findex1, findex2, min, max, nullptr, mg))
 				return TRUE;
 		}
 	} else {
 		card_set material;
 		get_synchro_material(pcard->current.controler, &material);
 		for(auto& tuner : material) {
-			if(check_tuner_material(L, pcard, tuner, findex1, findex2, min, max, smat, mg))
+			if(check_tuner_material(L, pcard, tuner, findex1, findex2, min, max, smat, nullptr))
 				return TRUE;
 		}
 	}

--- a/field.cpp
+++ b/field.cpp
@@ -1444,7 +1444,7 @@ void field::filter_player_effect(uint8 playerid, uint32 code, effect_set* eset, 
 	if(sort)
 		eset->sort();
 }
-int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, uint32 location2, group* pgroup, card* pexception, group* pexgroup, uint32 extraargs, card** pret, int32 fcount, int32 is_target) {
+int32 field::filter_matching_card(lua_State* L, int32 findex, uint8 self, uint32 location1, uint32 location2, group* pgroup, card* pexception, group* pexgroup, uint32 extraargs, card** pret, int32 fcount, int32 is_target) {
 	if(self != 0 && self != 1)
 		return FALSE;
 	card_set result;
@@ -1454,7 +1454,7 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 			for(auto& pcard : player[self].list_mzone) {
 				if(pcard && !pcard->is_treated_as_not_on_field()
 						&& pcard != pexception && !(pexgroup && pexgroup->has_card(pcard))
-						&& pduel->lua->check_matching(pcard, findex, extraargs)
+						&& pduel->lua->check_filter(L, pcard, findex, extraargs)
 						&& (!is_target || pcard->is_capable_be_effect_target(core.reason_effect, core.reason_player))) {
 					if(pret) {
 						*pret = pcard;
@@ -1470,7 +1470,7 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 			for(auto& pcard : player[self].list_szone) {
 				if(pcard && !pcard->is_treated_as_not_on_field()
 				        && pcard != pexception && !(pexgroup && pexgroup->has_card(pcard))
-				        && pduel->lua->check_matching(pcard, findex, extraargs)
+				        && pduel->lua->check_filter(L, pcard, findex, extraargs)
 				        && (!is_target || pcard->is_capable_be_effect_target(core.reason_effect, core.reason_player))) {
 					if(pret) {
 						*pret = pcard;
@@ -1486,7 +1486,7 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 			card* pcard = player[self].list_szone[5];
 			if(pcard && !pcard->is_treated_as_not_on_field()
 			        && pcard != pexception && !(pexgroup && pexgroup->has_card(pcard))
-			        && pduel->lua->check_matching(pcard, findex, extraargs)
+			        && pduel->lua->check_filter(L, pcard, findex, extraargs)
 			        && (!is_target || pcard->is_capable_be_effect_target(core.reason_effect, core.reason_player))) {
 				if(pret) {
 					*pret = pcard;
@@ -1502,7 +1502,7 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 				card* pcard = player[self].list_szone[core.duel_rule >= 4 ? i * 4 : i + 6];
 				if(pcard && pcard->current.pzone && !pcard->is_treated_as_not_on_field()
 				        && pcard != pexception && !(pexgroup && pexgroup->has_card(pcard))
-				        && pduel->lua->check_matching(pcard, findex, extraargs)
+				        && pduel->lua->check_filter(L, pcard, findex, extraargs)
 				        && (!is_target || pcard->is_capable_be_effect_target(core.reason_effect, core.reason_player))) {
 					if(pret) {
 						*pret = pcard;
@@ -1517,7 +1517,7 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 		if(location & LOCATION_DECK) {
 			for(auto cit = player[self].list_main.rbegin(); cit != player[self].list_main.rend(); ++cit) {
 				if(*cit != pexception && !(pexgroup && pexgroup->has_card(*cit))
-				        && pduel->lua->check_matching(*cit, findex, extraargs)
+				        && pduel->lua->check_filter(L, *cit, findex, extraargs)
 				        && (!is_target || (*cit)->is_capable_be_effect_target(core.reason_effect, core.reason_player))) {
 					if(pret) {
 						*pret = *cit;
@@ -1532,7 +1532,7 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 		if(location & LOCATION_EXTRA) {
 			for(auto cit = player[self].list_extra.rbegin(); cit != player[self].list_extra.rend(); ++cit) {
 				if(*cit != pexception && !(pexgroup && pexgroup->has_card(*cit))
-				        && pduel->lua->check_matching(*cit, findex, extraargs)
+				        && pduel->lua->check_filter(L, *cit, findex, extraargs)
 				        && (!is_target || (*cit)->is_capable_be_effect_target(core.reason_effect, core.reason_player))) {
 					if(pret) {
 						*pret = *cit;
@@ -1547,7 +1547,7 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 		if(location & LOCATION_HAND) {
 			for(auto& pcard : player[self].list_hand) {
 				if(pcard != pexception && !(pexgroup && pexgroup->has_card(pcard))
-				        && pduel->lua->check_matching(pcard, findex, extraargs)
+				        && pduel->lua->check_filter(L, pcard, findex, extraargs)
 				        && (!is_target || pcard->is_capable_be_effect_target(core.reason_effect, core.reason_player))) {
 					if(pret) {
 						*pret = pcard;
@@ -1562,7 +1562,7 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 		if(location & LOCATION_GRAVE) {
 			for(auto cit = player[self].list_grave.rbegin(); cit != player[self].list_grave.rend(); ++cit) {
 				if(*cit != pexception && !(pexgroup && pexgroup->has_card(*cit))
-				        && pduel->lua->check_matching(*cit, findex, extraargs)
+				        && pduel->lua->check_filter(L, *cit, findex, extraargs)
 				        && (!is_target || (*cit)->is_capable_be_effect_target(core.reason_effect, core.reason_player))) {
 					if(pret) {
 						*pret = *cit;
@@ -1577,7 +1577,7 @@ int32 field::filter_matching_card(int32 findex, uint8 self, uint32 location1, ui
 		if(location & LOCATION_REMOVED) {
 			for(auto cit = player[self].list_remove.rbegin(); cit != player[self].list_remove.rend(); ++cit) {
 				if(*cit != pexception && !(pexgroup && pexgroup->has_card(*cit))
-				        && pduel->lua->check_matching(*cit, findex, extraargs)
+				        && pduel->lua->check_filter(L, *cit, findex, extraargs)
 				        && (!is_target || (*cit)->is_capable_be_effect_target(core.reason_effect, core.reason_player))) {
 					if(pret) {
 						*pret = *cit;

--- a/field.cpp
+++ b/field.cpp
@@ -1932,13 +1932,13 @@ void field::ritual_release(card_set* material) {
 	release(&rel, core.reason_effect, REASON_RITUAL + REASON_EFFECT + REASON_MATERIAL, core.reason_player);
 	send_to(&rem, core.reason_effect, REASON_RITUAL + REASON_EFFECT + REASON_MATERIAL, core.reason_player, PLAYER_NONE, LOCATION_REMOVED, 0, POS_FACEUP);
 }
-void field::get_xyz_material(card* scard, int32 findex, uint32 lv, int32 maxc, group* mg) {
+void field::get_xyz_material(lua_State* L, card* scard, int32 findex, uint32 lv, int32 maxc, group* mg) {
 	core.xmaterial_lst.clear();
 	uint32 xyz_level;
 	if(mg) {
 		for (auto& pcard : mg->container) {
 			if(pcard->is_can_be_xyz_material(scard) && (xyz_level = pcard->check_xyz_level(scard, lv))
-					&& (findex == 0 || pduel->lua->check_matching(pcard, findex, 0)))
+					&& (findex == 0 || pduel->lua->check_filter(L, pcard, findex, 0)))
 				core.xmaterial_lst.emplace((xyz_level >> 12) & 0xf, pcard);
 		}
 	} else {
@@ -1946,13 +1946,13 @@ void field::get_xyz_material(card* scard, int32 findex, uint32 lv, int32 maxc, g
 		for(auto& pcard : player[playerid].list_mzone) {
 			if(pcard && pcard->is_position(POS_FACEUP) && !pcard->is_treated_as_not_on_field()
 					&& pcard->is_can_be_xyz_material(scard) && (xyz_level = pcard->check_xyz_level(scard, lv))
-					&& (findex == 0 || pduel->lua->check_matching(pcard, findex, 0)))
+					&& (findex == 0 || pduel->lua->check_filter(L, pcard, findex, 0)))
 				core.xmaterial_lst.emplace((xyz_level >> 12) & 0xf, pcard);
 		}
 		for(auto& pcard : player[1 - playerid].list_mzone) {
 			if(pcard && pcard->is_position(POS_FACEUP) && !pcard->is_treated_as_not_on_field()
 					&& pcard->is_can_be_xyz_material(scard) && (xyz_level = pcard->check_xyz_level(scard, lv))
-			        && pcard->is_affected_by_effect(EFFECT_XYZ_MATERIAL) && (findex == 0 || pduel->lua->check_matching(pcard, findex, 0)))
+			        && pcard->is_affected_by_effect(EFFECT_XYZ_MATERIAL) && (findex == 0 || pduel->lua->check_filter(L, pcard, findex, 0)))
 				core.xmaterial_lst.emplace((xyz_level >> 12) & 0xf, pcard);
 		}
 	}
@@ -2916,8 +2916,8 @@ int32 field::check_with_sum_greater_limit_m(const card_vector& mats, int32 acc, 
 		return TRUE;
 	return FALSE;
 }
-int32 field::check_xyz_material(card* scard, int32 findex, int32 lv, int32 min, int32 max, group* mg) {
-	get_xyz_material(scard, findex, lv, max, mg);
+int32 field::check_xyz_material(lua_State* L, card* scard, int32 findex, int32 lv, int32 min, int32 max, group* mg) {
+	get_xyz_material(L, scard, findex, lv, max, mg);
 	int32 playerid = scard->current.controler;
 	int32 ct = get_spsummonable_count(scard, playerid);
 	card_set handover_zone_cards;

--- a/field.cpp
+++ b/field.cpp
@@ -2625,9 +2625,14 @@ int32 field::check_tuner_material(lua_State* L, card* pcard, card* tuner, int32 
 	if(smat) {
 		if(pcheck)
 			pcheck->get_value(smat);
-		if((smat->current.location == LOCATION_MZONE && !smat->is_position(POS_FACEUP)) 
-			|| !smat->is_can_be_synchro_material(pcard, tuner) 
-			|| !pduel->lua->check_filter(L, smat, findex2, 1)) {
+		if((smat->current.location == LOCATION_MZONE && !smat->is_position(POS_FACEUP)) || !smat->is_can_be_synchro_material(pcard, tuner)) {
+			pduel->restore_assumes();
+			return FALSE;
+		}
+		interpreter::card2value(L, pcard);
+		auto res = pduel->lua->check_filter(L, smat, findex2, 1);
+		lua_pop(L, 1);
+		if (!res) {
 			pduel->restore_assumes();
 			return FALSE;
 		}
@@ -2678,9 +2683,14 @@ int32 field::check_tuner_material(lua_State* L, card* pcard, card* tuner, int32 
 				continue;
 			if(pcheck)
 				pcheck->get_value(mcard);
-			if((mcard->current.location == LOCATION_MZONE && !mcard->is_position(POS_FACEUP)) 
-				|| !mcard->is_can_be_synchro_material(pcard, tuner) 
-				|| !pduel->lua->check_filter(L, mcard, findex2, 1)) {
+			if((mcard->current.location == LOCATION_MZONE && !mcard->is_position(POS_FACEUP)) || !mcard->is_can_be_synchro_material(pcard, tuner)) {
+				pduel->restore_assumes();
+				return FALSE;
+			}
+			interpreter::card2value(L, pcard);
+			auto res = pduel->lua->check_filter(L, mcard, findex2, 1);
+			lua_pop(L, 1);
+			if (!res) {
 				pduel->restore_assumes();
 				return FALSE;
 			}
@@ -2723,7 +2733,10 @@ int32 field::check_tuner_material(lua_State* L, card* pcard, card* tuner, int32 
 				pcheck->get_value(pm);
 			if(pm->current.location == LOCATION_MZONE && !pm->is_position(POS_FACEUP))
 				continue;
-			if(!pduel->lua->check_filter(L, pm, findex2, 1))
+			interpreter::card2value(L, pcard);
+			auto res = pduel->lua->check_filter(L, pm, findex2, 1);
+			lua_pop(L, 1);
+			if (!res)
 				continue;
 			nsyn.push_back(pm);
 			pm->sum_param = pm->get_synchro_level(pcard);
@@ -2744,7 +2757,10 @@ int32 field::check_tuner_material(lua_State* L, card* pcard, card* tuner, int32 
 				pcheck->get_value(pm);
 			if(pm->current.location == LOCATION_MZONE && !pm->is_position(POS_FACEUP))
 				continue;
-			if(!pduel->lua->check_filter(L, pm, findex2, 1))
+			interpreter::card2value(L, pcard);
+			auto res = pduel->lua->check_filter(L, pm, findex2, 1);
+			lua_pop(L, 1);
+			if (!res)
 				continue;
 			nsyn.push_back(pm);
 			pm->sum_param = pm->get_synchro_level(pcard);

--- a/field.cpp
+++ b/field.cpp
@@ -1662,13 +1662,13 @@ effect* field::is_player_affected_by_effect(uint8 playerid, uint32 code) {
 	}
 	return nullptr;
 }
-int32 field::get_release_list(uint8 playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason) {
+int32 field::get_release_list(lua_State* L, uint8 playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason) {
 	uint32 rcount = 0;
 	effect* re = core.reason_effect;
 	for(auto& pcard : player[playerid].list_mzone) {
 		if(pcard && pcard != exc && !(exg && exg->has_card(pcard)) && pcard->is_releasable_by_nonsummon(playerid, reason)
 		        && (reason != REASON_EFFECT || pcard->is_releasable_by_effect(playerid, re))
-		        && (!use_con || pduel->lua->check_matching(pcard, fun, exarg))) {
+		        && (!use_con || pduel->lua->check_filter(L, pcard, fun, exarg))) {
 			if(release_list)
 				release_list->insert(pcard);
 			pcard->release_param = 1;
@@ -1679,7 +1679,7 @@ int32 field::get_release_list(uint8 playerid, card_set* release_list, card_set* 
 		for(auto& pcard : player[playerid].list_hand) {
 			if(pcard && pcard != exc && !(exg && exg->has_card(pcard)) && pcard->is_releasable_by_nonsummon(playerid, reason)
 				    && (reason != REASON_EFFECT || pcard->is_releasable_by_effect(playerid, re))
-			        && (!use_con || pduel->lua->check_matching(pcard, fun, exarg))) {
+			        && (!use_con || pduel->lua->check_filter(L, pcard, fun, exarg))) {
 				if(release_list)
 					release_list->insert(pcard);
 				pcard->release_param = 1;
@@ -1692,7 +1692,7 @@ int32 field::get_release_list(uint8 playerid, card_set* release_list, card_set* 
 		if(pcard && pcard != exc && !(exg && exg->has_card(pcard)) && (pcard->is_position(POS_FACEUP) || !use_con)
 		        && pcard->is_releasable_by_nonsummon(playerid, reason)
 			    && (reason != REASON_EFFECT || pcard->is_releasable_by_effect(playerid, re))
-			    && (!use_con || pduel->lua->check_matching(pcard, fun, exarg))) {
+			    && (!use_con || pduel->lua->check_filter(L, pcard, fun, exarg))) {
 			pcard->release_param = 1;
 			if(pcard->is_affected_by_effect(EFFECT_EXTRA_RELEASE)) {
 				if(ex_list)
@@ -1715,10 +1715,10 @@ int32 field::get_release_list(uint8 playerid, card_set* release_list, card_set* 
 	}
 	return rcount + ex_oneof_max;
 }
-int32 field::check_release_list(uint8 playerid, int32 count, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason) {
+int32 field::check_release_list(lua_State* L, uint8 playerid, int32 count, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason) {
 	card_set relcard;
 	card_set relcard_oneof;
-	get_release_list(playerid, &relcard, &relcard, &relcard_oneof, use_con, use_hand, fun, exarg, exc, exg, reason);
+	get_release_list(L, playerid, &relcard, &relcard, &relcard_oneof, use_con, use_hand, fun, exarg, exc, exg, reason);
 	bool has_oneof = false;
 	for(auto& pcard : core.must_select_cards) {
 		auto it = relcard.find(pcard);

--- a/field.h
+++ b/field.h
@@ -445,7 +445,7 @@ public:
 	void get_ritual_material(uint8 playerid, effect* peffect, card_set* material, uint8 no_level = FALSE);
 	void get_fusion_material(uint8 playerid, card_set* material_all, card_set* material_base, uint32 location);
 	void ritual_release(card_set* material);
-	void get_xyz_material(card* scard, int32 findex, uint32 lv, int32 maxc, group* mg);
+	void get_xyz_material(lua_State* L, card* scard, int32 findex, uint32 lv, int32 maxc, group* mg);
 	void get_overlay_group(uint8 self, uint8 s, uint8 o, card_set* pset);
 	int32 get_overlay_count(uint8 self, uint8 s, uint8 o);
 	void update_disable_check_list(effect* peffect);
@@ -485,7 +485,7 @@ public:
 	static int32 check_with_sum_limit_m(const card_vector& mats, int32 acc, int32 index, int32 min, int32 max, int32 opmin, int32 must_count);
 	static int32 check_with_sum_greater_limit(const card_vector& mats, int32 acc, int32 index, int32 opmin);
 	static int32 check_with_sum_greater_limit_m(const card_vector& mats, int32 acc, int32 index, int32 opmin, int32 must_count);
-	int32 check_xyz_material(card* pcard, int32 findex, int32 lv, int32 min, int32 max, group* mg);
+	int32 check_xyz_material(lua_State* L, card* pcard, int32 findex, int32 lv, int32 min, int32 max, group* mg);
 
 	int32 is_player_can_draw(uint8 playerid);
 	int32 is_player_can_discard_deck(uint8 playerid, int32 count);

--- a/field.h
+++ b/field.h
@@ -78,7 +78,6 @@ struct chain {
 };
 
 struct player_info {
-	using card_vector = std::vector<card*>;
 	int32 lp{ 0 };
 	int32 start_count{ 0 };
 	int32 draw_count{ 0 };
@@ -170,7 +169,6 @@ union return_value {
 };
 struct processor {
 	using effect_vector = std::vector<effect*>;
-	using card_vector = std::vector<card*>;
 	using option_vector = std::vector<uint32>;
 	using card_list = std::list<card*>;
 	using event_list = std::list<tevent>;
@@ -365,7 +363,6 @@ class field {
 public:
 	using effect_container = std::multimap<uint32, effect*>;
 	using effect_vector = std::vector<effect*>;
-	using card_vector = std::vector<card*>;
 	using card_list = std::list<card*>;
 	using event_list = std::list<tevent>;
 	using chain_list = std::list<chain>;

--- a/field.h
+++ b/field.h
@@ -178,7 +178,6 @@ struct processor {
 	using instant_f_list = std::map<effect*, chain>;
 	using chain_array = std::vector<chain>;
 	using processor_list = std::list<processor_unit>;
-	using card_set = std::set<card*, card_sort>;
 	using delayed_effect_collection = std::set<std::pair<effect*, tevent>>;
 	struct chain_limit_t {
 		chain_limit_t(int32 f, int32 p): function(f), player(p) {}
@@ -365,7 +364,6 @@ struct processor {
 class field {
 public:
 	using effect_container = std::multimap<uint32, effect*>;
-	using card_set = std::set<card*, card_sort>;
 	using effect_vector = std::vector<effect*>;
 	using card_vector = std::vector<card*>;
 	using card_list = std::list<card*>;

--- a/field.h
+++ b/field.h
@@ -11,6 +11,7 @@
 #include "common.h"
 #include "card.h"
 #include "effectset.h"
+#include "interpreter.h"
 #include <vector>
 #include <set>
 #include <map>
@@ -432,7 +433,7 @@ public:
 	void filter_affected_cards(effect* peffect, card_set* cset);
 	void filter_inrange_cards(effect* peffect, card_set* cset);
 	void filter_player_effect(uint8 playerid, uint32 code, effect_set* eset, uint8 sort = TRUE);
-	int32 filter_matching_card(int32 findex, uint8 self, uint32 location1, uint32 location2, group* pgroup, card* pexception, group* pexgroup, uint32 extraargs, card** pret = nullptr, int32 fcount = 0, int32 is_target = FALSE);
+	int32 filter_matching_card(lua_State* L, int32 findex, uint8 self, uint32 location1, uint32 location2, group* pgroup, card* pexception, group* pexgroup, uint32 extraargs, card** pret = nullptr, int32 fcount = 0, int32 is_target = FALSE);
 	int32 filter_field_card(uint8 self, uint32 location, uint32 location2, group* pgroup);
 	effect* is_player_affected_by_effect(uint8 playerid, uint32 code);
 

--- a/field.h
+++ b/field.h
@@ -437,8 +437,8 @@ public:
 	int32 filter_field_card(uint8 self, uint32 location, uint32 location2, group* pgroup);
 	effect* is_player_affected_by_effect(uint8 playerid, uint32 code);
 
-	int32 get_release_list(uint8 playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason);
-	int32 check_release_list(uint8 playerid, int32 count, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason);
+	int32 get_release_list(lua_State* L, uint8 playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason);
+	int32 check_release_list(lua_State* L, uint8 playerid, int32 count, int32 use_con, int32 use_hand, int32 fun, int32 exarg, card* exc, group* exg, uint32 reason);
 	int32 get_summon_release_list(card* target, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, group* mg = nullptr, uint32 ex = 0, uint32 releasable = 0xff00ff, uint32 pos = 0x1);
 	int32 get_summon_count_limit(uint8 playerid);
 	int32 get_draw_count(uint8 playerid);

--- a/field.h
+++ b/field.h
@@ -150,12 +150,14 @@ struct processor_unit {
 	uint32 arg2{ 0 };
 	uint32 arg3{ 0 };
 	uint32 arg4{ 0 };
-	void* ptr1{ nullptr };
-	void* ptr2{ nullptr };
 	int32 value1{ 0 };
 	int32 value2{ 0 };
 	int32 value3{ 0 };
 	int32 value4{ 0 };
+	void* ptr1{ nullptr };
+	void* ptr2{ nullptr };
+	void* ptr3{ nullptr };
+	void* ptr4{ nullptr };
 };
 constexpr int SIZE_SVALUE = SIZE_RETURN_VALUE / 2;
 constexpr int SIZE_IVALUE = SIZE_RETURN_VALUE / 4;

--- a/field.h
+++ b/field.h
@@ -477,8 +477,10 @@ public:
 	int32 get_must_material_list(uint8 playerid, uint32 limit, card_set* must_list);
 	int32 check_must_material(group* mg, uint8 playerid, uint32 limit);
 	void get_synchro_material(uint8 playerid, card_set* material, effect* tuner_limit = nullptr);
-	int32 check_synchro_material(card* pcard, int32 findex1, int32 findex2, int32 min, int32 max, card* smat, group* mg);
-	int32 check_tuner_material(card* pcard, card* tuner, int32 findex1, int32 findex2, int32 min, int32 max, card* smat, group* mg);
+	
+	//check material
+	int32 check_synchro_material(lua_State* L, card* pcard, int32 findex1, int32 findex2, int32 min, int32 max, card* smat, group* mg);
+	int32 check_tuner_material(lua_State* L, card* pcard, card* tuner, int32 findex1, int32 findex2, int32 min, int32 max, card* smat, group* mg);
 	int32 check_other_synchro_material(const card_vector& nsyn, int32 lv, int32 min, int32 max, int32 mcount);
 	int32 check_tribute(card* pcard, int32 min, int32 max, group* mg, uint8 toplayer, uint32 zone = 0x1f, uint32 releasable = 0xff00ff, uint32 pos = 0x1);
 	static int32 check_with_sum_limit(const card_vector& mats, int32 acc, int32 index, int32 count, int32 min, int32 max, int32 opmin);

--- a/field.h
+++ b/field.h
@@ -625,7 +625,7 @@ public:
 	int32 change_position(uint16 step, group* targets, effect* reason_effect, uint8 reason_player, uint32 enable);
 	int32 operation_replace(uint16 step, effect* replace_effect, group* targets, card* target, int32 is_destroy);
 	int32 activate_effect(uint16 step, effect* peffect);
-	int32 select_synchro_material(int16 step, uint8 playerid, card* pcard, int32 min, int32 max, card* smat, group* mg);
+	int32 select_synchro_material(int16 step, uint8 playerid, card* pcard, int32 min, int32 max, card* smat, group* mg, int32 filter1, int32 filter2);
 	int32 select_xyz_material(int16 step, uint8 playerid, uint32 lv, card* pcard, int32 min, int32 max);
 	int32 select_release_cards(int16 step, uint8 playerid, uint8 cancelable, int32 min, int32 max);
 	int32 select_tribute_cards(int16 step, card* target, uint8 playerid, uint8 cancelable, int32 min, int32 max, uint8 toplayer, uint32 zone);

--- a/group.h
+++ b/group.h
@@ -16,9 +16,10 @@
 class card;
 class duel;
 
+using card_set = std::set<card*, card_sort>;
+
 class group {
 public:
-	using card_set = std::set<card*, card_sort>;
 	duel* pduel;
 	card_set container;
 	card_set::iterator it;

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -436,9 +436,6 @@ int32 interpreter::check_filter(lua_State* L, card* pcard, int32 findex, int32 e
 	}
 	return result;
 }
-int32 interpreter::check_matching(card* pcard, int32 findex, int32 extraargs) {
-	return check_filter(current_state, pcard, findex, extraargs);
-}
 int32 interpreter::get_operation_value(card* pcard, int32 findex, int32 extraargs) {
 	if(!findex || lua_isnil(current_state, findex))
 		return 0;

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -404,37 +404,40 @@ int32 interpreter::check_condition(int32 f, uint32 param_count) {
 	}
 	return OPERATION_FAIL;
 }
-int32 interpreter::check_matching(card* pcard, int32 findex, int32 extraargs) {
-	if(!findex || lua_isnil(current_state, findex))
+int32 interpreter::check_filter(lua_State* L, card* pcard, int32 findex, int32 extraargs) {
+	if (!findex || lua_isnil(L, findex))
 		return TRUE;
 	++no_action;
 	++call_depth;
-	luaL_checkstack(current_state, 1 + extraargs, nullptr);
-	lua_pushvalue(current_state, findex);
-	interpreter::card2value(current_state, pcard);
-	for(int32 i = 0; i < extraargs; ++i)
-		lua_pushvalue(current_state, (int32)(-extraargs - 2));
-	if (lua_pcall(current_state, 1 + extraargs, 1, 0)) {
-		sprintf(pduel->strbuffer, "%s", lua_tostring(current_state, -1));
+	luaL_checkstack(L, 1 + extraargs, nullptr);
+	lua_pushvalue(L, findex);
+	card2value(L, pcard);
+	for (int32 i = 0; i < extraargs; ++i)
+		lua_pushvalue(L, (int32)(-extraargs - 2));
+	if (lua_pcall(L, 1 + extraargs, 1, 0)) {
+		sprintf(pduel->strbuffer, "%s", lua_tostring(L, -1));
 		handle_message(pduel, 1);
-		lua_pop(current_state, 1);
+		lua_pop(L, 1);
 		--no_action;
 		--call_depth;
-		if(call_depth == 0) {
+		if (call_depth == 0) {
 			pduel->release_script_group();
 			pduel->restore_assumes();
 		}
 		return OPERATION_FAIL;
 	}
-	int32 result = lua_toboolean(current_state, -1);
-	lua_pop(current_state, 1);
+	int32 result = lua_toboolean(L, -1);
+	lua_pop(L, 1);
 	--no_action;
 	--call_depth;
-	if(call_depth == 0) {
+	if (call_depth == 0) {
 		pduel->release_script_group();
 		pduel->restore_assumes();
 	}
 	return result;
+}
+int32 interpreter::check_matching(card* pcard, int32 findex, int32 extraargs) {
+	return check_filter(current_state, pcard, findex, extraargs);
 }
 int32 interpreter::get_operation_value(card* pcard, int32 findex, int32 extraargs) {
 	if(!findex || lua_isnil(current_state, findex))

--- a/interpreter.h
+++ b/interpreter.h
@@ -70,6 +70,7 @@ public:
 	int32 call_card_function(card* pcard, const char* f, uint32 param_count, int32 ret_count);
 	int32 call_code_function(uint32 code, const char* f, uint32 param_count, int32 ret_count);
 	int32 check_condition(int32 f, uint32 param_count);
+	int32 check_filter(lua_State* L, card* pcard, int32 findex, int32 extraargs);
 	int32 check_matching(card* pcard, int32 findex, int32 extraargs);
 	int32 get_operation_value(card* pcard, int32 findex, int32 extraargs);
 	int32 get_function_value(int32 f, uint32 param_count);

--- a/interpreter.h
+++ b/interpreter.h
@@ -71,7 +71,6 @@ public:
 	int32 call_code_function(uint32 code, const char* f, uint32 param_count, int32 ret_count);
 	int32 check_condition(int32 f, uint32 param_count);
 	int32 check_filter(lua_State* L, card* pcard, int32 findex, int32 extraargs);
-	int32 check_matching(card* pcard, int32 findex, int32 extraargs);
 	int32 get_operation_value(card* pcard, int32 findex, int32 extraargs);
 	int32 get_function_value(int32 f, uint32 param_count);
 	int32 get_function_value(int32 f, uint32 param_count, std::vector<int32>* result);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2535,7 +2535,7 @@ int32 scriptlib::card_is_chain_attackable(lua_State *L) {
 		lua_pushboolean(L, 0);
 		return 1;
 	}
-	field::card_vector cv;
+	card_vector cv;
 	pduel->game_field->get_attack_target(attacker, &cv, TRUE);
 	if(cv.size() == 0 && (monsteronly || attacker->direct_attackable == 0))
 		lua_pushboolean(L, 0);
@@ -3260,7 +3260,7 @@ int32 scriptlib::card_get_attackable_target(lua_State *L) {
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	duel* pduel = pcard->pduel;
-	field::card_vector targets;
+	card_vector targets;
 	uint8 chain_attack = FALSE;
 	if(pduel->game_field->core.chain_attacker_id == pcard->fieldid)
 		chain_attack = TRUE;

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -411,7 +411,7 @@ int32 scriptlib::card_get_linked_group(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	card::card_set cset;
+	card_set cset;
 	pcard->get_linked_cards(&cset);
 	group* pgroup = pcard->pduel->new_group(cset);
 	interpreter::group2value(L, pgroup);
@@ -421,7 +421,7 @@ int32 scriptlib::card_get_linked_group_count(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	card::card_set cset;
+	card_set cset;
 	pcard->get_linked_cards(&cset);
 	lua_pushinteger(L, cset.size());
 	return 1;
@@ -444,7 +444,7 @@ int32 scriptlib::card_get_mutual_linked_group(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**)lua_touserdata(L, 1);
-	card::card_set cset;
+	card_set cset;
 	pcard->get_mutual_linked_cards(&cset);
 	group* pgroup = pcard->pduel->new_group(cset);
 	interpreter::group2value(L, pgroup);
@@ -454,7 +454,7 @@ int32 scriptlib::card_get_mutual_linked_group_count(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**)lua_touserdata(L, 1);
-	card::card_set cset;
+	card_set cset;
 	pcard->get_mutual_linked_cards(&cset);
 	lua_pushinteger(L, cset.size());
 	return 1;
@@ -491,7 +491,7 @@ int32 scriptlib::card_get_column_group(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	card::card_set cset;
+	card_set cset;
 	pcard->get_column_cards(&cset);
 	group* pgroup = pcard->pduel->new_group(cset);
 	interpreter::group2value(L, pgroup);
@@ -501,7 +501,7 @@ int32 scriptlib::card_get_column_group_count(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
 	card* pcard = *(card**) lua_touserdata(L, 1);
-	card::card_set cset;
+	card_set cset;
 	pcard->get_column_cards(&cset);
 	lua_pushinteger(L, cset.size());
 	return 1;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3581,7 +3581,7 @@ int32 scriptlib::duel_check_xyz_material(lua_State *L) {
 		check_param(L, PARAM_TYPE_GROUP, 6);
 		mg = *(group**) lua_touserdata(L, 6);
 	}
-	lua_pushboolean(L, scard->pduel->game_field->check_xyz_material(scard, findex, lv, minc, maxc, mg));
+	lua_pushboolean(L, scard->pduel->game_field->check_xyz_material(L, scard, findex, lv, minc, maxc, mg));
 	return 1;
 }
 int32 scriptlib::duel_select_xyz_material(lua_State *L) {
@@ -3604,9 +3604,9 @@ int32 scriptlib::duel_select_xyz_material(lua_State *L) {
 		mg = *(group**) lua_touserdata(L, 7);
 	}
 	duel* pduel = scard->pduel;
-	if(!pduel->game_field->check_xyz_material(scard, findex, lv, minc, maxc, mg))
+	if(!pduel->game_field->check_xyz_material(L, scard, findex, lv, minc, maxc, mg))
 		return 0;
-	pduel->game_field->get_xyz_material(scard, findex, lv, maxc, mg);
+	pduel->game_field->get_xyz_material(L, scard, findex, lv, maxc, mg);
 	scard->pduel->game_field->add_process(PROCESSOR_SELECT_XMATERIAL, 0, 0, (group*)scard, playerid + (lv << 16), minc + (maxc << 16));
 	return lua_yield(L, 0);
 }

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3305,7 +3305,7 @@ int32 scriptlib::duel_check_tuner_material(lua_State *L) {
 		check_param(L, PARAM_TYPE_GROUP, 7);
 		mg = *(group**) lua_touserdata(L, 7);
 	}
-	lua_pushboolean(L, pduel->game_field->check_tuner_material(L, pcard, tuner, 3, 4, min, max, 0, mg));
+	lua_pushboolean(L, pduel->game_field->check_tuner_material(L, pcard, tuner, 3, 4, min, max, nullptr, mg));
 	return 1;
 }
 int32 scriptlib::duel_get_ritual_material(lua_State *L) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -577,7 +577,7 @@ int32 scriptlib::duel_special_summon(lua_State *L) {
 	if(lua_gettop(L) >= 8)
 		zone = (uint32)lua_tointeger(L, 8);
 	if(pcard) {
-		field::card_set cset;
+		card_set cset;
 		cset.insert(pcard);
 		pduel->game_field->special_summon(&cset, sumtype, sumplayer, playerid, nocheck, nolimit, positions, zone);
 	} else
@@ -807,7 +807,7 @@ int32 scriptlib::duel_change_form(lua_State *L) {
 	if(top > 4) dd = (uint32)lua_tointeger(L, 5);
 	if(top > 5 && lua_toboolean(L, 6)) flag |= NO_FLIP_EFFECT;
 	if(pcard) {
-		field::card_set cset;
+		card_set cset;
 		cset.insert(pcard);
 		pduel->game_field->change_position(&cset, pduel->game_field->core.reason_effect, pduel->game_field->core.reason_player, au, ad, du, dd, flag, TRUE);
 	} else
@@ -934,7 +934,7 @@ int32 scriptlib::duel_swap_sequence(lua_State *L) {
 		&& pcard1->is_affect_by_effect(pduel->game_field->core.reason_effect)
 		&& pcard2->is_affect_by_effect(pduel->game_field->core.reason_effect)) {
 		pduel->game_field->swap_card(pcard1, pcard2);
-		field::card_set swapped;
+		card_set swapped;
 		swapped.insert(pcard1);
 		swapped.insert(pcard2);
 		pduel->game_field->raise_single_event(pcard1, 0, EVENT_MOVE, pduel->game_field->core.reason_effect, 0, pduel->game_field->core.reason_player, player, 0);
@@ -1363,7 +1363,7 @@ int32 scriptlib::duel_equip(lua_State *L) {
 }
 int32 scriptlib::duel_equip_complete(lua_State *L) {
 	duel* pduel = interpreter::get_duel_info(L);
-	field::card_set etargets;
+	card_set etargets;
 	for(auto& equip_card : pduel->game_field->core.equiping_cards) {
 		if(equip_card->is_position(POS_FACEUP))
 			equip_card->enable_field_effect(true);
@@ -1865,7 +1865,7 @@ int32 scriptlib::duel_disable_summon(lua_State *L) {
 	}
 	uint8 sumplayer = PLAYER_NONE;
 	effect* reason_effect = pduel->game_field->core.reason_effect;
-	field::card_set negated_cards;
+	card_set negated_cards;
 	if (sumtype == SUMMON_TYPE_DUAL || sumtype & SUMMON_TYPE_FLIP) {
 		if (!pcard->is_summon_negatable(sumtype, reason_effect))
 			return 0;
@@ -2124,7 +2124,7 @@ int32 scriptlib::duel_get_linked_group(lua_State *L) {
 	uint32 s = (uint32)lua_tointeger(L, 2);
 	uint32 o = (uint32)lua_tointeger(L, 3);
 	duel* pduel = interpreter::get_duel_info(L);
-	field::card_set cset;
+	card_set cset;
 	pduel->game_field->get_linked_cards(rplayer, s, o, &cset);
 	group* pgroup = pduel->new_group(cset);
 	interpreter::group2value(L, pgroup);
@@ -2138,7 +2138,7 @@ int32 scriptlib::duel_get_linked_group_count(lua_State *L) {
 	uint32 s = (uint32)lua_tointeger(L, 2);
 	uint32 o = (uint32)lua_tointeger(L, 3);
 	duel* pduel = interpreter::get_duel_info(L);
-	field::card_set cset;
+	card_set cset;
 	pduel->game_field->get_linked_cards(rplayer, s, o, &cset);
 	lua_pushinteger(L, cset.size());
 	return 1;
@@ -3184,7 +3184,7 @@ int32 scriptlib::duel_get_synchro_material(lua_State *L) {
 	if (lua_gettop(L) >= 2)
 		facedown = lua_toboolean(L, 2);
 	duel* pduel = interpreter::get_duel_info(L);
-	group::card_set mats;
+	card_set mats;
 	pduel->game_field->get_synchro_material(playerid, &mats);
 	group* pgroup = pduel->new_group();
 	for (auto cit = mats.begin(); cit != mats.end(); ++cit) {
@@ -3222,7 +3222,7 @@ int32 scriptlib::duel_select_synchro_material(lua_State *L) {
 	}
 	auto filter1 = interpreter::get_function_handle(L, 3);
 	auto filter2 = interpreter::get_function_handle(L, 4);
-	field::card_set select_cards;
+	card_set select_cards;
 	if (mg) {
 		for (auto& pm : mg->container) {
 			if (pduel->game_field->check_tuner_material(L, pcard, pm, 3, 4, min, max, nullptr, mg))
@@ -3232,7 +3232,7 @@ int32 scriptlib::duel_select_synchro_material(lua_State *L) {
 		pduel->game_field->add_process(PROCESSOR_SELECT_SYNCHRO, 0, nullptr, nullptr, playerid, min + (max << 16), filter1, filter2, pcard, mg);
 	}
 	else {
-		field::card_set material;
+		card_set material;
 		pduel->game_field->get_synchro_material(playerid, &material);
 		for (auto& tuner : material) {
 			if (pduel->game_field->check_tuner_material(L, pcard, tuner, 3, 4, min, max, smat, nullptr))
@@ -3631,7 +3631,7 @@ int32 scriptlib::duel_overlay(lua_State *L) {
 	} else
 		return luaL_error(L, "Parameter %d should be \"Card\" or \"Group\".", 2);
 	if(pcard) {
-		card::card_set cset;
+		card_set cset;
 		cset.insert(pcard);
 		target->xyz_overlay(&cset);
 	} else

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1674,7 +1674,7 @@ int32 scriptlib::duel_change_attack_target(lua_State *L) {
 		lua_pushboolean(L, 0);
 		return 1;
 	}
-	field::card_vector cv;
+	card_vector cv;
 	pduel->game_field->get_attack_target(attacker, &cv, pduel->game_field->core.chain_attack);
 	if(target && std::find(cv.begin(), cv.end(), target) != cv.end()
 		|| !target && !attacker->is_affected_by_effect(EFFECT_CANNOT_DIRECT_ATTACK)) {
@@ -1975,7 +1975,7 @@ int32 scriptlib::duel_get_mzone_count(lua_State *L) {
 	card* mcard = nullptr;
 	group* mgroup = nullptr;
 	uint32 used_location[2] = { 0, 0 };
-	player_info::card_vector list_mzone[2];
+	card_vector list_mzone[2];
 	if(lua_gettop(L) >= 2 && !lua_isnil(L, 2)) {
 		if(check_param(L, PARAM_TYPE_CARD, 2, TRUE)) {
 			mcard = *(card**)lua_touserdata(L, 2);
@@ -2034,7 +2034,7 @@ int32 scriptlib::duel_get_location_count_fromex(lua_State *L) {
 	card* mcard = nullptr;
 	group* mgroup = nullptr;
 	uint32 used_location[2] = {0, 0};
-	player_info::card_vector list_mzone[2];
+	card_vector list_mzone[2];
 	if(lua_gettop(L) >= 3 && !lua_isnil(L, 3)) {
 		if(check_param(L, PARAM_TYPE_CARD, 3, TRUE)) {
 			mcard = *(card**) lua_touserdata(L, 3);

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3252,7 +3252,7 @@ int32 scriptlib::duel_check_synchro_material(lua_State *L) {
 		mg = *(group**) lua_touserdata(L, 7);
 	}
 	lua_pushvalue(L, 1);
-	lua_pushboolean(L, pduel->game_field->check_synchro_material(pcard, 2, 3, min, max, smat, mg));
+	lua_pushboolean(L, pduel->game_field->check_synchro_material(L, pcard, 2, 3, min, max, smat, mg));
 	return 1;
 }
 int32 scriptlib::duel_select_tuner_material(lua_State *L) {
@@ -3277,7 +3277,7 @@ int32 scriptlib::duel_select_tuner_material(lua_State *L) {
 		mg = *(group**) lua_touserdata(L, 8);
 	}
 	lua_pushvalue(L, 2);
-	if(!pduel->game_field->check_tuner_material(pcard, tuner, 4, 5, min, max, 0, mg))
+	if(!pduel->game_field->check_tuner_material(L, pcard, tuner, 4, 5, min, max, 0, mg))
 		return 0;
 	lua_pop(L, 1);
 	pduel->game_field->core.select_cards.clear();
@@ -3309,7 +3309,7 @@ int32 scriptlib::duel_check_tuner_material(lua_State *L) {
 		mg = *(group**) lua_touserdata(L, 7);
 	}
 	lua_pushvalue(L, 1);
-	lua_pushboolean(L, pduel->game_field->check_tuner_material(pcard, tuner, 3, 4, min, max, 0, mg));
+	lua_pushboolean(L, pduel->game_field->check_tuner_material(L, pcard, tuner, 3, 4, min, max, 0, mg));
 	return 1;
 }
 int32 scriptlib::duel_get_ritual_material(lua_State *L) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1517,7 +1517,7 @@ int32 scriptlib::duel_discard_hand(lua_State *L) {
 	uint32 max = (uint32)lua_tointeger(L, 4);
 	uint32 reason = (uint32)lua_tointeger(L, 5);
 	group* pgroup = pduel->new_group();
-	pduel->game_field->filter_matching_card(2, playerid, LOCATION_HAND, 0, pgroup, pexception, pexgroup, extraargs);
+	pduel->game_field->filter_matching_card(L, 2, playerid, LOCATION_HAND, 0, pgroup, pexception, pexgroup, extraargs);
 	pduel->game_field->core.select_cards.assign(pgroup->container.begin(), pgroup->container.end());
 	if(pduel->game_field->core.select_cards.size() == 0) {
 		lua_pushinteger(L, 0);
@@ -2564,7 +2564,7 @@ int32 scriptlib::duel_get_matching_group(lua_State *L) {
 	uint32 location1 = (uint32)lua_tointeger(L, 3);
 	uint32 location2 = (uint32)lua_tointeger(L, 4);
 	group* pgroup = pduel->new_group();
-	pduel->game_field->filter_matching_card(1, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs);
+	pduel->game_field->filter_matching_card(L, 1, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs);
 	interpreter::group2value(L, pgroup);
 	return 1;
 }
@@ -2589,7 +2589,7 @@ int32 scriptlib::duel_get_matching_count(lua_State *L) {
 	uint32 location1 = (uint32)lua_tointeger(L, 3);
 	uint32 location2 = (uint32)lua_tointeger(L, 4);
 	group* pgroup = pduel->new_group();
-	pduel->game_field->filter_matching_card(1, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs);
+	pduel->game_field->filter_matching_card(L, 1, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs);
 	uint32 count = (uint32)pgroup->container.size();
 	lua_pushinteger(L, count);
 	return 1;
@@ -2615,7 +2615,7 @@ int32 scriptlib::duel_get_first_matching_card(lua_State *L) {
 	uint32 location1 = (uint32)lua_tointeger(L, 3);
 	uint32 location2 = (uint32)lua_tointeger(L, 4);
 	card* pret = nullptr;
-	pduel->game_field->filter_matching_card(1, (uint8)self, location1, location2, 0, pexception, pexgroup, extraargs, &pret);
+	pduel->game_field->filter_matching_card(L, 1, (uint8)self, location1, location2, 0, pexception, pexgroup, extraargs, &pret);
 	if(pret)
 		interpreter::card2value(L, pret);
 	else lua_pushnil(L);
@@ -2642,7 +2642,7 @@ int32 scriptlib::duel_is_existing_matching_card(lua_State *L) {
 	uint32 location1 = (uint32)lua_tointeger(L, 3);
 	uint32 location2 = (uint32)lua_tointeger(L, 4);
 	uint32 fcount = (uint32)lua_tointeger(L, 5);
-	lua_pushboolean(L, pduel->game_field->filter_matching_card(1, (uint8)self, location1, location2, 0, pexception, pexgroup, extraargs, nullptr, fcount));
+	lua_pushboolean(L, pduel->game_field->filter_matching_card(L, 1, (uint8)self, location1, location2, 0, pexception, pexgroup, extraargs, nullptr, fcount));
 	return 1;
 }
 /**
@@ -2672,7 +2672,7 @@ int32 scriptlib::duel_select_matching_cards(lua_State *L) {
 	uint32 min = (uint32)lua_tointeger(L, 6);
 	uint32 max = (uint32)lua_tointeger(L, 7);
 	group* pgroup = pduel->new_group();
-	pduel->game_field->filter_matching_card(2, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs);
+	pduel->game_field->filter_matching_card(L, 2, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs);
 	pduel->game_field->core.select_cards.assign(pgroup->container.begin(), pgroup->container.end());
 	pduel->game_field->add_process(PROCESSOR_SELECT_CARD, 0, 0, 0, playerid, min + (max << 16));
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
@@ -2990,7 +2990,7 @@ int32 scriptlib::duel_get_target_count(lua_State *L) {
 	uint32 location2 = (uint32)lua_tointeger(L, 4);
 	group* pgroup = pduel->new_group();
 	uint32 count = 0;
-	pduel->game_field->filter_matching_card(1, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs, nullptr, 0, TRUE);
+	pduel->game_field->filter_matching_card(L, 1, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs, nullptr, 0, TRUE);
 	count = (uint32)pgroup->container.size();
 	lua_pushinteger(L, count);
 	return 1;
@@ -3016,7 +3016,7 @@ int32 scriptlib::duel_is_existing_target(lua_State *L) {
 	uint32 location1 = (uint32)lua_tointeger(L, 3);
 	uint32 location2 = (uint32)lua_tointeger(L, 4);
 	uint32 count = (uint32)lua_tointeger(L, 5);
-	lua_pushboolean(L, pduel->game_field->filter_matching_card(1, (uint8)self, location1, location2, 0, pexception, pexgroup, extraargs, nullptr, count, TRUE));
+	lua_pushboolean(L, pduel->game_field->filter_matching_card(L, 1, (uint8)self, location1, location2, 0, pexception, pexgroup, extraargs, nullptr, count, TRUE));
 	return 1;
 }
 /**
@@ -3048,7 +3048,7 @@ int32 scriptlib::duel_select_target(lua_State *L) {
 	if(pduel->game_field->core.current_chain.size() == 0)
 		return 0;
 	group* pgroup = pduel->new_group();
-	pduel->game_field->filter_matching_card(2, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs, nullptr, 0, TRUE);
+	pduel->game_field->filter_matching_card(L, 2, (uint8)self, location1, location2, pgroup, pexception, pexgroup, extraargs, nullptr, 0, TRUE);
 	pduel->game_field->core.select_cards.assign(pgroup->container.begin(), pgroup->container.end());
 	pduel->game_field->add_process(PROCESSOR_SELECT_CARD, 0, 0, 0, playerid, min + (max << 16));
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2704,7 +2704,7 @@ int32 scriptlib::duel_get_release_group(lua_State *L) {
 		reason = (uint32)lua_tointeger(L, 3);
 	duel* pduel = interpreter::get_duel_info(L);
 	group* pgroup = pduel->new_group();
-	pduel->game_field->get_release_list(playerid, &pgroup->container, &pgroup->container, &pgroup->container, FALSE, hand, 0, 0, nullptr, nullptr, reason);
+	pduel->game_field->get_release_list(L, playerid, &pgroup->container, &pgroup->container, &pgroup->container, FALSE, hand, 0, 0, nullptr, nullptr, reason);
 	interpreter::group2value(L, pgroup);
 	return 1;
 }
@@ -2725,7 +2725,7 @@ int32 scriptlib::duel_get_release_group_count(lua_State *L) {
 	if (lua_gettop(L) >= 3)
 		reason = (uint32)lua_tointeger(L, 3);
 	duel* pduel = interpreter::get_duel_info(L);
-	lua_pushinteger(L, pduel->game_field->get_release_list(playerid, nullptr, nullptr, FALSE, FALSE, hand, 0, 0, nullptr, nullptr, reason));
+	lua_pushinteger(L, pduel->game_field->get_release_list(L, playerid, nullptr, nullptr, nullptr, FALSE, hand, 0, 0, nullptr, nullptr, reason));
 	return 1;
 }
 int32 scriptlib::duel_check_release_group(lua_State *L) {
@@ -2748,7 +2748,7 @@ int32 scriptlib::duel_check_release_group(lua_State *L) {
 		pexgroup = *(group**) lua_touserdata(L, 4);
 	uint32 extraargs = lua_gettop(L) - must_param;
 	duel* pduel = interpreter::get_duel_info(L);
-	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, FALSE, 2, extraargs, pexception, pexgroup, REASON_COST);
+	int32 result = pduel->game_field->check_release_list(L, playerid, fcount, use_con, FALSE, 2, extraargs, pexception, pexgroup, REASON_COST);
 	pduel->game_field->core.must_select_cards.clear();
 	lua_pushboolean(L, result);
 	return 1;
@@ -2778,7 +2778,7 @@ int32 scriptlib::duel_select_release_group(lua_State *L) {
 	pduel->game_field->core.release_cards.clear();
 	pduel->game_field->core.release_cards_ex.clear();
 	pduel->game_field->core.release_cards_ex_oneof.clear();
-	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_con, FALSE, 2, extraargs, pexception, pexgroup, REASON_COST);
+	pduel->game_field->get_release_list(L, playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_con, FALSE, 2, extraargs, pexception, pexgroup, REASON_COST);
 	pduel->game_field->add_process(PROCESSOR_SELECT_RELEASE, 0, 0, 0, playerid, (max << 16) + min);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;
@@ -2813,7 +2813,7 @@ int32 scriptlib::duel_check_release_group_ex(lua_State *L) {
 		pexgroup = *(group**) lua_touserdata(L, 6);
 	uint32 extraargs = lua_gettop(L) - must_param;
 	duel* pduel = interpreter::get_duel_info(L);
-	int32 result = pduel->game_field->check_release_list(playerid, fcount, use_con, use_hand, 2, extraargs, pexception, pexgroup, reason);
+	int32 result = pduel->game_field->check_release_list(L, playerid, fcount, use_con, use_hand, 2, extraargs, pexception, pexgroup, reason);
 	pduel->game_field->core.must_select_cards.clear();
 	lua_pushboolean(L, result);
 	return 1;
@@ -2845,7 +2845,7 @@ int32 scriptlib::duel_select_release_group_ex(lua_State *L) {
 	pduel->game_field->core.release_cards.clear();
 	pduel->game_field->core.release_cards_ex.clear();
 	pduel->game_field->core.release_cards_ex_oneof.clear();
-	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_con, use_hand, 2, extraargs, pexception, pexgroup, reason);
+	pduel->game_field->get_release_list(L, playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_con, use_hand, 2, extraargs, pexception, pexgroup, reason);
 	pduel->game_field->add_process(PROCESSOR_SELECT_RELEASE, 0, 0, 0, playerid, (max << 16) + min);
 	return lua_yieldk(L, 0, (lua_KContext)pduel, [](lua_State *L, int32 status, lua_KContext ctx) {
 		duel* pduel = (duel*)ctx;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3222,12 +3222,13 @@ int32 scriptlib::duel_select_synchro_material(lua_State *L) {
 	}
 	auto filter1 = interpreter::get_function_handle(L, 3);
 	auto filter2 = interpreter::get_function_handle(L, 4);
-	pduel->game_field->core.select_cards.clear();
+	field::card_set select_cards;
 	if (mg) {
 		for (auto& pm : mg->container) {
 			if (pduel->game_field->check_tuner_material(L, pcard, pm, 3, 4, min, max, nullptr, mg))
-				pduel->game_field->core.select_cards.push_back(pm);
+				select_cards.insert(pm);
 		}
+		pduel->game_field->core.select_cards.assign(select_cards.begin(), select_cards.end());
 		pduel->game_field->add_process(PROCESSOR_SELECT_SYNCHRO, 0, nullptr, nullptr, playerid, min + (max << 16), filter1, filter2, pcard, mg);
 	}
 	else {
@@ -3235,8 +3236,9 @@ int32 scriptlib::duel_select_synchro_material(lua_State *L) {
 		pduel->game_field->get_synchro_material(playerid, &material);
 		for (auto& tuner : material) {
 			if (pduel->game_field->check_tuner_material(L, pcard, tuner, 3, 4, min, max, smat, nullptr))
-				pduel->game_field->core.select_cards.push_back(tuner);
+				select_cards.insert(tuner);
 		}
+		pduel->game_field->core.select_cards.assign(select_cards.begin(), select_cards.end());
 		pduel->game_field->add_process(PROCESSOR_SELECT_SYNCHRO, 0, nullptr, nullptr, playerid + 0x10000, min + (max << 16), filter1, filter2, pcard, smat);
 	}
 	return lua_yield(L, 0);
@@ -3286,7 +3288,7 @@ int32 scriptlib::duel_select_tuner_material(lua_State *L) {
 		check_param(L, PARAM_TYPE_GROUP, 8);
 		mg = *(group**) lua_touserdata(L, 8);
 	}
-	if(!pduel->game_field->check_tuner_material(L, pcard, tuner, 4, 5, min, max, 0, mg))
+	if(!pduel->game_field->check_tuner_material(L, pcard, tuner, 4, 5, min, max, nullptr, mg))
 		return 0;
 	pduel->game_field->core.select_cards.clear();
 	pduel->game_field->core.select_cards.push_back(tuner);

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3220,10 +3220,10 @@ int32 scriptlib::duel_select_synchro_material(lua_State *L) {
 		check_param(L, PARAM_TYPE_GROUP, 8);
 		mg = *(group**) lua_touserdata(L, 8);
 	}
-	if(mg)
-		pduel->game_field->add_process(PROCESSOR_SELECT_SYNCHRO, 0, (effect*)mg, (group*)pcard, playerid, min + (max << 16));
+	if (mg)
+		pduel->game_field->add_process(PROCESSOR_SELECT_SYNCHRO, 0, nullptr, nullptr, playerid, min + (max << 16), 0, 0, pcard, mg);
 	else
-		pduel->game_field->add_process(PROCESSOR_SELECT_SYNCHRO, 0, (effect*)smat, (group*)pcard, playerid + 0x10000, min + (max << 16));
+		pduel->game_field->add_process(PROCESSOR_SELECT_SYNCHRO, 0, nullptr, nullptr, playerid + 0x10000, min + (max << 16), 0, 0, pcard, smat);
 	lua_pushvalue(L, 3);
 	lua_pushvalue(L, 4);
 	lua_pushvalue(L, 2);
@@ -3283,7 +3283,7 @@ int32 scriptlib::duel_select_tuner_material(lua_State *L) {
 	pduel->game_field->core.select_cards.clear();
 	pduel->game_field->core.select_cards.push_back(tuner);
 	pduel->game_field->returns.bvalue[1] = 0;
-	pduel->game_field->add_process(PROCESSOR_SELECT_SYNCHRO, 1, (effect*)mg, (group*)pcard, playerid, min + (max << 16));
+	pduel->game_field->add_process(PROCESSOR_SELECT_SYNCHRO, 1, nullptr, nullptr, playerid, min + (max << 16), 0, 0, pcard, mg);
 	lua_pushvalue(L, 4);
 	lua_pushvalue(L, 5);
 	lua_pushvalue(L, 2);

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3251,7 +3251,6 @@ int32 scriptlib::duel_check_synchro_material(lua_State *L) {
 		check_param(L, PARAM_TYPE_GROUP, 7);
 		mg = *(group**) lua_touserdata(L, 7);
 	}
-	lua_pushvalue(L, 1);
 	lua_pushboolean(L, pduel->game_field->check_synchro_material(L, pcard, 2, 3, min, max, smat, mg));
 	return 1;
 }
@@ -3276,10 +3275,8 @@ int32 scriptlib::duel_select_tuner_material(lua_State *L) {
 		check_param(L, PARAM_TYPE_GROUP, 8);
 		mg = *(group**) lua_touserdata(L, 8);
 	}
-	lua_pushvalue(L, 2);
 	if(!pduel->game_field->check_tuner_material(L, pcard, tuner, 4, 5, min, max, 0, mg))
 		return 0;
-	lua_pop(L, 1);
 	pduel->game_field->core.select_cards.clear();
 	pduel->game_field->core.select_cards.push_back(tuner);
 	pduel->game_field->returns.bvalue[1] = 0;
@@ -3308,7 +3305,6 @@ int32 scriptlib::duel_check_tuner_material(lua_State *L) {
 		check_param(L, PARAM_TYPE_GROUP, 7);
 		mg = *(group**) lua_touserdata(L, 7);
 	}
-	lua_pushvalue(L, 1);
 	lua_pushboolean(L, pduel->game_field->check_tuner_material(L, pcard, tuner, 3, 4, min, max, 0, mg));
 	return 1;
 }

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -448,7 +448,7 @@ int32 scriptlib::group_check_with_sum_equal(lua_State *L) {
 	if(max < min)
 		max = min;
 	int32 extraargs = lua_gettop(L) - 5;
-	field::card_vector cv(pduel->game_field->core.must_select_cards);
+	card_vector cv(pduel->game_field->core.must_select_cards);
 	int32 mcount = (int32)cv.size();
 	for(auto& pcard : pgroup->container) {
 		auto it = std::find(pduel->game_field->core.must_select_cards.begin(), pduel->game_field->core.must_select_cards.end(), pcard);
@@ -486,7 +486,7 @@ int32 scriptlib::group_select_with_sum_equal(lua_State *L) {
 		auto it = std::remove(pduel->game_field->core.select_cards.begin(), pduel->game_field->core.select_cards.end(), pcard);
 		pduel->game_field->core.select_cards.erase(it, pduel->game_field->core.select_cards.end());
 	}
-	field::card_vector cv(pduel->game_field->core.must_select_cards);
+	card_vector cv(pduel->game_field->core.must_select_cards);
 	int32 mcount = (int32)cv.size();
 	cv.insert(cv.end(), pduel->game_field->core.select_cards.begin(), pduel->game_field->core.select_cards.end());
 	for(auto& pcard : cv)
@@ -519,7 +519,7 @@ int32 scriptlib::group_check_with_sum_greater(lua_State *L) {
 	duel* pduel = pgroup->pduel;
 	int32 acc = (int32)lua_tointeger(L, 3);
 	int32 extraargs = lua_gettop(L) - 3;
-	field::card_vector cv(pduel->game_field->core.must_select_cards);
+	card_vector cv(pduel->game_field->core.must_select_cards);
 	int32 mcount = (int32)cv.size();
 	for(auto& pcard : pgroup->container) {
 		auto it = std::find(pduel->game_field->core.must_select_cards.begin(), pduel->game_field->core.must_select_cards.end(), pcard);
@@ -549,7 +549,7 @@ int32 scriptlib::group_select_with_sum_greater(lua_State *L) {
 		auto it = std::remove(pduel->game_field->core.select_cards.begin(), pduel->game_field->core.select_cards.end(), pcard);
 		pduel->game_field->core.select_cards.erase(it, pduel->game_field->core.select_cards.end());
 	}
-	field::card_vector cv(pduel->game_field->core.must_select_cards);
+	card_vector cv(pduel->game_field->core.must_select_cards);
 	int32 mcount = (int32)cv.size();
 	cv.insert(cv.end(), pduel->game_field->core.select_cards.begin(), pduel->game_field->core.select_cards.end());
 	for(auto& pcard : cv)

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -133,22 +133,6 @@ int32 scriptlib::group_get_count(lua_State *L) {
 	lua_pushinteger(L, pgroup->container.size());
 	return 1;
 }
-int32 scriptlib::group_for_each(lua_State *L) {
-	check_param_count(L, 2);
-	check_param(L, PARAM_TYPE_GROUP, 1);
-	check_param(L, PARAM_TYPE_FUNCTION, 2);
-	duel* pduel = interpreter::get_duel_info(L);
-	group* pgroup = *(group**) lua_touserdata(L, 1);
-	int32 f = interpreter::get_function_handle(L, 2);
-	int32 extraargs = lua_gettop(L) - 2;
-	for (auto& pcard : pgroup->container) {
-		pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
-		for(int32 i = 0; i < extraargs; ++i)
-			pduel->lua->add_param(-extraargs + i, PARAM_TYPE_INDEX);
-		pduel->lua->call_function(f, 1 + extraargs, 0);
-	}
-	return 0;
-}
 int32 scriptlib::group_filter(lua_State *L) {
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_GROUP, 1);
@@ -924,7 +908,6 @@ static const struct luaL_Reg grouplib[] = {
 	{ "GetFirst", scriptlib::group_get_first },
 	{ "GetCount", scriptlib::group_get_count },
 	{ "__len", scriptlib::group_get_count },
-	{ "ForEach", scriptlib::group_for_each },
 	{ "Filter", scriptlib::group_filter },
 	{ "FilterCount", scriptlib::group_filter_count },
 	{ "FilterSelect", scriptlib::group_filter_select },

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -138,7 +138,7 @@ int32 scriptlib::group_filter(lua_State *L) {
 	check_param(L, PARAM_TYPE_GROUP, 1);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	group* pgroup = *(group**) lua_touserdata(L, 1);
-	field::card_set cset(pgroup->container);
+	card_set cset(pgroup->container);
 	if(check_param(L, PARAM_TYPE_CARD, 3, TRUE)) {
 		card* pexception = *(card**) lua_touserdata(L, 3);
 		cset.erase(pexception);
@@ -163,7 +163,7 @@ int32 scriptlib::group_filter_count(lua_State *L) {
 	check_param(L, PARAM_TYPE_GROUP, 1);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	group* pgroup = *(group**) lua_touserdata(L, 1);
-	field::card_set cset(pgroup->container);
+	card_set cset(pgroup->container);
 	if(check_param(L, PARAM_TYPE_CARD, 3, TRUE)) {
 		card* pexception = *(card**) lua_touserdata(L, 3);
 		cset.erase(pexception);
@@ -188,7 +188,7 @@ int32 scriptlib::group_filter_select(lua_State *L) {
 	check_param(L, PARAM_TYPE_GROUP, 1);
 	check_param(L, PARAM_TYPE_FUNCTION, 3);
 	group* pgroup = *(group**) lua_touserdata(L, 1);
-	field::card_set cset(pgroup->container);
+	card_set cset(pgroup->container);
 	if(check_param(L, PARAM_TYPE_CARD, 6, TRUE)) {
 		card* pexception = *(card**) lua_touserdata(L, 6);
 		cset.erase(pexception);
@@ -226,7 +226,7 @@ int32 scriptlib::group_select(lua_State *L) {
 	check_param_count(L, 5);
 	check_param(L, PARAM_TYPE_GROUP, 1);
 	group* pgroup = *(group**) lua_touserdata(L, 1);
-	field::card_set cset(pgroup->container);
+	card_set cset(pgroup->container);
 	if(check_param(L, PARAM_TYPE_CARD, 5, TRUE)) {
 		card* pexception = *(card**) lua_touserdata(L, 5);
 		cset.erase(pexception);
@@ -364,7 +364,7 @@ int32 scriptlib::group_cancelable_select(lua_State *L) {
 	check_param_count(L, 5);
 	check_param(L, PARAM_TYPE_GROUP, 1);
 	group* pgroup = *(group**) lua_touserdata(L, 1);
-	field::card_set cset(pgroup->container);
+	card_set cset(pgroup->container);
 	if(check_param(L, PARAM_TYPE_CARD, 5, TRUE)) {
 		card* pexception = *(card**) lua_touserdata(L, 5);
 		cset.erase(pexception);
@@ -404,7 +404,7 @@ int32 scriptlib::group_is_exists(lua_State *L) {
 	check_param(L, PARAM_TYPE_GROUP, 1);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	group* pgroup = *(group**) lua_touserdata(L, 1);
-	field::card_set cset(pgroup->container);
+	card_set cset(pgroup->container);
 	if(check_param(L, PARAM_TYPE_CARD, 4, TRUE)) {
 		card* pexception = *(card**) lua_touserdata(L, 4);
 		cset.erase(pexception);
@@ -839,7 +839,7 @@ int32 scriptlib::group_meta_band(lua_State* L) {
 		return luaL_error(L, "Parameter %d should be \"Card\" or \"Group\".", 2);
 	duel* pduel = interpreter::get_duel_info(L);
 	group* pgroup = pduel->new_group();
-	field::card_set check_set;
+	card_set check_set;
 	if(check_param(L, PARAM_TYPE_CARD, 1, TRUE)) {
 		card* ccard = *(card**) lua_touserdata(L, 1);
 		check_set.insert(ccard);

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -167,7 +167,7 @@ int32 scriptlib::group_filter(lua_State *L) {
 	group* new_group = pduel->new_group();
 	uint32 extraargs = lua_gettop(L) - 3;
 	for(auto& pcard : cset) {
-		if(pduel->lua->check_matching(pcard, 2, extraargs)) {
+		if(pduel->lua->check_filter(L, pcard, 2, extraargs)) {
 			new_group->container.insert(pcard);
 		}
 	}
@@ -192,7 +192,7 @@ int32 scriptlib::group_filter_count(lua_State *L) {
 	uint32 extraargs = lua_gettop(L) - 3;
 	uint32 count = 0;
 	for (auto& pcard : cset) {
-		if(pduel->lua->check_matching(pcard, 2, extraargs))
+		if(pduel->lua->check_filter(L, pcard, 2, extraargs))
 			++count;
 	}
 	lua_pushinteger(L, count);
@@ -222,7 +222,7 @@ int32 scriptlib::group_filter_select(lua_State *L) {
 	uint32 extraargs = lua_gettop(L) - 6;
 	pduel->game_field->core.select_cards.clear();
 	for (auto& pcard : cset) {
-		if(pduel->lua->check_matching(pcard, 3, extraargs))
+		if(pduel->lua->check_filter(L, pcard, 3, extraargs))
 			pduel->game_field->core.select_cards.push_back(pcard);
 	}
 	pduel->game_field->add_process(PROCESSOR_SELECT_CARD, 0, 0, 0, playerid, min + (max << 16));
@@ -439,7 +439,7 @@ int32 scriptlib::group_is_exists(lua_State *L) {
 		return 1;
 	}
 	for (auto& pcard : cset) {
-		if(pduel->lua->check_matching(pcard, 2, extraargs)) {
+		if(pduel->lua->check_filter(L, pcard, 2, extraargs)) {
 			++fcount;
 			if(fcount >= count) {
 				result = TRUE;
@@ -692,7 +692,7 @@ int32 scriptlib::group_remove(lua_State *L) {
 		return 0;
 	pgroup->is_iterator_dirty = true;
 	for (auto cit = pgroup->container.begin(); cit != pgroup->container.end();) {
-		if((*cit) != pexception && pduel->lua->check_matching(*cit, 2, extraargs)) {
+		if((*cit) != pexception && pduel->lua->check_filter(L, *cit, 2, extraargs)) {
 			cit = pgroup->container.erase(cit);
 		}
 		else
@@ -767,7 +767,7 @@ int32 scriptlib::group_search_card(lua_State *L) {
 	duel* pduel = pgroup->pduel;
 	uint32 extraargs = lua_gettop(L) - 2;
 	for (auto& pcard : pgroup->container) {
-		if (pduel->lua->check_matching(pcard, 2, extraargs)) {
+		if (pduel->lua->check_filter(L, pcard, 2, extraargs)) {
 			interpreter::card2value(L, pcard);
 			return 1;
 		}

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -185,7 +185,7 @@ extern "C" DECL_DLLEXPORT int32 query_card(intptr_t pduel, uint8 playerid, uint8
 	if(location & LOCATION_ONFIELD)
 		pcard = ptduel->game_field->get_field_card(playerid, location, sequence);
 	else {
-		field::card_vector* lst = nullptr;
+		card_vector* lst = nullptr;
 		if (location == LOCATION_HAND)
 			lst = &ptduel->game_field->player[playerid].list_hand;
 		else if (location == LOCATION_GRAVE)
@@ -269,7 +269,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(intptr_t pduel, uint8 playerid,
 		}
 	}
 	else {
-		field::card_vector* lst = nullptr;
+		card_vector* lst = nullptr;
 		if(location == LOCATION_HAND)
 			lst = &player.list_hand;
 		else if(location == LOCATION_GRAVE)

--- a/operations.cpp
+++ b/operations.cpp
@@ -5290,20 +5290,6 @@ int32 field::activate_effect(uint16 step, effect* peffect) {
 int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, int32 min, int32 max, card* smat, group* mg, int32 filter1, int32 filter2) {
 	switch(step) {
 	case 0: {
-		core.select_cards.clear();
-		if(mg) {
-			for(auto& pm : mg->container) {
-				if(check_tuner_material(pcard, pm, -3, -2, min, max, smat, mg))
-					core.select_cards.push_back(pm);
-			}
-		} else {
-			card_set material;
-			get_synchro_material(playerid, &material);
-			for(auto& tuner : material) {
-				if(check_tuner_material(pcard, tuner, -3, -2, min, max, smat, mg))
-					core.select_cards.push_back(tuner);
-			}
-		}
 		if(core.select_cards.size() == 0)
 			return TRUE;
 		pduel->write_buffer8(MSG_HINT);
@@ -5315,7 +5301,6 @@ int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, in
 	}
 	case 1: {
 		if(returns.ivalue[0] == -1) {
-			lua_pop(pduel->lua->current_state, 3);
 			pduel->lua->add_param(nullptr, PARAM_TYPE_GROUP);
 			core.limit_tuner = 0;
 			return TRUE;
@@ -5331,7 +5316,7 @@ int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, in
 				return FALSE;
 			core.synchro_materials.clear();
 			pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
-			pduel->lua->add_param(-2, PARAM_TYPE_INDEX);
+			pduel->lua->add_param(filter2, PARAM_TYPE_FUNCTION);
 			pduel->lua->add_param(min, PARAM_TYPE_INT);
 			pduel->lua->add_param(max, PARAM_TYPE_INT);
 			core.sub_solving_event.push_back(nil_event);
@@ -5342,7 +5327,6 @@ int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, in
 		return FALSE;
 	}
 	case 2: {
-		lua_pop(pduel->lua->current_state, 3);
 		group* pgroup = pduel->new_group(core.synchro_materials);
 		pgroup->container.insert(core.limit_tuner);
 		pduel->lua->add_param(pgroup, PARAM_TYPE_GROUP);
@@ -5441,7 +5425,9 @@ int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, in
 					pcheck->get_value(pm);
 				if(pm->current.location == LOCATION_MZONE && !pm->is_position(POS_FACEUP))
 					continue;
-				if(!pduel->lua->check_matching(pm, -2, 1))
+				pduel->lua->add_param(pm, PARAM_TYPE_CARD);
+				pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
+				if (!pduel->lua->check_condition(filter2, 2))
 					continue;
 				nsyn.push_back(pm);
 				pm->sum_param = pm->get_synchro_level(pcard);
@@ -5462,7 +5448,9 @@ int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, in
 					pcheck->get_value(pm);
 				if(pm->current.location == LOCATION_MZONE && !pm->is_position(POS_FACEUP))
 					continue;
-				if(!pduel->lua->check_matching(pm, -2, 1))
+				pduel->lua->add_param(pm, PARAM_TYPE_CARD);
+				pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
+				if (!pduel->lua->check_condition(filter2, 2))
 					continue;
 				nsyn.push_back(pm);
 				pm->sum_param = pm->get_synchro_level(pcard);
@@ -5593,7 +5581,6 @@ int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, in
 		return FALSE;
 	}
 	case 8: {
-		lua_pop(pduel->lua->current_state, 3);
 		group* pgroup = pduel->new_group();
 		int32 mcount = (int32)core.must_select_cards.size();
 		for(int32 i = mcount; i < returns.bvalue[0]; ++i) {
@@ -5608,7 +5595,6 @@ int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, in
 		return TRUE;
 	}
 	case 9: {
-		lua_pop(pduel->lua->current_state, 3);
 		group* pgroup = pduel->new_group();
 		pgroup->container.insert(core.limit_tuner);
 		pgroup->container.insert(smat);

--- a/operations.cpp
+++ b/operations.cpp
@@ -5516,8 +5516,8 @@ int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, in
 		select_cards->swap(core.select_cards);
 		card_vector* must_select_cards = new card_vector;
 		must_select_cards->swap(core.must_select_cards);
-		core.units.begin()->ptr1 = select_cards;
-		core.units.begin()->ptr2 = must_select_cards;
+		core.units.begin()->ptr3 = select_cards;
+		core.units.begin()->ptr4 = must_select_cards;
 		pduel->write_buffer8(MSG_HINT);
 		pduel->write_buffer8(HINT_SELECTMSG);
 		pduel->write_buffer8(playerid);
@@ -5527,10 +5527,10 @@ int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, in
 	}
 	case 6: {
 		card* pcard = core.select_cards[returns.bvalue[1]];
-		card_vector* select_cards = (card_vector*)core.units.begin()->ptr1;
+		card_vector* select_cards = (card_vector*)core.units.begin()->ptr3;
 		auto it = std::find(select_cards->begin(), select_cards->end(), pcard);
 		select_cards->erase(it);
-		card_vector* must_select_cards = (card_vector*)core.units.begin()->ptr2;
+		card_vector* must_select_cards = (card_vector*)core.units.begin()->ptr4;
 		must_select_cards->push_back(pcard);
 		select_cards->swap(core.select_cards);
 		must_select_cards->swap(core.must_select_cards);

--- a/operations.cpp
+++ b/operations.cpp
@@ -5287,7 +5287,7 @@ int32 field::activate_effect(uint16 step, effect* peffect) {
 	}
 	return TRUE;
 }
-int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, int32 min, int32 max, card* smat, group* mg) {
+int32 field::select_synchro_material(int16 step, uint8 playerid, card* pcard, int32 min, int32 max, card* smat, group* mg, int32 filter1, int32 filter2) {
 	switch(step) {
 	case 0: {
 		core.select_cards.clear();

--- a/processor.cpp
+++ b/processor.cpp
@@ -610,9 +610,9 @@ uint32 field::process() {
 	case PROCESSOR_SELECT_SYNCHRO: {
 		int32 ret = TRUE;
 		if(!(it->arg1 >> 16))
-			ret = select_synchro_material(it->step, it->arg1 & 0xffff, (card*)it->ptarget, it->arg2 & 0xffff, it->arg2 >> 16, 0, (group*)it->peffect);
+			ret = select_synchro_material(it->step, it->arg1 & 0xffff, (card*)it->ptr1, it->arg2 & 0xffff, it->arg2 >> 16, nullptr, (group*)it->ptr2);
 		else
-			ret = select_synchro_material(it->step, it->arg1 & 0xffff, (card*)it->ptarget, it->arg2 & 0xffff, it->arg2 >> 16, (card*)it->peffect, 0);
+			ret = select_synchro_material(it->step, it->arg1 & 0xffff, (card*)it->ptr1, it->arg2 & 0xffff, it->arg2 >> 16, (card*)it->ptr2, nullptr);
 		if(ret)
 			core.units.pop_front();
 		else

--- a/processor.cpp
+++ b/processor.cpp
@@ -609,10 +609,10 @@ uint32 field::process() {
 	}
 	case PROCESSOR_SELECT_SYNCHRO: {
 		int32 ret = TRUE;
-		if(!(it->arg1 >> 16))
-			ret = select_synchro_material(it->step, it->arg1 & 0xffff, (card*)it->ptr1, it->arg2 & 0xffff, it->arg2 >> 16, nullptr, (group*)it->ptr2);
+		if (!(it->arg1 >> 16))
+			ret = select_synchro_material(it->step, it->arg1 & 0xffff, (card*)it->ptr1, it->arg2 & 0xffff, it->arg2 >> 16, nullptr, (group*)it->ptr2, it->arg3, it->arg4);
 		else
-			ret = select_synchro_material(it->step, it->arg1 & 0xffff, (card*)it->ptr1, it->arg2 & 0xffff, it->arg2 >> 16, (card*)it->ptr2, nullptr);
+			ret = select_synchro_material(it->step, it->arg1 & 0xffff, (card*)it->ptr1, it->arg2 & 0xffff, it->arg2 >> 16, (card*)it->ptr2, nullptr, it->arg3, it->arg4);
 		if(ret)
 			core.units.pop_front();
 		else

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -365,7 +365,6 @@ public:
 	static int32 group_get_next(lua_State *L);
 	static int32 group_get_first(lua_State *L);
 	static int32 group_get_count(lua_State *L);
-	static int32 group_for_each(lua_State *L);
 	static int32 group_filter(lua_State *L);
 	static int32 group_filter_count(lua_State *L);
 	static int32 group_filter_select(lua_State *L);


### PR DESCRIPTION
# Add interpreter::check_filter
`check_matching` is replaced by `check_filter`, which takes lua_State* as 1st parameter.

This function is usually called from Lua functions like:
```cpp
int32 scriptlib::duel_select_matching_cards(lua_State *L);
```
The arguments are on the stack of L, so the function indices are also the index of L.

# Add ptr3, ptr4 to processor_unit 
d5accce
Avoid unnecessary pointer casting.

#  Push pcard in check_tuner_material 
A new parameter `scard` is added to  Card.IsNotTuner in 3c46099, and the new parameter is pushed onto the stack before every function call to `check_tuner_material` or`check_synchro_material`.
It will make the stack tracing very hard.

0101614
Because we have the pointer to L now, we can push the synchro monster `pcard` is onto the stack of L before `check_filter`.
It will make the stack tracing easier.

# Always take `mg` first
c752dee93a75c440330c9c2f53bd430f478e9c8e
Before:
In `duel_select_synchro_material`, `smat` will be ignored if `mg` is given.
In `duel_check_synchro_material`, `smat` will not be ignored if `mg` is given.

Now:
`smat` will always be ignored if `mg` is given.

# Remove lua_pop in synchro procedures
https://github.com/Fluorohydride/ygopro/issues/2407
I agree that passing Lua functions by pushing onto the stack is a bad idea too.

## Problems in https://github.com/Fluorohydride/ygopro/issues/2406
https://www.lua.org/manual/5.4/manual.html#lua_status
You can call functions only in threads with status [LUA_OK](https://www.lua.org/manual/5.4/manual.html#pdf-LUA_OK). You can resume threads with status [LUA_OK](https://www.lua.org/manual/5.4/manual.html#pdf-LUA_OK) (to start a new coroutine) or [LUA_YIELD](https://www.lua.org/manual/5.4/manual.html#pdf-LUA_YIELD) (to resume a coroutine).

Before #582
In order to reuse the arguments on the stack, ygopro used the yielded thread to call new functions.
It is not allowed by Lua, so the assertion of LUA_USE_APICHECK will fail.

After #582 
Now we restore `current_state` after `lua_resume` returns.
The Lua treads are:
lua_state
rthread (The arguments of coroutine are here)

So we have to use `lua_xmove` to move the arguments to another stack.

## Problems in https://github.com/Fluorohydride/ygopro/issues/2407
Pushing the arguments on the stack of rthread and moving to another stack is harmful.
It will make the stack tracing hard as hell.

The heap corruption still happens after #582 .
I think it is caused by the same problems in https://github.com/Fluorohydride/ygopro/issues/2407

## Solution
If we want to use Lua functions or any objects after the coroutine yields:
We can use reference in Lua registry instead.

If we want to call a Lua filter outside the Lua functions:
We can use `interpreter::check_condition` instead.

Now the functions filter1 and filter2 are passed to `select_synchro_material` by the reference in registry.
We don't need to use `PARAM_TYPE_INDEX` anymore.
fix https://github.com/Fluorohydride/ygopro/issues/2407

# remove  Group.ForEach 
https://github.com/edo9300/ygopro-core/commit/de60f7982a2a2faae24d5fb03f36b4eb14b0b6c8
I have reached the same conclusion.
`Group.ForEach` is not used in ygopro-scripts now.
It can (and should) be replaced by normal for-loop in Lua.

`PARAM_TYPE_INDEX` is not used now.

----
https://github.com/Fluorohydride/ygopro/issues/2406
https://github.com/Fluorohydride/ygopro/issues/2407
Lua線程
lua_state（主線程）
rthread （呼叫coroutine使用)

原本的傳遞參數方式
函數f1 push到rthread的堆疊
lua_xmove移動到主線程
傳遞f1在主線程堆疊的index
手動從主線程的堆疊pop

這是 @mercury233 記錄在2407的問題
這會讓堆疊的管理變得非常麻煩並且容易出錯
我認為同步召喚有時會產生的heap corruption的主要原因是這個

現在改成
傳遞函數都用registry reference
這是每個線程共通的數值
由於沒有手動push這步
也就不再需要手動pop

Group.ForEach 
這個函數會有和2407相同的問題
現有的腳本沒有使用
並且他的功能可以由普通的Lua迴圈完成
因此移除這個函數


@mercury233 
@purerosefallen 
