### PR TITLE
24/9/19 change: return control after face-down

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2164,9 +2164,6 @@ void card::reset(uint32 id, uint32 reset_type) {
 				cmit = counters.erase(cmit);
 			}
 		}
-		if(id & RESET_TURN_SET) {
-			refresh_control_status();
-		}
 	}
 	for (auto i = indexer.begin(); i != indexer.end();) {
 		auto rm = i++;

--- a/card.cpp
+++ b/card.cpp
@@ -2165,19 +2165,7 @@ void card::reset(uint32 id, uint32 reset_type) {
 			}
 		}
 		if(id & RESET_TURN_SET) {
-			effect* peffect = std::get<effect*>(refresh_control_status());
-			if(peffect && (!(peffect->type & EFFECT_TYPE_SINGLE) || peffect->condition)) {
-				effect* new_effect = pduel->new_effect();
-				new_effect->id = peffect->id;
-				new_effect->owner = this;
-				new_effect->handler = this;
-				new_effect->type = EFFECT_TYPE_SINGLE;
-				new_effect->code = EFFECT_SET_CONTROL;
-				new_effect->value = current.controler;
-				new_effect->flag[0] = EFFECT_FLAG_CANNOT_DISABLE;
-				new_effect->reset_flag = RESET_EVENT | 0xec0000;
-				this->add_effect(new_effect);
-			}
+			refresh_control_status();
 		}
 	}
 	for (auto i = indexer.begin(); i != indexer.end();) {

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -3125,7 +3125,7 @@ int32 scriptlib::card_is_immune_to_effect(lua_State *L) {
 	check_param(L, PARAM_TYPE_EFFECT, 2);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 2);
-	lua_pushboolean(L, (int)!pcard->is_affect_by_effect(peffect));
+	lua_pushboolean(L, !pcard->is_affect_by_effect(peffect));
 	return 1;
 }
 int32 scriptlib::card_is_can_be_disabled_by_effect(lua_State* L) {

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -3125,7 +3125,7 @@ int32 scriptlib::card_is_immune_to_effect(lua_State *L) {
 	check_param(L, PARAM_TYPE_EFFECT, 2);
 	card* pcard = *(card**) lua_touserdata(L, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 2);
-	lua_pushboolean(L, !pcard->is_affect_by_effect(peffect));
+	lua_pushboolean(L, (int)!pcard->is_affect_by_effect(peffect));
 	return 1;
 }
 int32 scriptlib::card_is_can_be_disabled_by_effect(lua_State* L) {


### PR DESCRIPTION
https://db.ygoresources.com/qa#9423
https://db.ygoresources.com/qa#11049
https://db.ygoresources.com/qa#16310
https://db.ygoresources.com/qa#24100

Before:
If the control is changed by an equip card, the control will not return after flipped face-down.

Now:
The control will return.

@mercury233 
@purerosefallen 
