### PR TITLE
ocgapi change: preload_script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Get all cards in some location.
 
 - `void set_responseb(intptr_t pduel, byte* buf);`
 
-- `int32 preload_script(intptr_t pduel, const char* script, int32 len);`
+- `int32 preload_script(intptr_t pduel, const char* script_name);`
 
 
 # Lua functions

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -347,6 +347,6 @@ extern "C" DECL_DLLEXPORT void set_responsei(intptr_t pduel, int32 value) {
 extern "C" DECL_DLLEXPORT void set_responseb(intptr_t pduel, byte* buf) {
 	((duel*)pduel)->set_responseb(buf);
 }
-extern "C" DECL_DLLEXPORT int32 preload_script(intptr_t pduel, const char* script, int32 len) {
-	return ((duel*)pduel)->lua->load_script(script);
+extern "C" DECL_DLLEXPORT int32 preload_script(intptr_t pduel, const char* script_name) {
+	return ((duel*)pduel)->lua->load_script(script_name);
 }

--- a/ocgapi.h
+++ b/ocgapi.h
@@ -53,7 +53,7 @@ extern "C" DECL_DLLEXPORT int32 query_field_card(intptr_t pduel, uint8 playerid,
 extern "C" DECL_DLLEXPORT int32 query_field_info(intptr_t pduel, byte* buf);
 extern "C" DECL_DLLEXPORT void set_responsei(intptr_t pduel, int32 value);
 extern "C" DECL_DLLEXPORT void set_responseb(intptr_t pduel, byte* buf);
-extern "C" DECL_DLLEXPORT int32 preload_script(intptr_t pduel, const char* script, int32 len);
+extern "C" DECL_DLLEXPORT int32 preload_script(intptr_t pduel, const char* script_name);
 byte* default_script_reader(const char* script_name, int* len);
 uint32 default_card_reader(uint32 code, card_data* data);
 uint32 default_message_handler(intptr_t pduel, uint32 msg_type);


### PR DESCRIPTION
It is a wrapper of `interpreter::load_script` since the beginning of this submodule (2015 Sep).
The signature is misleading because the parameter is actually the script filename.

@mercury233 
@purerosefallen 