### PR TITLE
 change cardid to uint64_t 

### DIFF
--- a/card.h
+++ b/card.h
@@ -54,10 +54,10 @@ struct card_state {
 	uint8_t sequence{ 0 };
 	uint8_t position{ 0 };
 	uint32_t reason{ 0 };
-	bool pzone{ false };
 	card* reason_card{ nullptr };
-	uint8_t reason_player{ PLAYER_NONE };
 	effect* reason_effect{ nullptr };
+	uint8_t reason_player{ PLAYER_NONE };
+	bool pzone{ false };
 
 	bool is_location(uint32_t loc) const;
 	bool is_main_mzone() const {
@@ -168,7 +168,7 @@ public:
 	uint8_t attacked_count{};
 	uint8_t attack_all_target{};
 	uint8_t attack_controler{};
-	uint16_t cardid{};
+	uint64_t cardid{};
 	uint32_t fieldid{};
 	uint32_t fieldid_r{};
 	uint16_t turnid{};

--- a/field.h
+++ b/field.h
@@ -123,11 +123,11 @@ struct field_effect {
 	grant_effect_container grant_effect;
 };
 struct field_info {
+	uint64_t card_id{ 1 };
 	int32_t field_id{ 1 };
 	uint16_t copy_id{ 1 };
 	uint16_t turn_id{};
 	uint16_t turn_id_by_player[2]{};
-	uint16_t card_id{ 1 };
 	uint16_t phase{};
 	uint8_t turn_player{};
 	uint8_t priorities[2]{};

--- a/group.h
+++ b/group.h
@@ -22,7 +22,7 @@ constexpr uint32_t GTYPE_DEFAULT = 0;
 constexpr uint32_t GTYPE_READ_ONLY = 1;
 constexpr uint32_t GTYPE_KEEP_ALIVE = 2;
 
-class group {
+class alignas(8) group {
 public:
 	int32_t ref_handle{ 0 };
 	uint32_t is_readonly{ GTYPE_DEFAULT };

--- a/group.h
+++ b/group.h
@@ -18,17 +18,17 @@ class duel;
 
 using card_set = std::set<card*, card_sort>;
 
-constexpr int GTYPE_DEFAULT = 0;
-constexpr int GTYPE_READ_ONLY = 1;
-constexpr int GTYPE_KEEP_ALIVE = 2;
+constexpr uint32_t GTYPE_DEFAULT = 0;
+constexpr uint32_t GTYPE_READ_ONLY = 1;
+constexpr uint32_t GTYPE_KEEP_ALIVE = 2;
 
 class group {
 public:
+	int32_t ref_handle{ 0 };
+	uint32_t is_readonly{ GTYPE_DEFAULT };
 	duel* pduel;
 	card_set container;
 	card_set::iterator it;
-	int32_t ref_handle{ 0 };
-	uint32_t is_readonly{ GTYPE_DEFAULT };
 	bool is_iterator_dirty{ true };
 	
 	bool has_card(card* c) {


### PR DESCRIPTION
5.2.10 Reinterpret cast
[expr.reinterpret.cast]
paragraph 7
An object pointer can be explicitly converted to an object pointer of a different type. When a prvalue v of object pointer type is converted to the object pointer type “pointer to cv T”, the result is `static_cast<cv T*>(static_cast<cv void*>(v))`. 
Converting a prvalue of type “pointer to T1” to the type “pointer to T2” (where T1 and T2 are object types and where the alignment requirements of T2 are no stricter than those of T1) and back to its original type yields the original pointer value.

ygopro is full of pointer casting.
Since `effect` is 8 bytes alignment now, `card` and `group` should be 8 bytes alignment.

`card`
`group` 
為了讓指針轉型成立，都改成8對齊


@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust