### PR TITLE
 add Effect.GetRange, IsHasRange 

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1756,6 +1756,8 @@ void card::enable_field_effect(bool enabled) {
 	filter_disable_related_cards();
 }
 int32 card::add_effect(effect* peffect) {
+	if (!peffect)
+		return 0;
 	if (get_status(STATUS_COPYING_EFFECT) && peffect->is_flag(EFFECT_FLAG_UNCOPYABLE)) {
 		pduel->uncopy.insert(peffect);
 		return 0;

--- a/card.cpp
+++ b/card.cpp
@@ -26,7 +26,7 @@ const std::unordered_map<uint32, uint32> card::second_code = {
 bool card_sort::operator()(card* const& c1, card* const& c2) const {
 	return c1->cardid < c2->cardid;
 }
-bool card_state::is_location(int32 loc) const {
+bool card_state::is_location(uint32 loc) const {
 	if((loc & LOCATION_FZONE) && location == LOCATION_SZONE && sequence == 5)
 		return true;
 	if((loc & LOCATION_PZONE) && location == LOCATION_SZONE && pzone)

--- a/card.h
+++ b/card.h
@@ -56,7 +56,7 @@ struct card_state {
 	uint8 reason_player{ PLAYER_NONE };
 	effect* reason_effect{ nullptr };
 
-	bool is_location(int32 loc) const;
+	bool is_location(uint32 loc) const;
 	bool is_main_mzone() const {
 		return location == LOCATION_MZONE && sequence >= 0 && sequence <= 4;
 	}

--- a/field.cpp
+++ b/field.cpp
@@ -1161,6 +1161,8 @@ void field::tag_swap(uint8 playerid) {
 		pduel->write_buffer32(pcard->data.code | (pcard->is_position(POS_FACEUP) ? 0x80000000 : 0));
 }
 void field::add_effect(effect* peffect, uint8 owner_player) {
+	if (!peffect)
+		return;
 	if (effects.indexer.find(peffect) != effects.indexer.end())
 		return;
 	effect_container::iterator it;

--- a/libeffect.cpp
+++ b/libeffect.cpp
@@ -12,6 +12,64 @@
 #include "effect.h"
 #include "group.h"
 
+int32 scriptlib::get_effect_property(lua_State* L, effect_member type) {
+	check_param_count(L, 1);
+	check_param(L, PARAM_TYPE_EFFECT, 1);
+	effect* peffect = *(effect**)lua_touserdata(L, 1);
+	lua_Integer value{};
+	if (peffect) {
+		switch (type) {
+		case MEMBER_CATEGORY:
+			value = peffect->category;
+			break;
+		case MEMBER_CODE:
+			value = peffect->code;
+			break;
+		case MEMBER_DESCRIPTION:
+			value = peffect->description;
+			break;
+		case MEMBER_ID:
+			value = peffect->id;
+			break;
+		case MEMBER_RANGE:
+			value = peffect->range;
+			break;
+		case MEMBER_TYPE:
+			value = peffect->type;
+			break;
+		}
+	}
+	lua_pushinteger(L, value);
+	return 1;
+}
+int32 scriptlib::is_effect_property(lua_State* L, effect_member type) {
+	check_param_count(L, 2);
+	check_param(L, PARAM_TYPE_EFFECT, 1);
+	effect* peffect = *(effect**)lua_touserdata(L, 1);
+	uint32 value{};
+	if (peffect) {
+		switch (type) {
+		case MEMBER_CATEGORY:
+			value = peffect->category;
+			break;
+		case MEMBER_CODE:
+			value = peffect->code;
+			break;
+		case MEMBER_RANGE:
+			value = peffect->range;
+			break;
+		case MEMBER_TYPE:
+			value = peffect->type;
+			break;
+		}
+	}
+	uint32 x = (uint32)lua_tointeger(L, 2);
+	if (value & x)
+		lua_pushboolean(L, 1);
+	else
+		lua_pushboolean(L, 0);
+	return 1;
+}
 int32 scriptlib::effect_new(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_CARD, 1);
@@ -52,11 +110,7 @@ int32 scriptlib::effect_reset(lua_State *L) {
 	return 0;
 }
 int32 scriptlib::effect_get_field_id(lua_State *L) {
-	check_param_count(L, 1);
-	check_param(L, PARAM_TYPE_EFFECT, 1);
-	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	lua_pushinteger(L, peffect->id);
-	return 1;
+	return get_effect_property(L, MEMBER_ID);
 }
 int32 scriptlib::effect_set_description(lua_State *L) {
 	check_param_count(L, 2);
@@ -303,34 +357,13 @@ int32 scriptlib::effect_set_owner_player(lua_State *L) {
 	return 0;
 }
 int32 scriptlib::effect_get_description(lua_State *L) {
-	check_param_count(L, 1);
-	check_param(L, PARAM_TYPE_EFFECT, 1);
-	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	if (peffect) {
-		lua_pushinteger(L, peffect->description);
-		return 1;
-	}
-	return 0;
+	return get_effect_property(L, MEMBER_DESCRIPTION);
 }
 int32 scriptlib::effect_get_code(lua_State *L) {
-	check_param_count(L, 1);
-	check_param(L, PARAM_TYPE_EFFECT, 1);
-	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	if (peffect) {
-		lua_pushinteger(L, peffect->code);
-		return 1;
-	}
-	return 0;
+	return get_effect_property(L, MEMBER_CODE);
 }
 int32 scriptlib::effect_get_type(lua_State *L) {
-	check_param_count(L, 1);
-	check_param(L, PARAM_TYPE_EFFECT, 1);
-	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	if (peffect) {
-		lua_pushinteger(L, peffect->type);
-		return 1;
-	}
-	return 0;
+	return get_effect_property(L, MEMBER_TYPE);
 }
 int32 scriptlib::effect_get_property(lua_State *L) {
 	check_param_count(L, 1);
@@ -376,14 +409,10 @@ int32 scriptlib::effect_get_label_object(lua_State *L) {
 	}
 }
 int32 scriptlib::effect_get_category(lua_State *L) {
-	check_param_count(L, 1);
-	check_param(L, PARAM_TYPE_EFFECT, 1);
-	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	if (peffect) {
-		lua_pushinteger(L, peffect->category);
-		return 1;
-	}
-	return 0;
+	return get_effect_property(L, MEMBER_CATEGORY);
+}
+int32 scriptlib::effect_get_range(lua_State* L) {
+	return get_effect_property(L, MEMBER_RANGE);
 }
 int32 scriptlib::effect_get_owner(lua_State *L) {
 	check_param_count(L, 1);
@@ -482,26 +511,13 @@ int32 scriptlib::effect_is_has_property(lua_State *L) {
 	return 1;
 }
 int32 scriptlib::effect_is_has_category(lua_State *L) {
-	check_param_count(L, 2);
-	check_param(L, PARAM_TYPE_EFFECT, 1);
-	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 tcate = (uint32)lua_tointeger(L, 2);
-	if (peffect && (peffect->category & tcate))
-		lua_pushboolean(L, 1);
-	else
-		lua_pushboolean(L, 0);
-	return 1;
+	return is_effect_property(L, MEMBER_CATEGORY);
 }
 int32 scriptlib::effect_is_has_type(lua_State *L) {
-	check_param_count(L, 2);
-	check_param(L, PARAM_TYPE_EFFECT, 1);
-	effect* peffect = *(effect**) lua_touserdata(L, 1);
-	uint32 ttype = (uint32)lua_tointeger(L, 2);
-	if (peffect && (peffect->type & ttype))
-		lua_pushboolean(L, 1);
-	else
-		lua_pushboolean(L, 0);
-	return 1;
+	return is_effect_property(L, MEMBER_TYPE);
+}
+int32 scriptlib::effect_is_has_range(lua_State* L) {
+	return is_effect_property(L, MEMBER_RANGE);
 }
 int32 scriptlib::effect_is_activatable(lua_State *L) {
 	check_param_count(L, 2);
@@ -615,6 +631,7 @@ static const struct luaL_Reg effectlib[] = {
 	{ "GetLabel", scriptlib::effect_get_label },
 	{ "GetLabelObject", scriptlib::effect_get_label_object },
 	{ "GetCategory", scriptlib::effect_get_category },
+	{ "GetRange", scriptlib::effect_get_range },
 	{ "GetOwner", scriptlib::effect_get_owner },
 	{ "GetHandler", scriptlib::effect_get_handler },
 	{ "GetCondition", scriptlib::effect_get_condition },
@@ -629,6 +646,7 @@ static const struct luaL_Reg effectlib[] = {
 	{ "IsHasProperty", scriptlib::effect_is_has_property },
 	{ "IsHasCategory", scriptlib::effect_is_has_category },
 	{ "IsHasType", scriptlib::effect_is_has_type },
+	{ "IsHasRange", scriptlib::effect_is_has_range },
 	{ "IsActivatable", scriptlib::effect_is_activatable },
 	{ "IsActivated", scriptlib::effect_is_activated },
 	{ "IsCostChecked", scriptlib::effect_is_cost_checked },

--- a/libeffect.cpp
+++ b/libeffect.cpp
@@ -201,19 +201,27 @@ int32 scriptlib::effect_set_type(lua_State *L) {
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**) lua_touserdata(L, 1);
 	uint32 v = (uint32)lua_tointeger(L, 2);
+	if (v & EFFECT_TYPE_ACTIVATE) {
+		v = EFFECT_TYPE_FIELD | EFFECT_TYPE_ACTIVATE;
+		peffect->range = LOCATION_SZONE + LOCATION_FZONE + LOCATION_HAND;
+	}
+	else if(v & EFFECT_TYPE_FLIP) {
+		peffect->code = EVENT_FLIP;
+		if (v & EFFECT_TYPE_TRIGGER_O) {
+			v = EFFECT_TYPE_SINGLE | EFFECT_TYPE_FLIP | EFFECT_TYPE_TRIGGER_O;
+			peffect->flag[0] |= EFFECT_FLAG_DELAY;
+		}
+		else {
+			v = EFFECT_TYPE_SINGLE | EFFECT_TYPE_FLIP | EFFECT_TYPE_TRIGGER_F;
+		}
+	}
+	else if (v & (EFFECT_TYPE_IGNITION | EFFECT_TYPE_QUICK_O | EFFECT_TYPE_QUICK_F)) {
+			v |= EFFECT_TYPE_FIELD;
+	}
 	if (v & (EFFECT_TYPES_CHAIN_LINK | EFFECT_TYPE_CONTINUOUS))
 		v |= EFFECT_TYPE_ACTIONS;
 	else
 		v &= ~EFFECT_TYPE_ACTIONS;
-	if(v & (EFFECT_TYPE_ACTIVATE | EFFECT_TYPE_IGNITION | EFFECT_TYPE_QUICK_O | EFFECT_TYPE_QUICK_F))
-		v |= EFFECT_TYPE_FIELD;
-	if(v & EFFECT_TYPE_ACTIVATE)
-		peffect->range = LOCATION_SZONE + LOCATION_FZONE + LOCATION_HAND;
-	if(v & EFFECT_TYPE_FLIP) {
-		peffect->code = EVENT_FLIP;
-		if(!(v & EFFECT_TYPE_TRIGGER_O))
-			v |= EFFECT_TYPE_TRIGGER_F;
-	}
 	peffect->type = v;
 	return 0;
 }

--- a/libeffect.cpp
+++ b/libeffect.cpp
@@ -46,7 +46,7 @@ int32 scriptlib::is_effect_property(lua_State* L, effect_member type) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_EFFECT, 1);
 	effect* peffect = *(effect**)lua_touserdata(L, 1);
-	uint32 value{};
+	uint64 value{};
 	if (peffect) {
 		switch (type) {
 		case MEMBER_CATEGORY:
@@ -63,7 +63,7 @@ int32 scriptlib::is_effect_property(lua_State* L, effect_member type) {
 			break;
 		}
 	}
-	uint32 x = (uint32)lua_tointeger(L, 2);
+	uint64 x = lua_tointeger(L, 2);
 	if (value & x)
 		lua_pushboolean(L, 1);
 	else

--- a/operations.cpp
+++ b/operations.cpp
@@ -4759,7 +4759,7 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 				peffect->reset_flag = RESET_EVENT + 0x1fc0000;
 				peffect->value = TYPE_MONSTER | type;
 				target->add_effect(peffect);
-				if(core.duel_rule <= 4 && (type & TYPE_TRAPMONSTER)) {
+				if(core.duel_rule <= NEW_MASTER_RULE && (type & TYPE_TRAPMONSTER)) {
 					peffect = pduel->new_effect();
 					peffect->owner = target;
 					peffect->type = EFFECT_TYPE_FIELD;

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -17,6 +17,14 @@ constexpr bool match_all(uint32 x, uint32 y) {
 
 class scriptlib {
 public:
+	enum effect_member : int32 {
+		MEMBER_CATEGORY,
+		MEMBER_CODE,
+		MEMBER_DESCRIPTION,
+		MEMBER_ID,
+		MEMBER_RANGE,
+		MEMBER_TYPE,
+	};
 	static int32 check_param(lua_State* L, int32 param_type, int32 index, int32 retfalse = FALSE);
 	static int32 check_param_count(lua_State* L, int32 count);
 	static int32 check_action_permission(lua_State* L);
@@ -299,6 +307,8 @@ public:
 	static void open_cardlib(lua_State *L);
 
 	//Effect functions
+	static int32 get_effect_property(lua_State* L, effect_member type);
+	static int32 is_effect_property(lua_State* L, effect_member type);
 	static int32 effect_new(lua_State *L);
 	static int32 effect_newex(lua_State *L);
 	static int32 effect_clone(lua_State *L);
@@ -330,6 +340,7 @@ public:
 	static int32 effect_get_label(lua_State *L);
 	static int32 effect_get_label_object(lua_State *L);
 	static int32 effect_get_category(lua_State *L);
+	static int32 effect_get_range(lua_State* L);
 	static int32 effect_get_owner(lua_State *L);
 	static int32 effect_get_handler(lua_State *L);
 	static int32 effect_get_owner_player(lua_State *L);
@@ -343,6 +354,7 @@ public:
 	static int32 effect_is_active_type(lua_State *L);
 	static int32 effect_is_has_property(lua_State *L);
 	static int32 effect_is_has_category(lua_State *L);
+	static int32 effect_is_has_range(lua_State* L);
 	static int32 effect_is_has_type(lua_State *L);
 	static int32 effect_is_activatable(lua_State *L);
 	static int32 effect_is_activated(lua_State *L);


### PR DESCRIPTION
## fix Effect.SetType
Explicitly set type for EFFECT_TYPE_ACTIVATE.
Explicitly set code, type for EFFECT_TYPE_FLIP.

## simplify Effect functions
```cpp
static int32 get_effect_property(lua_State* L, effect_member type);
static int32 is_effect_property(lua_State* L, effect_member type);
```
Effect.GetFieldID, GetCode, ...
Effect.IsHasCategory
Now they use the same function.

## add Effect.GetRange, IsHasRange 
「叛逆者エト」は１ターンに１度、以下の効果を持つモンスターカードが相手のフィールドか墓地に存在し、LPを半分払った場合のみ手札・墓地から特殊召喚できる。
●効果が発動した時にチェーンして手札かモンスターゾーンで発動する効果

effect filter:
```lua
function filter(e)
    return e:GetCode()==EVENT_CHAINING and e:IsHasType(EFFECT_TYPE_QUICK_O) and e:IsHasRange(LOCATION_HAND+LOCATION_MZONE)
end
```

@mercury233 
@purerosefallen 


