### PR TITLE
 fix card::check_xyz_level 

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1069,13 +1069,14 @@ uint32_t card::check_xyz_level(card* pcard, uint32_t lv) {
 		pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
 		uint32_t lev = eset[i]->get_value(2);
 		uint16_t lv1 = lev & MAX_XYZ_LEVEL;
-		uint16_t count1 = (lev & MAX_PARAMETER) >> 12;
+		uint16_t count1 = (lev & 0xf000) >> 12;
 		if (count1 < min_count)
 			count1 = min_count;
 		if (lv1 == lv)
 			return lv1 | ((uint32_t)count1 << 12);
-		uint16_t lv2 = (lev >> 16) & MAX_XYZ_LEVEL;
-		uint16_t count2 = lev >> 28;
+		lev >>= 16;
+		uint16_t lv2 = lev & MAX_XYZ_LEVEL;
+		uint16_t count2 = (lev & 0xf000) >> 12;
 		if (count2 < min_count)
 			count2 = min_count;
 		if (lv2 == lv)

--- a/card.cpp
+++ b/card.cpp
@@ -1061,7 +1061,7 @@ uint32_t card::check_xyz_level(card* pcard, uint32_t lv) {
 	if(!eset.size()) {
 		uint32_t card_lv = get_level();
 		if (card_lv == lv)
-			return (card_lv & MAX_XYZ_LEVEL) | (min_count << 12);
+			return (card_lv & MAX_XYZ_LEVEL) | ((uint32_t)min_count << 12);
 		return 0;
 	}
 	for(int32_t i = 0; i < eset.size(); ++i) {
@@ -1073,13 +1073,13 @@ uint32_t card::check_xyz_level(card* pcard, uint32_t lv) {
 		if (count1 < min_count)
 			count1 = min_count;
 		if (lv1 == lv)
-			return lv1 | (count1 << 12);
+			return lv1 | ((uint32_t)count1 << 12);
 		uint16_t lv2 = (lev >> 16) & MAX_XYZ_LEVEL;
 		uint16_t count2 = lev >> 28;
 		if (count2 < min_count)
 			count2 = min_count;
 		if (lv2 == lv)
-			return lv2 | (count2 << 12);
+			return lv2 | ((uint32_t)count2 << 12);
 	}
 	return 0;
 }

--- a/effect.h
+++ b/effect.h
@@ -529,6 +529,7 @@ const std::map<uint64_t, uint64_t> category_checklist{
 #define EFFECT_TUNER					369
 #define EFFECT_KAISER_COLOSSEUM			370
 #define EFFECT_REPLACE_DAMAGE			371
+#define EFFECT_XYZ_MIN_COUNT			372
 
 //#define EVENT_STARTUP		1000
 #define EVENT_FLIP			1001
@@ -608,6 +609,9 @@ const std::map<uint64_t, uint64_t> category_checklist{
 
 constexpr int32_t DOUBLE_DAMAGE = INT32_MIN;
 constexpr int32_t HALF_DAMAGE = INT32_MIN + 1;
+
+constexpr uint32_t MAX_PARAMETER = 0xffffU;
+constexpr uint32_t MAX_XYZ_LEVEL = 0x0fffU;
 
 // flag effect
 #define EFFECT_FLAG_EFFECT	0x20000000U

--- a/effect.h
+++ b/effect.h
@@ -606,8 +606,8 @@ const std::map<uint64_t, uint64_t> category_checklist{
 #define EVENT_REMOVE_COUNTER		0x20000
 #define EVENT_CUSTOM				0x10000000
 
-constexpr int32_t DOUBLE_DAMAGE = 0x80000000;
-constexpr int32_t HALF_DAMAGE = 0x80000001;
+constexpr int32_t DOUBLE_DAMAGE = INT32_MIN;
+constexpr int32_t HALF_DAMAGE = INT32_MIN + 1;
 
 // flag effect
 #define EFFECT_FLAG_EFFECT	0x20000000U


### PR DESCRIPTION
see #709 

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11294&sort=2&request_locale=ja
光天使スローネ
このカードをX召喚の素材とする場合、モンスター３体以上を素材としたX召喚にしか使用できない。

https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=11544&request_locale=ja
星因士 カペラ
①：このカードが召喚・反転召喚・特殊召喚に成功した場合に発動できる。このターン自分は、モンスター３体以上を素材としたX召喚をする場合、自分フィールドのレベル４以下の「テラナイト」モンスターをレベル５の素材として扱う事ができる。 


@Wind2009-Louse 
我認為問題是
天座的效果不是改變超量召喚時的等級
因此不該用EFFECT_XYZ_LEVEL 

現在改成
EFFECT_XYZ_LEVEL 
星因士 カペラ
0x3005
3隻以上超量召喚時可以當作5星

EFFECT_XYZ_MIN_COUNT
光天使スローネ
只能用在3隻以上的超量召喚

@mercury233 
@purerosefallen 
@fallenstardust

----
EFFECT_XYZ_LEVEL 
Satellarknight Capella
0x3005
It can be treated as Level 5  when Xyz Summoning using 3+ monsters

EFFECT_XYZ_MIN_COUNT
Star Seraph Sovereignty
Cannot be used as material for an Xyz Summon, except for an Xyz Summon that uses 3 or more monsters as material.


Test:
```lua
--[[message xyz_level]]
Debug.SetAIName("Bug")
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(4031928,0,0,LOCATION_HAND,0,POS_FACEDOWN_DEFENSE)
Debug.AddCard(4031928,0,0,LOCATION_HAND,1,POS_FACEDOWN_DEFENSE)
Debug.AddCard(41587307,0,0,LOCATION_HAND,1,POS_FACEDOWN_DEFENSE)

Debug.AddCard(89631139,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK)
Debug.AddCard(36690018,0,0,LOCATION_SZONE,0,POS_FACEDOWN_DEFENSE)

Debug.AddCard(23846921,0,0,LOCATION_GRAVE,0,POS_FACEUP_ATTACK)
Debug.AddCard(73082255,0,0,LOCATION_EXTRA,0,POS_FACEDOWN_DEFENSE)

Debug.AddCard(89631139,0,0,LOCATION_DECK,0,POS_FACEDOWN_DEFENSE)
Debug.AddCard(89631139,0,0,LOCATION_DECK,1,POS_FACEDOWN_DEFENSE)

Debug.AddCard(91110378,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,1,1,LOCATION_GRAVE,0,POS_FACEUP_ATTACK)

Debug.ReloadFieldEnd()
```