### PR TITLE
Reorder EFFECT_BATTLE_DESTROY_REDIRECT and STATUS_DESTROY_CONFIRMED

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -3049,13 +3049,13 @@ int32 field::process_battle_command(uint16 step) {
 			core.attacker->current.reason_player = core.attack_target->current.controler;
 			uint32 dest = LOCATION_GRAVE;
 			uint32 seq = 0;
+			core.attacker->set_status(STATUS_DESTROY_CONFIRMED, TRUE);
 			if((peffect = core.attack_target->is_affected_by_effect(EFFECT_BATTLE_DESTROY_REDIRECT)) && (core.attacker->data.type & TYPE_MONSTER)) {
 				dest = peffect->get_value(core.attacker);
 				seq = dest >> 16;
 				dest &= 0xffff;
 			}
 			core.attacker->sendto_param.set(core.attacker->owner, POS_FACEUP, dest, seq);
-			core.attacker->set_status(STATUS_DESTROY_CONFIRMED, TRUE);
 		}
 		if(core.attack_target && core.attack_target->is_status(STATUS_BATTLE_RESULT)
 		        && core.attack_target->current.location == LOCATION_MZONE && core.attack_target->fieldid_r == core.pre_field[1]) {


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22112&keyword=&tag=-1&request_locale=ja
> Question
相手のモンスターゾーンに「[ヴェンデット・バスタード](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13534)」が表側攻撃表示で存在しています。
この状況で、「[ヴェンデット・コア](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13535)」を使用して儀式召喚された自分の「[リヴェンデット・スレイヤー](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13208)」が相手の「[ヴェンデット・バスタード](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13534)」を攻撃した際に、『①：このカードが相手モンスターと戦闘を行うダメージ計算時に１度、自分の墓地からアンデット族モンスター１体を除外して発動できる。このカードの攻撃力は３００アップする』モンスター効果を発動した事で同じ攻撃力となり、互いに戦闘で破壊される場合、得ている『●このカードが戦闘で破壊したモンスターは墓地へは行かず除外される』効果は適用されますか？
Answer
「[ヴェンデット・アニマ](https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=13705)」を使用して儀式召喚を行った事によって得ている『このカードが戦闘で破壊したモンスターは墓地へは行かず除外される』効果は、質問の状況のように、その儀式モンスターが同じ攻撃力のモンスターと戦闘を行い、互いに破壊されている場合には適用されません。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=19878&request_locale=ja
> ②：自分の「メメント」モンスターが戦闘で破壊したモンスターは墓地へは行かず除外される。
【②の効果について】
このカードが同じ攻撃力のモンスターと戦闘を行い、互いに破壊される場合、相手モンスターは除外されません。