### PR TITLE
fix spsummon.reason_player

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2562,7 +2562,7 @@ void card::set_special_summon_status(effect* peffect) {
 			spsummon.setcode.push_back(eset[i]->get_value(pcard) & 0xffffU);
 		}
 		spsummon.reason_effect = peffect;
-		spsummon.reason_player = peffect->get_handler_player();
+		spsummon.reason_player = cait->triggering_player;
 	} else {
 		pcard = cait->triggering_effect->get_handler();
 		spsummon.code = cait->triggering_state.code;


### PR DESCRIPTION
Should always be the player who activate the effect.

> Q.
「ゴブリンドバーグ」が効果を発動し、チェーンして「DNA改造手術」を発動して獣族を宣言し、その後、獣族のその「ゴブリンドバーグ」が「森の聖獣 カラントーサ」を特殊召喚した場合、その「森の聖獣 カラントーサ」の効果を発動することはできますか？
A.
ご質問の場合、「ゴブリンドバーグ」の効果を発動した一連のチェーン処理後に、自分はその「森の聖獣 カラントーサ」の効果を発動できます。
 
> Q.
自分の「ゴブリンドバーグ」が効果を発動し、「スウィッチヒーロー」をチェーンで発動し、その後、相手がコントロールしていたその「ゴブリンドバーグ」がモンスターを特殊召喚した場合、自分の墓地の「赫焉竜グランギニョル」が②の効果を発動することはできますか？
A.
ご質問の場合、自分は「赫焉竜グランギニョル」の『②』の効果を発動できません。