### PR TITLE
use gh-release@v2.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,11 +47,10 @@ jobs:
 
     - name: GitHub Release
       if: github.event_name == 'push'
-      uses: salix5/action-automatic-releases@node20
+      uses: softprops/action-gh-release@v2.1.0
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "latest"
+        tag_name: "latest"
         prerelease: true
-        title: "Development Build"
+        name: "Development Build"
         files: |
           build/bin/x64/Release/ocgcore.dll


### PR DESCRIPTION
https://github.com/marvinpinto/actions
This repository has been archived by the owner on May 6, 2024. It is now read-only. 

https://github.com/marvinpinto/actions/commit/40312c52f0ca0d0589b25e8f5172a3613f0759c3
Generating release notes & automatically maintaining releases was much needed when GitHub Actions launched many years ago, but our ecosystem has evolved and there are much better alternatives these days.

For example, the [semantic-release](https://github.com/semantic-release/semantic-release) project + their associated [GitHub Action](https://github.com/semantic-release/github) gives you full control over when releases occur, changelog formatting, custom exec scripts, and much more. Another popular option is the [action-gh-release](https://github.com/softprops/action-gh-release) which also allows you to do many of the things this project originally enabled.

https://github.com/Fluorohydride/ygopro-core/actions/runs/12030292519/job/33537390464
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

----
marvinpinto/actions
This repository is archived and no longer maintained.
Maybe we should use another Action instead.

https://github.com/marketplace/actions/gh-release
gh-release
It is recommended by marvinpinto and available in marketplace.

Test:
https://github.com/salix5/ygopro-core/actions/runs/12035122412/job/33553322619

@mercury233 

