### PR TITLE
remove disablewarnings C4267

### DIFF
--- a/premake/dll.lua
+++ b/premake/dll.lua
@@ -37,7 +37,7 @@ workspace "ocgcoredll"
     filter { "configurations:Release", "action:vs*" }
         flags { "LinkTimeOptimization" }
         staticruntime "On"
-        disablewarnings { "4267", "4334" }
+        disablewarnings { "4334" }
 
     filter "action:vs*"
         buildoptions { "/utf-8" }


### PR DESCRIPTION
It is necessary to check if it works in 64 bit environment.

----
保留C4267可以幫助檢查在64位系統是否正常

@mercury233 