### PR TITLE
Revert "use gh-release@v2.1.0"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,11 @@ jobs:
 
     - name: GitHub Release
       if: github.event_name == 'push'
-      uses: softprops/action-gh-release@v2.1.0
+      uses: salix5/action-automatic-releases@node20
       with:
-        tag_name: "latest"
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
         prerelease: true
-        name: "Development Build"
+        title: "Development Build"
         files: |
           build/bin/x64/Release/ocgcore.dll


### PR DESCRIPTION
Reverts Fluorohydride/ygopro-core#675

Maybe just wait until it is deprecated.
We can use GitHub CLI after that.
