### PR TITLE
ocgapi: update signature of start_duel(), add player_info::szone_size

### DIFF
--- a/common.h
+++ b/common.h
@@ -43,6 +43,7 @@ typedef signed char int8;
 #define NULL 0
 #endif
 
+#define MASTER_RULE3		3	//Master Rule 3 (2014)
 #define NEW_MASTER_RULE		4	//New Master Rule (2017)
 #define MASTER_RULE_2020	5	//Master Rule 2020
 #define CURRENT_RULE		5

--- a/field.cpp
+++ b/field.cpp
@@ -280,10 +280,10 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 				if (playerid == preplayer && sequence == presequence)
 					return;
 				if(location == LOCATION_MZONE) {
-					if(sequence >= player[playerid].list_mzone.size() || player[playerid].list_mzone[sequence])
+					if(sequence >= (int32)player[playerid].list_mzone.size() || player[playerid].list_mzone[sequence])
 						return;
 				} else {
-					if(sequence >= player[playerid].list_szone.size() || player[playerid].list_szone[sequence])
+					if(sequence >= player[playerid].szone_size || player[playerid].list_szone[sequence])
 						return;
 				}
 				if(preplayer == playerid) {
@@ -491,14 +491,14 @@ card* field::get_field_card(uint8 playerid, uint32 general_location, uint8 seque
 		return nullptr;
 	switch(general_location) {
 	case LOCATION_MZONE: {
-		if(sequence < player[playerid].list_mzone.size())
+		if(sequence < (int32)player[playerid].list_mzone.size())
 			return player[playerid].list_mzone[sequence];
 		else
 			return nullptr;
 		break;
 	}
 	case LOCATION_SZONE: {
-		if(sequence < player[playerid].list_szone.size())
+		if(sequence < player[playerid].szone_size)
 			return player[playerid].list_szone[sequence];
 		else
 			return nullptr;
@@ -565,7 +565,7 @@ int32 field::is_location_useable(uint8 playerid, uint32 general_location, uint8 
 		return FALSE;
 	uint32 flag = player[playerid].disabled_location | player[playerid].used_location;
 	if (general_location == LOCATION_MZONE) {
-		if (sequence >= (int32)player[0].list_mzone.size())
+		if (sequence >= (int32)player[playerid].list_mzone.size())
 			return FALSE;
 		if(flag & (0x1u << sequence))
 			return FALSE;
@@ -575,7 +575,7 @@ int32 field::is_location_useable(uint8 playerid, uint32 general_location, uint8 
 				return FALSE;
 		}
 	} else if (general_location == LOCATION_SZONE) {
-		if (sequence >= (int32)player[0].list_szone.size())
+		if (sequence >= player[playerid].szone_size)
 			return FALSE;
 		if(flag & (0x100u << sequence))
 			return FALSE;
@@ -1107,7 +1107,7 @@ void field::refresh_player_info(uint8 playerid) {
 		if (player[playerid].list_mzone[i])
 			used_flag |= 0x1U << i;
 	}
-	for (int32 i = 0; i < (int32)player[playerid].list_szone.size(); ++i) {
+	for (int32 i = 0; i < player[playerid].szone_size; ++i) {
 		if (player[playerid].list_szone[i])
 			used_flag |= 0x100U << i;
 	}

--- a/field.cpp
+++ b/field.cpp
@@ -55,25 +55,7 @@ bool tevent::operator< (const tevent& v) const {
 }
 field::field(duel* pduel) {
 	this->pduel = pduel;
-	infos.field_id = 1;
-	infos.copy_id = 1;
-	infos.can_shuffle = TRUE;
-	infos.turn_id = 0;
-	infos.turn_id_by_player[0] = 0;
-	infos.turn_id_by_player[1] = 0;
-	infos.card_id = 1;
-	infos.phase = 0;
-	infos.turn_player = 0;
 	for (int32 i = 0; i < 2; ++i) {
-		//cost[i].count = 0;
-		//cost[i].amount = 0;
-		player[i].lp = 8000;
-		player[i].start_count = 5;
-		player[i].draw_count = 1;
-		player[i].disabled_location = 0;
-		player[i].used_location = 0;
-		player[i].extra_p_count = 0;
-		player[i].tag_extra_p_count = 0;
 		player[i].list_mzone.resize(7, 0);
 		player[i].list_szone.resize(8, 0);
 		player[i].list_main.reserve(60);
@@ -82,8 +64,6 @@ field::field(duel* pduel) {
 		player[i].list_remove.reserve(75);
 		player[i].list_extra.reserve(30);
 	}
-	returns = { 0 };
-	temp_card = nullptr;
 }
 void field::reload_field_info() {
 	pduel->write_buffer8(MSG_RELOAD_FIELD);

--- a/field.h
+++ b/field.h
@@ -80,9 +80,9 @@ struct chain {
 };
 
 struct player_info {
-	int32 lp{ 0 };
-	int32 start_count{ 0 };
-	int32 draw_count{ 0 };
+	int32 lp{ 8000 };
+	int32 start_count{ 5 };
+	int32 draw_count{ 1 };
 	uint32 used_location{ 0 };
 	uint32 disabled_location{ 0 };
 	uint32 extra_p_count{ 0 };
@@ -127,19 +127,19 @@ struct field_effect {
 	grant_effect_container grant_effect;
 };
 struct field_info {
-	int32 field_id{ 0 };
-	int16 copy_id{ 0 };
-	int16 turn_id{ 0 };
+	int32 field_id{ 1 };
+	int16 copy_id{ 1 };
+	int16 turn_id{};
 	int16 turn_id_by_player[2]{};
-	int16 card_id{ 0 };
-	uint16 phase{ 0 };
-	uint8 turn_player{ 0 };
+	int16 card_id{ 1 };
+	uint16 phase{};
+	uint8 turn_player{};
 	uint8 priorities[2]{};
 	uint8 can_shuffle{ TRUE };
 };
 struct lpcost {
-	int32 count{ 0 };
-	int32 amount{ 0 };
+	int32 count{};
+	int32 amount{};
 	int32 lpstack[8]{};
 };
 struct processor_unit {
@@ -306,7 +306,7 @@ struct processor {
 	uint8 extra_summon[2]{};
 	int32 spe_effect[2]{};
 	int32 last_select_hint[2]{ 0 };
-	int32 duel_options{ 0 };
+	uint32 duel_options{ 0 };
 	int32 duel_rule{ CURRENT_RULE };
 	uint32 copy_reset{ 0 };
 	int32 copy_reset_count{ 0 };
@@ -374,12 +374,12 @@ public:
 
 	duel* pduel;
 	player_info player[2];
-	card* temp_card;
+	card* temp_card{};
 	field_info infos;
 	//lpcost cost[2];
 	field_effect effects;
 	processor core;
-	return_value returns;
+	return_value returns{};
 	tevent nil_event;
 
 	static int32 field_used_count[32];

--- a/field.h
+++ b/field.h
@@ -87,6 +87,7 @@ struct player_info {
 	uint32 disabled_location{ 0 };
 	uint32 extra_p_count{ 0 };
 	uint32 tag_extra_p_count{ 0 };
+	int32 szone_size{ 6 };
 	card_vector list_mzone;
 	card_vector list_szone;
 	card_vector list_main;

--- a/libdebug.cpp
+++ b/libdebug.cpp
@@ -148,6 +148,10 @@ int32 scriptlib::debug_reload_field_begin(lua_State *L) {
 		pduel->game_field->core.duel_rule = 1;
 	else
 		pduel->game_field->core.duel_rule = CURRENT_RULE;
+	if (pduel->game_field->core.duel_rule == MASTER_RULE3) {
+		pduel->game_field->player[0].szone_size = 8;
+		pduel->game_field->player[1].szone_size = 8;
+	}
 	return 0;
 }
 int32 scriptlib::debug_reload_field_end(lua_State *L) {

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -64,7 +64,7 @@ extern "C" DECL_DLLEXPORT intptr_t create_duel(uint_fast32_t seed) {
 	pduel->random.reset(seed);
 	return (intptr_t)pduel;
 }
-extern "C" DECL_DLLEXPORT void start_duel(intptr_t pduel, int32 options) {
+extern "C" DECL_DLLEXPORT void start_duel(intptr_t pduel, uint32 options) {
 	duel* pd = (duel*)pduel;
 	pd->game_field->core.duel_options |= options & 0xffff;
 	int32 duel_rule = options >> 16;
@@ -72,8 +72,12 @@ extern "C" DECL_DLLEXPORT void start_duel(intptr_t pduel, int32 options) {
 		pd->game_field->core.duel_rule = duel_rule;
 	else if(options & DUEL_OBSOLETE_RULING)		//provide backward compatibility with replay
 		pd->game_field->core.duel_rule = 1;
-	else if(!pd->game_field->core.duel_rule)
+	if (pd->game_field->core.duel_rule < 1 || pd->game_field->core.duel_rule > CURRENT_RULE)
 		pd->game_field->core.duel_rule = CURRENT_RULE;
+	if (pd->game_field->core.duel_rule == MASTER_RULE3) {
+		pd->game_field->player[0].szone_size = 8;
+		pd->game_field->player[1].szone_size = 8;
+	}
 	pd->game_field->core.shuffle_hand_check[0] = FALSE;
 	pd->game_field->core.shuffle_hand_check[1] = FALSE;
 	pd->game_field->core.shuffle_deck_check[0] = FALSE;

--- a/ocgapi.h
+++ b/ocgapi.h
@@ -39,7 +39,7 @@ uint32 read_card(uint32 code, card_data* data);
 uint32 handle_message(void* pduel, uint32 message_type);
 
 extern "C" DECL_DLLEXPORT intptr_t create_duel(uint_fast32_t seed);
-extern "C" DECL_DLLEXPORT void start_duel(intptr_t pduel, int32 options);
+extern "C" DECL_DLLEXPORT void start_duel(intptr_t pduel, uint32 options);
 extern "C" DECL_DLLEXPORT void end_duel(intptr_t pduel);
 extern "C" DECL_DLLEXPORT void set_player_info(intptr_t pduel, int32 playerid, int32 lp, int32 startcount, int32 drawcount);
 extern "C" DECL_DLLEXPORT void get_log_message(intptr_t pduel, char* buf);


### PR DESCRIPTION
![bug-szone6](https://github.com/user-attachments/assets/959645a9-b670-4b83-aa60-3988f4a72c79)

list_szone[6], list_szone[7] still exist in current rule.
We can use `Debug.AddCard` to add a card in those zones.

Solution:
player_info::szone_size
The actual size of LOCATION_SZONE in current rule (6 by default).
If the duel is started by MASTER_RULE3, it will become 8.

ocgapi: update signature of start_duel() 
```cpp
extern "C" DECL_DLLEXPORT void start_duel(intptr_t pduel, uint32 options);
```
`options` is a bit field:
0xFFFF0000
duel_rule

0x0000FFFF
duel options

Right shift on signed integer might cause undefined behavior.

@mercury233 
@purerosefallen 

