### PR TITLE
Fix EFFECT_XYZ_LEVEL

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1052,14 +1052,22 @@ uint32_t card::check_xyz_level(card* pcard, uint32_t lv) {
 			return lev;
 		return 0;
 	}
+	uint32_t maxctlimit = 0;
+	for (int32_t i = 0; i < eset.size(); ++i) {
+		pduel->lua->add_param(this, PARAM_TYPE_CARD);
+		pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
+		uint32_t ctlimit = (eset[i]->get_value(2) >> 12) & 0xf;
+		if (ctlimit > 0)
+			maxctlimit = maxctlimit > ctlimit ? maxctlimit : ctlimit;
+	}
 	for(int32_t i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(this, PARAM_TYPE_CARD);
 		pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
 		uint32_t lev = eset[i]->get_value(2);
 		if(((lev & 0xfff) == lv))
-			return lev & 0xffff;
+			return (lev & 0xfff) | (maxctlimit << 12);
 		if(((lev >> 16) & 0xfff) == lv)
-			return (lev >> 16) & 0xffff;
+			return ((lev >> 16) & 0xffff) | (maxctlimit << 12);
 	}
 	return 0;
 }

--- a/field.cpp
+++ b/field.cpp
@@ -1941,6 +1941,7 @@ void field::ritual_release(const card_set& material) {
 }
 void field::get_xyz_material(lua_State* L, card* scard, int32_t findex, uint32_t lv, int32_t maxc, group* mg) {
 	core.xmaterial_lst.clear();
+	core.xmaterial_lst_origin.clear();
 	uint32_t xyz_level;
 	if(mg) {
 		for (auto& pcard : mg->container) {
@@ -1969,6 +1970,7 @@ void field::get_xyz_material(lua_State* L, card* scard, int32_t findex, uint32_t
 		auto iter = core.xmaterial_lst.lower_bound(maxc);
 		core.xmaterial_lst.erase(core.xmaterial_lst.begin(), iter);
 	}
+	core.xmaterial_lst_origin.insert(core.xmaterial_lst.begin(), core.xmaterial_lst.end());
 }
 void field::get_overlay_group(uint8_t self, uint8_t s, uint8_t o, card_set* pset) {
 	if (!check_playerid(self))

--- a/field.h
+++ b/field.h
@@ -260,6 +260,7 @@ struct processor {
 	std::unordered_map<uint32_t, uint32_t> effect_count_code_chain;
 	std::unordered_map<uint32_t, uint32_t> spsummon_once_map[2];
 	std::multimap<int32_t, card*, std::greater<int32_t>> xmaterial_lst;
+	std::multimap<int32_t, card*, std::greater<int32_t>> xmaterial_lst_origin;
 
 	int32_t temp_var[4]{};
 	uint32_t global_flag{ 0 };

--- a/operations.cpp
+++ b/operations.cpp
@@ -5942,6 +5942,7 @@ int32_t field::select_xyz_material(int16_t step, uint8_t playerid, uint32_t lv, 
 		min = 0;
 		if(pv - (int32_t)core.operated_set.size() > min)
 			min = pv - (int32_t)core.operated_set.size();
+		core.units.begin()->arg3 = core.units.begin()->arg2;
 		core.units.begin()->arg2 = min + (max << 16);
 		if(min == 0) {
 			add_process(PROCESSOR_SELECT_YESNO, 0, 0, 0, playerid, 93);
@@ -5967,15 +5968,24 @@ int32_t field::select_xyz_material(int16_t step, uint8_t playerid, uint32_t lv, 
 		if(min == 0)
 			min = 1;
 		if(min + (int32_t)core.operated_set.size() >= maxv)
-			add_process(PROCESSOR_SELECT_CARD, 0, 0, 0, playerid, min + (max << 16));
+			add_process(PROCESSOR_SELECT_CARD, 0, 0, 0, playerid + ((uint32_t)1 << 16), min + (max << 16));
 		else {
-			add_process(PROCESSOR_SELECT_CARD, 0, 0, 0, playerid, min + (min << 16));
+			add_process(PROCESSOR_SELECT_CARD, 0, 0, 0, playerid + ((uint32_t)1 << 16), min + (min << 16));
 			core.units.begin()->step = 7;
 		}
 		return FALSE;
 	}
 	case 10: {
 		group* pgroup = pduel->new_group(core.operated_set);
+		if (returns.ivalue[0] == -1) {
+			core.units.begin()->arg2 = core.units.begin()->arg3;
+			core.units.begin()->arg3 = 0;
+			core.units.begin()->step = -1;
+			core.operated_set.clear();
+			core.xmaterial_lst.clear();
+			core.xmaterial_lst.insert(core.xmaterial_lst_origin.begin(), core.xmaterial_lst_origin.end());
+			return FALSE;
+		}
 		for(int32_t i = 0; i < returns.bvalue[0]; ++i) {
 			card* pcard = core.select_cards[returns.bvalue[i + 1]];
 			pgroup->container.insert(pcard);


### PR DESCRIPTION
Fix:
* While controlling ``光天使スローネ`` and having ``真血公ヴァンパイア`` in extra deck, you can xyz summon ``真血公ヴァンパイア`` with only 2 materials including ``光天使スローネ``.

Update: 
* Add cancelable selection for ``光天使スローネ`` and ``塊斬機ダランベルシアン`` situation. While summoning ``塊斬機ダランベルシアン``, after selecting ``光天使スローネ`` as material, it can still be canceled.