### PR TITLE
change effect::type to uint32, fix effect_sort_id

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -12,6 +12,10 @@
 #include "interpreter.h"
 
 bool effect_sort_id(const effect* e1, const effect* e2) {
+	int32 is_single1 = e1->is_iniital_single();
+	int32 is_single2 = e2->is_iniital_single();
+	if (is_single1 != is_single2)
+		return is_single1 > is_single2;
 	return e1->id < e2->id;
 }
 // return: code is an event reserved for EFFECT_TYPE_CONTINUOUS or not
@@ -614,6 +618,9 @@ int32 effect::is_chainable(uint8 tp) {
 }
 int32 effect::is_hand_trigger() {
 	return (range & LOCATION_HAND) && (type & EFFECT_TYPE_TRIGGER_O) && get_code_type() != CODE_PHASE;
+}
+int32 effect::is_iniital_single() const {
+	return (type & EFFECT_TYPE_SINGLE) && is_flag(EFFECT_FLAG_SINGLE_RANGE) && is_flag(EFFECT_FLAG_INITIAL);
 }
 //return: this can be reset by reset_level or not
 //RESET_DISABLE is valid only when owner == handler

--- a/effect.h
+++ b/effect.h
@@ -36,7 +36,7 @@ public:
 	uint32 code{ 0 };
 	uint32 flag[2]{};
 	uint32 id{ 0 };
-	uint16 type{ 0 };
+	uint32 type{ 0 };
 	uint16 copy_id{ 0 };
 	uint16 range{ 0 };
 	uint16 s_range{ 0 };

--- a/effect.h
+++ b/effect.h
@@ -88,6 +88,7 @@ public:
 	int32 is_immuned(card* pcard);
 	int32 is_chainable(uint8 tp);
 	int32 is_hand_trigger();
+	int32 is_iniital_single() const;
 	int32 reset(uint32 reset_level, uint32 reset_type);
 	void dec_count(uint8 playerid = PLAYER_NONE);
 	void recharge();


### PR DESCRIPTION
`effect::type`
Bit field should be uint32.

```cpp
int32 is_iniital_single() const;
```
Check if it is a EFFECT_TYPE_SINGLE continuous effect created in `initial_effect`.
(A continuous effect owned by the card, not granted by another effect.)

```cpp
bool effect_sort_id(const effect* e1, const effect* e2);
```
According to the mail in #624, continuous effect owned by the card should be applied first.

----
`effect::type`
bit field 應該使用uint32

```cpp
int32 is_iniital_single() const;
```
檢查是否為在initial_effect創建的EFFECT_TYPE_SINGLE永續效果
也就是固有（而不是用其他效果取得）的永續效果


```cpp
bool effect_sort_id(const effect* e1, const effect* e2);
```
根據 #624 的郵件結果，固有的永續效果應該先適用

- 發動DNA移植手術，宣言神屬性
- 召喚 暗黑神鸟 斯摩夫

適用順序：
1. 暗黑神鸟 斯摩夫（固有的永續效果）
2. DNA移植手術

@Wind2009-Louse
@mercury233 
@purerosefallen 