### PR TITLE
keep last active_type until the next activate

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -299,7 +299,7 @@ int32 effect::is_activateable(uint8 playerid, const tevent& e, int32 neglect_con
 				return FALSE;
 		} else if(!(type & EFFECT_TYPE_CONTINUOUS)) {
 			card* phandler = get_handler();
-			if(!(phandler->get_type() & TYPE_MONSTER) && (get_active_type() & TYPE_MONSTER))
+			if(!(phandler->get_type() & TYPE_MONSTER) && (get_active_type(FALSE) & TYPE_MONSTER))
 				return FALSE;
 			if((type & EFFECT_TYPE_QUICK_O) && is_flag(EFFECT_FLAG_DELAY) && !in_range(phandler))
 				return FALSE;
@@ -837,9 +837,9 @@ void effect::set_active_type() {
 	if(active_type & TYPE_TRAPMONSTER)
 		active_type &= ~TYPE_TRAP;
 }
-uint32 effect::get_active_type() {
+uint32 effect::get_active_type(uint8 uselast) {
 	if(type & 0x7f0) {
-		if(active_type)
+		if(active_type && uselast)
 			return active_type;
 		else if((type & EFFECT_TYPE_ACTIVATE) && (get_handler()->data.type & TYPE_PENDULUM))
 			return TYPE_PENDULUM + TYPE_SPELL;

--- a/effect.h
+++ b/effect.h
@@ -109,7 +109,7 @@ public:
 	int32 in_range(const chain& ch);
 	void set_activate_location();
 	void set_active_type();
-	uint32 get_active_type();
+	uint32 get_active_type(uint8 uselast = TRUE);
 	int32 get_code_type() const;
 
 	bool is_flag(effect_flag x) const {

--- a/processor.cpp
+++ b/processor.cpp
@@ -4497,7 +4497,8 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 					destroy(fscard, 0, REASON_RULE, 1 - pcard->current.controler);
 			}
 		}
-		peffect->active_type = 0;
+		// keep last active_type until the next activate, for the using in script
+		// peffect->active_type = 0;
 		peffect->active_handler = 0;
 		pcard->release_relation(*cait);
 		if(cait->target_cards)


### PR DESCRIPTION
Problem:
In the condition of `EVENT_CHAINING` effects, the script may need to check `re:IsActiveType`.
If the re handler change its type in chain (_Centur-Ion Trudea_), `re:IsActiveType` should return the type when re was activating.
We set and return `active_type` to solve this problem.
But if `EVENT_CHAINING` effect check `re:IsActiveType` after the chain solve (`EFFECT_FLAG_ACTIVATE_CONDITION`, _Kashtira Preparations_), the `active_type` will be reset at that time.

Solution:
Don't reset. Generally `effect::get_active_type` won't be used outside `EVENT_CHAINING`.