### PR TITLE
update deck sequence

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -95,7 +95,7 @@ bool card::card_operation_sort(card* c1, card* c2) {
 			return c1->overlay_target->current.sequence < c2->overlay_target->current.sequence;
 		else
 			return c1->current.sequence < c2->current.sequence;
-	} else if (c1->current.location & LOCATION_DECK && cp1 == pduel->game_field->core.selecting_player && !pduel->game_field->core.select_deck_seq_preserved) {
+	} else if (c1->current.location & LOCATION_DECK && pduel->game_field->is_select_hide_deck_sequence(cp1)) {
 		// if deck reversed and the card being at the top, it should go first
 		if(pduel->game_field->core.deck_reversed) {
 			if(c1->current.sequence == pduel->game_field->player[cp1].list_main.size() - 1)
@@ -1511,7 +1511,7 @@ int32 card::is_all_column() {
 	return FALSE;
 }
 uint8 card::get_select_sequence(uint8 *deck_seq_pointer) {
-	if(current.location == LOCATION_DECK && current.controler == pduel->game_field->core.selecting_player && !pduel->game_field->core.select_deck_seq_preserved) {
+	if(current.location == LOCATION_DECK && pduel->game_field->is_select_hide_deck_sequence(current.controler)) {
 		return (*deck_seq_pointer)++;
 	} else {
 		return current.sequence;

--- a/common.h
+++ b/common.h
@@ -418,6 +418,7 @@ typedef signed char int8;
 #define DUEL_TAG_MODE			0x20
 #define DUEL_SIMPLE_AI			0x40
 #define DUEL_RETURN_DECK_TOP	0x80
+#define DUEL_REVEAL_DECK_SEQ	0x100
 
 //Activity
 #define ACTIVITY_SUMMON			1

--- a/field.cpp
+++ b/field.cpp
@@ -2293,6 +2293,9 @@ int32 field::check_spsummon_counter(uint8 playerid, uint8 ct) {
 	}
 	return TRUE;
 }
+bool field::is_select_hide_deck_sequence(uint8 playerid) {
+	return !core.select_deck_sequence_revealed && !(core.duel_options & DUEL_REVEAL_DECK_SEQ) && playerid == core.selecting_player;
+}
 int32 field::check_lp_cost(uint8 playerid, uint32 lp, uint32 must_pay) {
 	effect_set eset;
 	int32 val = lp;

--- a/field.h
+++ b/field.h
@@ -463,6 +463,7 @@ public:
 	void check_chain_counter(effect* peffect, int32 playerid, int32 chainid, bool cancel = false);
 	void set_spsummon_counter(uint8 playerid);
 	int32 check_spsummon_counter(uint8 playerid, uint8 ct = 1);
+	bool is_select_hide_deck_sequence(uint8 playerid);
 
 	int32 check_lp_cost(uint8 playerid, uint32 cost, uint32 must_pay);
 	void save_lp_cost() {}

--- a/field.h
+++ b/field.h
@@ -350,7 +350,7 @@ struct processor {
 	uint32 hint_timing[2]{};
 	uint8 current_player{ PLAYER_NONE };
 	uint8 conti_player{ PLAYER_NONE };
-	uint8 select_deck_seq_preserved{ FALSE };
+	uint8 select_deck_sequence_revealed{ FALSE };
 	uint8 selecting_player{ PLAYER_NONE };
 	std::unordered_map<uint32, std::pair<uint32, uint32>> summon_counter;
 	std::unordered_map<uint32, std::pair<uint32, uint32>> normalsummon_counter;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1546,12 +1546,12 @@ int32 scriptlib::duel_disable_self_destroy_check(lua_State* L) {
 	pduel->game_field->core.selfdes_disabled = disable;
 	return 0;
 }
-int32 scriptlib::duel_preserve_select_deck_seq(lua_State* L) {
+int32 scriptlib::duel_reveal_select_deck_sequence(lua_State* L) {
 	duel* pduel = interpreter::get_duel_info(L);
-	uint8 preserve = TRUE;
+	uint8 reveal = TRUE;
 	if(lua_gettop(L) > 0)
-		preserve = lua_toboolean(L, 1);
-	pduel->game_field->core.select_deck_seq_preserved = preserve;
+		reveal = lua_toboolean(L, 1);
+	pduel->game_field->core.select_deck_sequence_revealed = reveal;
 	return 0;
 }
 int32 scriptlib::duel_shuffle_deck(lua_State *L) {
@@ -4876,7 +4876,7 @@ static const struct luaL_Reg duellib[] = {
 	{ "DiscardHand", scriptlib::duel_discard_hand },
 	{ "DisableShuffleCheck", scriptlib::duel_disable_shuffle_check },
 	{ "DisableSelfDestroyCheck", scriptlib::duel_disable_self_destroy_check },
-	{ "PreserveSelectDeckSequence", scriptlib::duel_preserve_select_deck_seq },
+	{ "RevealSelectDeckSequence", scriptlib::duel_reveal_select_deck_sequence },
 	{ "ShuffleDeck", scriptlib::duel_shuffle_deck },
 	{ "ShuffleExtra", scriptlib::duel_shuffle_extra },
 	{ "ShuffleHand", scriptlib::duel_shuffle_hand },

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -462,7 +462,7 @@ public:
 	static int32 duel_discard_hand(lua_State *L);
 	static int32 duel_disable_shuffle_check(lua_State *L);
 	static int32 duel_disable_self_destroy_check(lua_State *L);
-	static int32 duel_preserve_select_deck_seq(lua_State *L);
+	static int32 duel_reveal_select_deck_sequence(lua_State *L);
 	static int32 duel_shuffle_deck(lua_State *L);
 	static int32 duel_shuffle_extra(lua_State *L);
 	static int32 duel_shuffle_hand(lua_State *L);


### PR DESCRIPTION
In puzzle mode, the player should know the sequence of cards in deck when selecting cards.

-----

`preserve` don't make sense, it should be called **reveal**, and use **hide** as counterpart.