### PR TITLE
update left shift

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -420,13 +420,13 @@ uint32 card::get_info_location() const {
 		uint32 l = overlay_target->current.location | LOCATION_OVERLAY;
 		uint32 s = overlay_target->current.sequence;
 		uint32 ss = current.sequence;
-		return c + (l << 8) + (s << 16) + (ss << 24);
+		return c | (l << 8) | (s << 16) | (ss << 24);
 	} else {
 		uint32 c = current.controler;
 		uint32 l = current.location;
 		uint32 s = current.sequence;
 		uint32 ss = current.position;
-		return c + (l << 8) + (s << 16) + (ss << 24);
+		return c | (l << 8) | (s << 16) | (ss << 24);
 	}
 }
 // get the printed code on card
@@ -1347,8 +1347,8 @@ uint32 card::get_mutual_linked_zone() {
 	int32 p = current.controler;
 	int32 s = current.sequence;
 	uint32 linked_zone = get_linked_zone();
-	uint32 icheck = 0x1;
-	for(uint32 i = 0; i < 7; ++i, icheck <<= 1) {
+	uint32 icheck = 0x1U;
+	for(int32 i = 0; i < 7; ++i, icheck <<= 1) {
 		if(icheck & linked_zone) {
 			card* pcard = pduel->game_field->player[p].list_mzone[i];
 			if(pcard && (pcard->get_linked_zone() & (1u << s)))

--- a/field.cpp
+++ b/field.cpp
@@ -567,31 +567,31 @@ int32 field::is_location_useable(uint8 playerid, uint32 general_location, uint8 
 	if (general_location == LOCATION_MZONE) {
 		if (sequence >= (int32)player[playerid].list_mzone.size())
 			return FALSE;
-		if(flag & (0x1u << sequence))
+		if(flag & (0x1U << sequence))
 			return FALSE;
 		if(sequence >= 5) {
 			uint32 oppo = player[1 - playerid].disabled_location | player[1 - playerid].used_location;
-			if(oppo & (0x1u << (11 - sequence)))
+			if(oppo & (0x1U << (11 - sequence)))
 				return FALSE;
 		}
 	} else if (general_location == LOCATION_SZONE) {
 		if (sequence >= player[playerid].szone_size)
 			return FALSE;
-		if(flag & (0x100u << sequence))
+		if(flag & (0x100U << sequence))
 			return FALSE;
 	} else if (general_location == LOCATION_FZONE) {
 		if (sequence >= 1)
 			return FALSE;
-		if(flag & (0x100u << (5 + sequence)))
+		if(flag & (0x100U << (5 + sequence)))
 			return FALSE;
 	} else if (general_location == LOCATION_PZONE) {
 		if (sequence >= 2)
 			return FALSE;
 		if(core.duel_rule >= NEW_MASTER_RULE) {
-			if(flag & (0x100u << (sequence * 4)))
+			if(flag & (0x100U << (sequence * 4)))
 				return FALSE;
 		} else {
-			if(flag & (0x100u << (6 + sequence)))
+			if(flag & (0x100U << (6 + sequence)))
 				return FALSE;
 		}
 	}
@@ -1334,7 +1334,7 @@ void field::add_effect_code(uint32 code, uint32 playerid) {
 		count_map = &core.effect_count_code_duel;
 	else if(code & EFFECT_COUNT_CODE_CHAIN)
 		count_map = &core.effect_count_code_chain;
-	++(*count_map)[code + (playerid << 30)];
+	(*count_map)[code + (playerid << 30)]++;
 }
 uint32 field::get_effect_code(uint32 code, uint32 playerid) {
 	auto* count_map = &core.effect_count_code;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -863,7 +863,7 @@ int32 scriptlib::duel_move_to_field(lua_State *L) {
 		zone = (uint32)lua_tointeger(L, 7);
 	if(destination == LOCATION_FZONE) {
 		destination = LOCATION_SZONE;
-		zone = 0x1 << 5;
+		zone = 0x1U << 5;
 	}
 	uint32 pzone = FALSE;
 	if(destination == LOCATION_PZONE) {
@@ -1984,7 +1984,7 @@ int32 scriptlib::duel_get_mzone_count(lua_State *L) {
 		} else
 			return luaL_error(L, "Parameter %d should be \"Card\" or \"Group\".", 2);
 		for(int32 p = 0; p < 2; p++) {
-			uint32 digit = 1;
+			uint32 digit = 0x1U;
 			for(auto& pcard : pduel->game_field->player[p].list_mzone) {
 				if(pcard && pcard != mcard && !(mgroup && mgroup->container.find(pcard) != mgroup->container.end())) {
 					used_location[p] |= digit;
@@ -3846,11 +3846,11 @@ int32 scriptlib::duel_select_disable_field(lua_State * L) {
 	}
 	if((location1 & LOCATION_MZONE) && (location2 & LOCATION_MZONE) && pduel->game_field->core.duel_rule >= NEW_MASTER_RULE) {
 		if(pduel->game_field->is_location_useable(playerid, LOCATION_MZONE, 5)) {
-			flag &= ~(0x1 << 5);
+			flag &= ~(0x1U << 5);
 			ct1 += 1;
 		}
 		if(pduel->game_field->is_location_useable(playerid, LOCATION_MZONE, 6)) {
-			flag &= ~(0x1 << 6);
+			flag &= ~(0x1U << 6);
 			ct1 += 1;
 		}
 	}
@@ -3870,13 +3870,13 @@ int32 scriptlib::duel_select_disable_field(lua_State * L) {
 			uint8 p = pduel->game_field->returns.bvalue[pa];
 			uint8 l = pduel->game_field->returns.bvalue[pa + 1];
 			uint8 s = pduel->game_field->returns.bvalue[pa + 2];
-			dfflag |= 0x1u << (s + (p == playerid ? 0 : 16) + (l == LOCATION_MZONE ? 0 : 8));
+			dfflag |= 0x1U << (s + (p == playerid ? 0 : 16) + (l == LOCATION_MZONE ? 0 : 8));
 			pa += 3;
 		}
-		if(dfflag & (0x1 << 5))
-			dfflag |= 0x1 << (16 + 6);
+		if(dfflag & (0x1U << 5))
+			dfflag |= 0x1U << (16 + 6);
 		if(dfflag & (0x1 << 6))
-			dfflag |= 0x1 << (16 + 5);
+			dfflag |= 0x1U << (16 + 5);
 		lua_pushinteger(L, dfflag);
 		return 1;
 	});
@@ -3937,10 +3937,10 @@ int32 scriptlib::duel_select_field(lua_State* L) {
 			dfflag |= 0x1u << (s + (p == playerid ? 0 : 16) + (l == LOCATION_MZONE ? 0 : 8));
 			pa += 3;
 		}
-		if(dfflag & (0x1 << 5))
-			dfflag |= 0x1 << (16 + 6);
-		if(dfflag & (0x1 << 6))
-			dfflag |= 0x1 << (16 + 5);
+		if(dfflag & (0x1U << 5))
+			dfflag |= 0x1U << (16 + 6);
+		if(dfflag & (0x1U << 6))
+			dfflag |= 0x1U << (16 + 5);
 		lua_pushinteger(L, dfflag);
 		return 1;
 		});

--- a/operations.cpp
+++ b/operations.cpp
@@ -1079,9 +1079,9 @@ int32 field::swap_control(uint16 step, effect* reason_effect, uint8 reason_playe
 		uint32 flag;
 		get_useable_count(nullptr, p1, LOCATION_MZONE, reason_player, LOCATION_REASON_CONTROL, 0xff, &flag);
 		if(reason_player == p1)
-			flag = (flag & ~(1 << s1) & 0xff) | ~0x1f;
+			flag = (flag & ~(0x1U << s1) & 0xff) | ~0x1f;
 		else
-			flag = ((flag & ~(1 << s1)) << 16 & 0xff0000) | ~0x1f0000;
+			flag = ((flag & ~(0x1U << s1)) << 16 & 0xff0000) | ~0x1f0000;
 		pduel->write_buffer8(MSG_HINT);
 		pduel->write_buffer8(HINT_SELECTMSG);
 		pduel->write_buffer8(reason_player);
@@ -1102,9 +1102,9 @@ int32 field::swap_control(uint16 step, effect* reason_effect, uint8 reason_playe
 		uint32 flag;
 		get_useable_count(nullptr, p2, LOCATION_MZONE, reason_player, LOCATION_REASON_CONTROL, 0xff, &flag);
 		if(reason_player == p2)
-			flag = (flag & ~(1 << s2) & 0xff) | ~0x1f;
+			flag = (flag & ~(0x1U << s2) & 0xff) | ~0x1f;
 		else
-			flag = ((flag & ~(1 << s2)) << 16 & 0xff0000) | ~0x1f0000;
+			flag = ((flag & ~(0x1U << s2)) << 16 & 0xff0000) | ~0x1f0000;
 		pduel->write_buffer8(MSG_HINT);
 		pduel->write_buffer8(HINT_SELECTMSG);
 		pduel->write_buffer8(reason_player);
@@ -2465,7 +2465,7 @@ int32 field::sset(uint16 step, uint8 setplayer, uint8 toplayer, card * target, e
 	}
 	case 2: {
 		target->enable_field_effect(false);
-		move_to_field(target, setplayer, toplayer, LOCATION_SZONE, POS_FACEDOWN, FALSE, 0, FALSE, 0x1 << target->to_field_param);
+		move_to_field(target, setplayer, toplayer, LOCATION_SZONE, POS_FACEDOWN, FALSE, 0, FALSE, 0x1U << target->to_field_param);
 		return FALSE;
 	}
 	case 3: {
@@ -2568,7 +2568,7 @@ int32 field::sset_g(uint16 step, uint8 setplayer, uint8 toplayer, group* ptarget
 		uint32 seq = returns.bvalue[2];
 		core.set_group_seq[core.set_group_pre_set.size()] = seq;
 		core.set_group_pre_set.insert(target);
-		core.set_group_used_zones |= (1 << seq);
+		core.set_group_used_zones |= (0x1U << seq);
 		set_cards->erase(target);
 		if(!set_cards->empty())
 			core.units.begin()->step = 0;
@@ -2582,10 +2582,10 @@ int32 field::sset_g(uint16 step, uint8 setplayer, uint8 toplayer, group* ptarget
 		target->enable_field_effect(false);
 		uint32 zone;
 		if(target->data.type & TYPE_FIELD) {
-			zone = 1 << 5;
+			zone = 0x1U << 5;
 		} else {
-			for(uint32 i = 0; i < 7; i++) {
-				zone = 1 << i;
+			for(int32 i = 0; i < 7; i++) {
+				zone = 0x1U << i;
 				if(core.set_group_used_zones & zone) {
 					core.set_group_used_zones &= ~zone;
 					break;
@@ -2649,7 +2649,7 @@ int32 field::sset_g(uint16 step, uint8 setplayer, uint8 toplayer, group* ptarget
 			core.operated_set.insert(pcard);
 		}
 		uint8 ct = (uint8)core.operated_set.size();
-		if(core.set_group_used_zones & (1 << 5))
+		if(core.set_group_used_zones & (0x1U << 5))
 			--ct;
 		if(ct <= 1)
 			return FALSE;
@@ -4554,7 +4554,7 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 		returns.ivalue[0] = FALSE;
 		if((ret == RETURN_TEMP_REMOVE_TO_FIELD) && (!(target->current.reason & REASON_TEMPORARY) || (target->current.reason_effect->owner != core.reason_effect->owner)))
 			return TRUE;
-		if(location == LOCATION_SZONE && zone == 0x1 << 5 && (target->data.type & TYPE_FIELD) && (target->data.type & TYPE_SPELL)) {
+		if(location == LOCATION_SZONE && zone == 0x1U << 5 && (target->data.type & TYPE_FIELD) && (target->data.type & TYPE_SPELL)) {
 			card* pcard = get_field_card(playerid, LOCATION_SZONE, 5);
 			if(pcard) {
 				if(core.duel_rule >= 3)
@@ -4599,8 +4599,8 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 				return FALSE;
 			}
 			if((zone & zone - 1) == 0) {
-				for(uint8 seq = 0; seq < 8; seq++) {
-					if((1 << seq) & zone) {
+				for(uint8 seq = 0; seq < 8; ++seq) {
+					if((0x1U << seq) & zone) {
 						returns.bvalue[2] = seq;
 						return FALSE;
 					}

--- a/playerop.cpp
+++ b/playerop.cpp
@@ -787,7 +787,7 @@ int32 field::sort_card(int16 step, uint8 playerid) {
 int32 field::announce_race(int16 step, uint8 playerid, int32 count, int32 available) {
 	if(step == 0) {
 		int32 scount = 0;
-		for(int32 ft = 0x1; ft < (1 << RACES_COUNT); ft <<= 1) {
+		for(uint32 ft = 0x1; ft < (0x1U << RACES_COUNT); ft <<= 1) {
 			if(ft & available)
 				++scount;
 		}
@@ -803,8 +803,9 @@ int32 field::announce_race(int16 step, uint8 playerid, int32 count, int32 availa
 	} else {
 		int32 rc = returns.ivalue[0];
 		int32 sel = 0;
-		for(int32 ft = 0x1; ft < (1 << RACES_COUNT); ft <<= 1) {
-			if(!(ft & rc)) continue;
+		for(uint32 ft = 0x1; ft < (0x1U << RACES_COUNT); ft <<= 1) {
+			if(!(ft & rc))
+				continue;
 			if(!(ft & available)) {
 				pduel->write_buffer8(MSG_RETRY);
 				return FALSE;

--- a/processor.cpp
+++ b/processor.cpp
@@ -4019,7 +4019,7 @@ int32 field::add_chain(uint16 step) {
 				phandler->enable_field_effect(false);
 				phandler->set_status(STATUS_ACT_FROM_HAND, TRUE);
 				if(phandler->data.type & TYPE_FIELD)
-					zone = 0x1 << 5;
+					zone = 0x1U << 5;
 				move_to_field(phandler, phandler->current.controler, phandler->current.controler, LOCATION_SZONE, POS_FACEUP, FALSE, 0, (phandler->data.type & TYPE_PENDULUM) ? TRUE : FALSE, zone);
 			} else {
 				phandler->set_status(STATUS_ACT_FROM_HAND, FALSE);


### PR DESCRIPTION
C99
6.5.7 bitwise-shift-operators
3
> The ***integer promotions*** are performed on each of the operands.
> The type of the result is that of the promoted left operand. 
> If the value of the right operand is negative or is greater than or equal to the width of the promoted left operand, the behavior is undefined.

4 (left shift)
> The result of E1 << E2 is E1 left-shifted E2 bit positions; vacated bits are filled with zeros.
> - If E1 has an unsigned type, the value of the result is E1 × 2^E2, reduced modulo one more than the maximum value representable in the result type.
> - If E1 has a signed type and nonnegative value, and E1 × 2^E2 is representable in the result type, then that is the resulting value; otherwise, the behavior is undefined.

5 (right shift)
> The result of E1 >> E2 is E1 right-shifted E2 bit positions.
> - If E1 has an unsigned type or if E1 has a signed type and a nonnegative value, the value of the result is the integral part of the quotient of E1 / 2^E2. 
> - If E1 has a signed type and a negative value, the resulting value is implementation-defined.