### PR TITLE
effect: change category to uint64

### DIFF
--- a/effect.h
+++ b/effect.h
@@ -44,7 +44,7 @@ public:
 	int32 reset_count{ 0 };
 	uint32 reset_flag{ 0 };
 	uint32 count_code{ 0 };
-	uint32 category{ 0 };
+	uint64 category{ 0 };
 	uint32 hint_timing[2]{};
 	uint32 card_type{ 0 };
 	uint32 active_type{ 0 };


### PR DESCRIPTION
CATEGORY_TOEXTRA			=0x80000000

The category bot field is full now.
To prepare for "card with effect X", we should update to uint64.

Category bit field目前已滿。
為了應對其他的「持有X效果」，建議改成uint64以加入更多類別。

@mercury233 
@purerosefallen 
@Wind2009-Louse 
@fallenstardust