### PR TITLE
Update card::get_attribute() and card::get_race()

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1171,21 +1171,18 @@ uint32 card::get_race() {
 	if(temp.race != UINT32_MAX) // prevent recursion, return the former value
 		return temp.race;
 	effect_set effects;
-	int32 race = data.race;
+	auto race = data.race;
 	temp.race = data.race;
 	filter_effect(EFFECT_ADD_RACE, &effects, FALSE);
-	filter_effect(EFFECT_REMOVE_RACE, &effects);
+	filter_effect(EFFECT_REMOVE_RACE, &effects, FALSE);
+	filter_effect(EFFECT_CHANGE_RACE, &effects);
 	for (int32 i = 0; i < effects.size(); ++i) {
 		if (effects[i]->code == EFFECT_ADD_RACE)
 			race |= effects[i]->get_value(this);
-		else
+		else if (effects[i]->code == EFFECT_REMOVE_RACE)
 			race &= ~(effects[i]->get_value(this));
-		temp.race = race;
-	}
-	effects.clear();
-	filter_effect(EFFECT_CHANGE_RACE, &effects);
-	for (int32 i = 0; i < effects.size(); ++i) {
-		race = effects[i]->get_value(this);
+		else if (effects[i]->code == EFFECT_CHANGE_RACE)
+			race = effects[i]->get_value(this);
 		temp.race = race;
 	}
 	temp.race = UINT32_MAX;

--- a/card.cpp
+++ b/card.cpp
@@ -1108,17 +1108,14 @@ uint32 card::get_attribute() {
 	temp.attribute = data.attribute;
 	filter_effect(EFFECT_ADD_ATTRIBUTE, &effects, FALSE);
 	filter_effect(EFFECT_REMOVE_ATTRIBUTE, &effects);
+	filter_effect(EFFECT_CHANGE_ATTRIBUTE, &effects);
 	for (int32 i = 0; i < effects.size(); ++i) {
 		if (effects[i]->code == EFFECT_ADD_ATTRIBUTE)
 			attribute |= effects[i]->get_value(this);
-		else
+		else if (effects[i]->code == EFFECT_REMOVE_ATTRIBUTE)
 			attribute &= ~(effects[i]->get_value(this));
-		temp.attribute = attribute;
-	}
-	effects.clear();
-	filter_effect(EFFECT_CHANGE_ATTRIBUTE, &effects);
-	for (int32 i = 0; i < effects.size(); ++i) {
-		attribute = effects[i]->get_value(this);
+		else if (effects[i]->code == EFFECT_CHANGE_ATTRIBUTE)
+			attribute = effects[i]->get_value(this);
 		temp.attribute = attribute;
 	}
 	temp.attribute = UINT32_MAX;

--- a/card.cpp
+++ b/card.cpp
@@ -1104,10 +1104,10 @@ uint32 card::get_attribute() {
 	if(temp.attribute != UINT32_MAX) // prevent recursion, return the former value
 		return temp.attribute;
 	effect_set effects;
-	int32 attribute = data.attribute;
+	auto attribute = data.attribute;
 	temp.attribute = data.attribute;
 	filter_effect(EFFECT_ADD_ATTRIBUTE, &effects, FALSE);
-	filter_effect(EFFECT_REMOVE_ATTRIBUTE, &effects);
+	filter_effect(EFFECT_REMOVE_ATTRIBUTE, &effects, FALSE);
 	filter_effect(EFFECT_CHANGE_ATTRIBUTE, &effects);
 	for (int32 i = 0; i < effects.size(); ++i) {
 		if (effects[i]->code == EFFECT_ADD_ATTRIBUTE)


### PR DESCRIPTION
#521 

> Ｑ：相手フィールドに《愉怪な燐のきつねびゆらら》が存在している状態で、自分が《ダーク・シムルグ》を特殊召喚した場合、《ダーク・シムルグ》の属性はどのようになりますか？
Ａ：炎属性になります。(24/01/12)

> Ｑ：相手フィールドに《愉怪な燐のきつねびゆらら》が存在している状態で、自分が《ファイアウォール・ドラゴン・ダークフルード－ネオテンペスト》の(2)の効果を発動し、光属性のモンスターを墓地へ送った場合、《ファイアウォール・ドラゴン・ダークフルード－ネオテンペスト》の属性はどのようになりますか？
Ａ：炎属性と光属性になります。(24/01/12)

> Ｑ：もう１度召喚されていない《ナチュラル・ボーン・サウルス》を対象として《千六百七十七万工房》の(1)の効果を発動している状態で、その《ナチュラル・ボーン・サウルス》に《スーペルヴィス》を装備した場合、《ナチュラル・ボーン・サウルス》の種族・属性はどのようになりますか？
Ａ：恐竜族・地属性になります。(24/01/12)
Ｑ：（上記の質問に関連して）装備されていた《スーペルヴィス》が破壊され、《ナチュラル・ボーン・サウルス》がもう１度召喚されていない状態に戻った場合、種族・属性はどのようになりますか？
Ａ：機械族の「光」「闇」「地」「水」「炎」「風」属性として扱います。(24/01/12)