### PR TITLE
set STATUS_SUMMONING before checking EFFECT_CANNOT_DISABLE_SUMMON

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3669,8 +3669,8 @@ int32 card::is_setable_szone(uint8 playerid, uint8 ignore_fd) {
 	return TRUE;
 }
 int32 card::is_affect_by_effect(effect* reason_effect) {
-	if(is_status(STATUS_SUMMONING) && reason_effect->code != EFFECT_CANNOT_DISABLE_SUMMON && reason_effect->code != EFFECT_CANNOT_DISABLE_SPSUMMON)
-		return FALSE;
+	if (is_status(STATUS_SUMMONING))
+		return reason_effect && (reason_effect->code == EFFECT_CANNOT_DISABLE_SUMMON || reason_effect->code == EFFECT_CANNOT_DISABLE_SPSUMMON);	
 	if(!reason_effect || reason_effect->is_flag(EFFECT_FLAG_IGNORE_IMMUNE))
 		return TRUE;
 	if(reason_effect->is_immuned(this))

--- a/card.cpp
+++ b/card.cpp
@@ -3670,7 +3670,7 @@ int32 card::is_setable_szone(uint8 playerid, uint8 ignore_fd) {
 }
 int32 card::is_affect_by_effect(effect* reason_effect) {
 	if (is_status(STATUS_SUMMONING))
-		return reason_effect && (reason_effect->code == EFFECT_CANNOT_DISABLE_SUMMON || reason_effect->code == EFFECT_CANNOT_DISABLE_SPSUMMON);	
+		return reason_effect && (reason_effect->code == EFFECT_CANNOT_DISABLE_SUMMON || reason_effect->code == EFFECT_CANNOT_DISABLE_SPSUMMON);
 	if(!reason_effect || reason_effect->is_flag(EFFECT_FLAG_IGNORE_IMMUNE))
 		return TRUE;
 	if(reason_effect->is_immuned(this))

--- a/effectset.h
+++ b/effectset.h
@@ -16,6 +16,7 @@ class effect;
 
 bool effect_sort_id(const effect* e1, const effect* e2);
 
+// std::array<effect*, 64>
 struct effect_set {
 	void add_item(effect* peffect) {
 		if (count >= 64)


### PR DESCRIPTION
Problem
```lua
--[[message summoning]]
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(27125110,0,0,LOCATION_HAND,0,POS_FACEDOWN)
Debug.AddCard(84117021,0,0,LOCATION_HAND,1,POS_FACEDOWN)

Debug.AddCard(74701381,0,0,LOCATION_SZONE,0,POS_FACEDOWN)
Debug.AddCard(84749824,0,0,LOCATION_SZONE,1,POS_FACEDOWN)

Debug.AddCard(23756165,0,0,LOCATION_DECK,0,POS_FACEDOWN)
Debug.AddCard(94259633,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)

Debug.AddCard(66570171,1,1,LOCATION_DECK,0,POS_FACEDOWN)
Debug.ReloadFieldEnd()
```
- Activate DNA Surgery (declare: Illusion)
- Activate Spell Wall
- Summon Thousand-Eyes Idol

Now:
Thousand-Eyes Idol is affected by DNA Surgery when checking EFFECT_CANNOT_DISABLE_SUMMON
The summon can be negated.

Correct:
Thousand-Eyes Idol is not on the field.
The summon cannot be negated.


@mercury233 
@purerosefallen 