### PR TITLE
Update move_to_field when location is LOCATION_PZONE

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -4567,7 +4567,7 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 			uint32 flag = 0;
 			if (is_location_useable(playerid, LOCATION_PZONE, 0) && zone & 0x1)
 				flag |= 0x1u << (core.duel_rule >= NEW_MASTER_RULE ? 8 : 14);
-			if (is_location_useable(playerid, LOCATION_PZONE, 1) && zone & 0x2)
+			if (is_location_useable(playerid, LOCATION_PZONE, 1) && zone & 0x10)
 				flag |= 0x1u << (core.duel_rule >= NEW_MASTER_RULE ? 12 : 15);
 			if(!flag) {
 				core.units.begin()->step = 3;

--- a/operations.cpp
+++ b/operations.cpp
@@ -4565,9 +4565,9 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 			}
 		} else if(pzone && location == LOCATION_SZONE && (target->data.type & TYPE_PENDULUM)) {
 			uint32 flag = 0;
-			if(is_location_useable(playerid, LOCATION_PZONE, 0))
+			if (is_location_useable(playerid, LOCATION_PZONE, 0) && zone & 0x1)
 				flag |= 0x1u << (core.duel_rule >= NEW_MASTER_RULE ? 8 : 14);
-			if(is_location_useable(playerid, LOCATION_PZONE, 1))
+			if (is_location_useable(playerid, LOCATION_PZONE, 1) && zone & 0x2)
 				flag |= 0x1u << (core.duel_rule >= NEW_MASTER_RULE ? 12 : 15);
 			if(!flag) {
 				core.units.begin()->step = 3;


### PR DESCRIPTION
let 'Duel.MoveToField' can limit the left or the right Pzone by paramete 'zone' 
'0x01' means sending to the left zone , '0x10' means sending to  the right zone and '0xff' means the both