### PR TITLE
 using effect_set = std::vector<effect*> 

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -430,7 +430,7 @@ uint32_t card::get_code() {
 	temp.code = code;
 	filter_effect(EFFECT_CHANGE_CODE, &effects);
 	if (effects.size())
-		code = effects.get_last()->get_value(this);
+		code = effects.back()->get_value(this);
 	temp.code = UINT32_MAX;
 	return code;
 }
@@ -450,7 +450,7 @@ uint32_t card::get_another_code() {
 	filter_effect(EFFECT_ADD_CODE, &eset);
 	if(!eset.size())
 		return code2;
-	uint32_t otcode = eset.get_last()->get_value(this);
+	uint32_t otcode = eset.back()->get_value(this);
 	if(code1 != otcode)
 		return otcode;
 	return 0;
@@ -642,7 +642,7 @@ std::pair<int32_t, int32_t> card::get_base_atk_def() {
 		filter_effect(EFFECT_SET_BASE_DEFENSE, &eset, FALSE);
 		filter_effect(EFFECT_SET_BASE_DEFENSE_FINAL, &eset, FALSE);
 	}
-	eset.sort();
+	std::sort(eset.begin(), eset.end(), effect_sort_id);
 	// calculate single effects of this first
 	for(int32_t i = 0; i < eset.size();) {
 		if (eset[i]->type & EFFECT_TYPE_SINGLE) {
@@ -652,14 +652,14 @@ std::pair<int32_t, int32_t> card::get_base_atk_def() {
 				if(batk < 0)
 					batk = 0;
 				temp.base_attack = batk;
-				eset.remove_item(i);
+				eset.erase(eset.begin() + i);
 				continue;
 			case EFFECT_SET_BASE_DEFENSE:
 				bdef = eset[i]->get_value(this);
 				if(bdef < 0)
 					bdef = 0;
 				temp.base_defense = bdef;
-				eset.remove_item(i);
+				eset.erase(eset.begin() + i);
 				continue;
 			}
 		}
@@ -746,7 +746,7 @@ std::pair<int32_t, int32_t> card::get_atk_def() {
 		filter_effect(EFFECT_SET_DEFENSE, &eset, FALSE);
 		filter_effect(EFFECT_SET_DEFENSE_FINAL, &eset, FALSE);
 	}
-	eset.sort();
+	std::sort(eset.begin(), eset.end(), effect_sort_id);
 	bool rev = false;
 	if (is_affected_by_effect(EFFECT_REVERSE_UPDATE))
 		rev = true;
@@ -758,14 +758,14 @@ std::pair<int32_t, int32_t> card::get_atk_def() {
 				if (atk < 0)
 					atk = 0;
 				temp.attack = atk;
-				eset.remove_item(i);
+				eset.erase(eset.begin() + i);
 				continue;
 			case EFFECT_SET_DEFENSE:
 				def = eset[i]->get_value(this);
 				if (def < 0)
 					def = 0;
 				temp.defense = def;
-				eset.remove_item(i);
+				eset.erase(eset.begin() + i);
 				continue;
 			}
 		}
@@ -775,7 +775,7 @@ std::pair<int32_t, int32_t> card::get_atk_def() {
 		switch (eset[i]->code) {
 		case EFFECT_UPDATE_ATTACK:
 			if (eset[i]->is_flag(EFFECT_FLAG2_REPEAT_UPDATE))
-				effects_repeat_update_atk.add_item(eset[i]);
+				effects_repeat_update_atk.push_back(eset[i]);
 			else if ((eset[i]->type & EFFECT_TYPE_SINGLE) && !eset[i]->is_flag(EFFECT_FLAG_SINGLE_RANGE))
 				up_atk += eset[i]->get_value(this);
 			else
@@ -796,19 +796,19 @@ std::pair<int32_t, int32_t> card::get_atk_def() {
 				upc_atk = 0;
 			}
 			else if (eset[i]->is_flag(EFFECT_FLAG2_OPTION)) {
-				effects_atk_option.add_item(eset[i]);
+				effects_atk_option.push_back(eset[i]);
 			}
 			else if (eset[i]->is_flag(EFFECT_FLAG2_WICKED)) {
-				effects_atk_wicked.add_item(eset[i]);
+				effects_atk_wicked.push_back(eset[i]);
 			}
 			else {
-				effects_atk_final.add_item(eset[i]);
+				effects_atk_final.push_back(eset[i]);
 			}
 			break;
 		// def
 		case EFFECT_UPDATE_DEFENSE:
 			if (eset[i]->is_flag(EFFECT_FLAG2_REPEAT_UPDATE))
-				effects_repeat_update_def.add_item(eset[i]);
+				effects_repeat_update_def.push_back(eset[i]);
 			else if ((eset[i]->type & EFFECT_TYPE_SINGLE) && !eset[i]->is_flag(EFFECT_FLAG_SINGLE_RANGE))
 				up_def += eset[i]->get_value(this);
 			else
@@ -829,13 +829,13 @@ std::pair<int32_t, int32_t> card::get_atk_def() {
 				upc_def = 0;
 			}
 			else if (eset[i]->is_flag(EFFECT_FLAG2_OPTION)) {
-				effects_def_option.add_item(eset[i]);
+				effects_def_option.push_back(eset[i]);
 			}
 			else if (eset[i]->is_flag(EFFECT_FLAG2_WICKED)) {
-				effects_def_wicked.add_item(eset[i]);
+				effects_def_wicked.push_back(eset[i]);
 			}
 			else {
-				effects_def_final.add_item(eset[i]);
+				effects_def_final.push_back(eset[i]);
 			}
 			break;
 		case EFFECT_SWAP_AD:
@@ -927,7 +927,7 @@ int32_t card::get_battle_attack() {
 	effect_set eset;
 	filter_effect(EFFECT_SET_BATTLE_ATTACK, &eset);
 	if (eset.size()) {
-		int32_t atk = eset.get_last()->get_value(this);
+		int32_t atk = eset.back()->get_value(this);
 		if (atk < 0)
 			atk = 0;
 		return atk;
@@ -939,7 +939,7 @@ int32_t card::get_battle_defense() {
 	effect_set eset;
 	filter_effect(EFFECT_SET_BATTLE_DEFENSE, &eset);
 	if (eset.size()) {
-		int32_t def = eset.get_last()->get_value(this);
+		int32_t def = eset.back()->get_value(this);
 		if (def < 0)
 			def = 0;
 		return def;
@@ -2200,7 +2200,7 @@ std::tuple<uint8_t, effect*> card::refresh_control_status() {
 	effect_set eset;
 	filter_effect(EFFECT_SET_CONTROL, &eset);
 	if(eset.size()) {
-		effect* peffect = eset.get_last();
+		effect* peffect = eset.back();
 		if(peffect->id >= last_id) {
 			final = (uint8_t)peffect->get_value(this);
 			ceffect = peffect;
@@ -2339,7 +2339,7 @@ int32_t card::add_counter(uint8_t playerid, uint16_t countertype, uint16_t count
 		int32_t limit = 0;
 		filter_effect(EFFECT_COUNTER_LIMIT + cttype, &eset);
 		if (eset.size())
-			limit = eset.get_last()->get_value();
+			limit = eset.back()->get_value();
 		if(limit) {
 			int32_t mcount = limit - get_counter(cttype);
 			if (mcount < 0)
@@ -2409,7 +2409,7 @@ int32_t card::is_can_add_counter(uint8_t playerid, uint16_t countertype, uint16_
 		cur = cmit->second;
 	filter_effect(EFFECT_COUNTER_LIMIT + countertype, &eset);
 	if (eset.size())
-		limit = eset.get_last()->get_value();
+		limit = eset.back()->get_value();
 	if(limit > 0 && (cur + (singly ? 1 : count) > limit))
 		return FALSE;
 	return TRUE;
@@ -2596,7 +2596,7 @@ void card::filter_effect_container(const effect_container& container, uint32_t c
 	auto rg = container.equal_range(code);
 	for (auto it = rg.first; it != rg.second; ++it) {
 		if (f(this, it->second))
-			eset.add_item(it->second);
+			eset.push_back(it->second);
 	}
 }
 void card::filter_effect_container(const effect_container& container, uint32_t code, effect_filter f, effect_collection& eset) {
@@ -2616,7 +2616,7 @@ void card::filter_effect(uint32_t code, effect_set* eset, uint8_t sort) {
 		filter_effect_container(pcard->xmaterial_effect, code, default_xmaterial_filter, *eset);
 	filter_effect_container(pduel->game_field->effects.aura_effect, code, default_aura_filter, *eset);
 	if(sort)
-		eset->sort();
+		std::sort(eset->begin(), eset->end(), effect_sort_id);
 }
 void card::filter_single_continuous_effect(uint32_t code, effect_set* eset, uint8_t sort) {
 	filter_effect_container(single_effect, code, accept_filter, *eset);
@@ -2633,7 +2633,7 @@ void card::filter_single_continuous_effect(uint32_t code, effect_set* eset, uint
 	for (auto& pcard : xyz_materials)
 		filter_effect_container(pcard->xmaterial_effect, code, xmaterial_filter, *eset);
 	if(sort)
-		eset->sort();
+		std::sort(eset->begin(), eset->end(), effect_sort_id);
 }
 void card::filter_self_effect(uint32_t code, effect_set* eset, uint8_t sort) {
 	auto single_filter = [](card* c, effect* peffect) -> bool {
@@ -2646,7 +2646,7 @@ void card::filter_self_effect(uint32_t code, effect_set* eset, uint8_t sort) {
 	for (auto& pcard : xyz_materials)
 		filter_effect_container(pcard->xmaterial_effect, code, xmaterial_filter, *eset);
 	if (sort)
-		eset->sort();
+		std::sort(eset->begin(), eset->end(), effect_sort_id);
 }
 // refresh this->immune_effect
 void card::filter_immune_effect() {
@@ -2665,7 +2665,7 @@ void card::filter_immune_effect() {
 	for (auto& pcard : xyz_materials)
 		filter_effect_container(pcard->xmaterial_effect, EFFECT_IMMUNE_EFFECT, xmaterial_filter, immune_effect);
 	filter_effect_container(pduel->game_field->effects.aura_effect, EFFECT_IMMUNE_EFFECT, target_filter, immune_effect);
-	immune_effect.sort();
+	std::sort(immune_effect.begin(), immune_effect.end(), effect_sort_id);
 }
 // for all disable-related peffect of this,
 // 1. Insert all cards in the target of peffect into effects.disable_check_list.
@@ -2700,7 +2700,7 @@ int32_t card::filter_summon_procedure(uint8_t playerid, effect_set* peset, uint8
 	if(eset.size()) {
 		for(int32_t i = 0; i < eset.size(); ++i) {
 			if(check_summon_procedure(eset[i], playerid, ignore_count, min_tribute, zone))
-				peset->add_item(eset[i]);
+				peset->push_back(eset[i]);
 		}
 		if(peset->size())
 			return -1;
@@ -2710,7 +2710,7 @@ int32_t card::filter_summon_procedure(uint8_t playerid, effect_set* peset, uint8
 	filter_effect(EFFECT_SUMMON_PROC, &eset);
 	for(int32_t i = 0; i < eset.size(); ++i) {
 		if(check_summon_procedure(eset[i], playerid, ignore_count, min_tribute, zone))
-			peset->add_item(eset[i]);
+			peset->push_back(eset[i]);
 	}
 	// ordinary summon
 	if(!pduel->game_field->is_player_can_summon(SUMMON_TYPE_NORMAL, playerid, this, playerid))
@@ -2786,7 +2786,7 @@ int32_t card::filter_set_procedure(uint8_t playerid, effect_set* peset, uint8_t 
 	if(eset.size()) {
 		for(int32_t i = 0; i < eset.size(); ++i) {
 			if(check_set_procedure(eset[i], playerid, ignore_count, min_tribute, zone))
-				peset->add_item(eset[i]);
+				peset->push_back(eset[i]);
 		}
 		if(peset->size())
 			return -1;
@@ -2796,7 +2796,7 @@ int32_t card::filter_set_procedure(uint8_t playerid, effect_set* peset, uint8_t 
 	filter_effect(EFFECT_SET_PROC, &eset);
 	for(int32_t i = 0; i < eset.size(); ++i) {
 		if(check_set_procedure(eset[i], playerid, ignore_count, min_tribute, zone))
-			peset->add_item(eset[i]);
+			peset->push_back(eset[i]);
 	}
 	if(!pduel->game_field->is_player_can_mset(SUMMON_TYPE_NORMAL, playerid, this, playerid))
 		return FALSE;
@@ -2883,7 +2883,7 @@ void card::filter_spsummon_procedure(uint8_t playerid, effect_set* peset, uint32
 			uint32_t sumtype = peffect->get_value(this);
 			if((!summon_type || summon_type == sumtype)
 			        && pduel->game_field->is_player_can_spsummon(sumeffect, sumtype, topos, playerid, toplayer, this))
-				peset->add_item(peffect);
+				peset->push_back(peffect);
 		}
 	}
 }
@@ -2903,7 +2903,7 @@ void card::filter_spsummon_procedure_g(uint8_t playerid, effect_set* peset) {
 		pduel->lua->add_param(peffect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(this, PARAM_TYPE_CARD);
 		if(pduel->lua->check_condition(peffect->condition, 2))
-			peset->add_item(peffect);
+			peset->push_back(peffect);
 		pduel->game_field->restore_lp_cost();
 		pduel->game_field->core.reason_effect = oreason;
 		pduel->game_field->core.reason_player = op;

--- a/card.cpp
+++ b/card.cpp
@@ -477,7 +477,7 @@ int32_t card::is_set_card(uint32_t set_code) {
 	//add set code
 	effect_set eset;
 	filter_effect(EFFECT_ADD_SETCODE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		uint32_t value = eset[i]->get_value(this);
 		uint16_t new_setcode = value & 0xffff;
 		if (check_setcode(new_setcode, set_code))
@@ -520,14 +520,14 @@ int32_t card::is_fusion_set_card(uint32_t set_code) {
 		return FALSE;
 	effect_set eset;
 	filter_effect(EFFECT_ADD_FUSION_CODE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		uint32_t code = eset[i]->get_value(this);
 		if (check_card_setcode(code, set_code))
 			return TRUE;
 	}
 	eset.clear();
 	filter_effect(EFFECT_ADD_FUSION_SETCODE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		uint32_t value = eset[i]->get_value(this);
 		uint16_t new_setcode = value & 0xffff;
 		if (check_setcode(new_setcode, set_code))
@@ -540,7 +540,7 @@ int32_t card::is_link_set_card(uint32_t set_code) {
 		return TRUE;
 	effect_set eset;
 	filter_effect(EFFECT_ADD_LINK_CODE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		uint32_t code = eset[i]->get_value(this);
 		if (check_card_setcode(code, set_code))
 			return TRUE;
@@ -576,7 +576,7 @@ uint32_t card::get_type() {
 	filter_effect(EFFECT_ADD_TYPE, &effects, FALSE);
 	filter_effect(EFFECT_REMOVE_TYPE, &effects, FALSE);
 	filter_effect(EFFECT_CHANGE_TYPE, &effects);
-	for (int32_t i = 0; i < effects.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects.size(); ++i) {
 		if (effects[i]->code == EFFECT_ADD_TYPE)
 			type |= effects[i]->get_value(this);
 		else if (effects[i]->code == EFFECT_REMOVE_TYPE)
@@ -644,7 +644,7 @@ std::pair<int32_t, int32_t> card::get_base_atk_def() {
 	}
 	std::sort(eset.begin(), eset.end(), effect_sort_id);
 	// calculate single effects of this first
-	for(int32_t i = 0; i < eset.size();) {
+	for(effect_set::size_type i = 0; i < eset.size();) {
 		if (eset[i]->type & EFFECT_TYPE_SINGLE) {
 			switch(eset[i]->code) {
 			case EFFECT_SET_BASE_ATTACK:
@@ -665,7 +665,7 @@ std::pair<int32_t, int32_t> card::get_base_atk_def() {
 		}
 		++i;
 	}
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		switch(eset[i]->code) {
 		case EFFECT_SET_BASE_ATTACK:
 		case EFFECT_SET_BASE_ATTACK_FINAL:
@@ -750,7 +750,7 @@ std::pair<int32_t, int32_t> card::get_atk_def() {
 	bool rev = false;
 	if (is_affected_by_effect(EFFECT_REVERSE_UPDATE))
 		rev = true;
-	for (int32_t i = 0; i < eset.size();) {
+	for (effect_set::size_type i = 0; i < eset.size();) {
 		if (eset[i]->type & EFFECT_TYPE_SINGLE) {
 			switch (eset[i]->code) {
 			case EFFECT_SET_ATTACK:
@@ -771,7 +771,7 @@ std::pair<int32_t, int32_t> card::get_atk_def() {
 		}
 		++i;
 	}
-	for (int32_t i = 0; i < eset.size(); ++i) {
+	for (effect_set::size_type i = 0; i < eset.size(); ++i) {
 		switch (eset[i]->code) {
 		case EFFECT_UPDATE_ATTACK:
 			if (eset[i]->is_flag(EFFECT_FLAG2_REPEAT_UPDATE))
@@ -855,23 +855,23 @@ std::pair<int32_t, int32_t> card::get_atk_def() {
 		if (temp.defense < 0)
 			temp.defense = 0;
 	}
-	for (int32_t i = 0; i < effects_repeat_update_atk.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects_repeat_update_atk.size(); ++i) {
 		temp.attack += effects_repeat_update_atk[i]->get_value(this);
 		if (temp.attack < 0)
 			temp.attack = 0;
 	}
-	for (int32_t i = 0; i < effects_repeat_update_def.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects_repeat_update_def.size(); ++i) {
 		temp.defense += effects_repeat_update_def[i]->get_value(this);
 		if (temp.defense < 0)
 			temp.defense = 0;
 	}
-	for (int32_t i = 0; i < effects_atk_final.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects_atk_final.size(); ++i) {
 		atk = effects_atk_final[i]->get_value(this);
 		if (atk < 0)
 			atk = 0;
 		temp.attack = atk;
 	}
-	for (int32_t i = 0; i < effects_def_final.size(); ++i){
+	for (effect_set::size_type i = 0; i < effects_def_final.size(); ++i){
 		def = effects_def_final[i]->get_value(this);
 		if (def < 0)
 			def = 0;
@@ -880,26 +880,26 @@ std::pair<int32_t, int32_t> card::get_atk_def() {
 	if (swap_final)
 		std::swap(temp.attack, temp.defense);
 	// The Wicked
-	for (int32_t i = 0; i < effects_atk_wicked.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects_atk_wicked.size(); ++i) {
 		atk = effects_atk_wicked[i]->get_value(this);
 		if (atk < 0)
 			atk = 0;
 		temp.attack = atk;
 	}
-	for (int32_t i = 0; i < effects_def_wicked.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects_def_wicked.size(); ++i) {
 		def = effects_def_wicked[i]->get_value(this);
 		if (def < 0)
 			def = 0;
 		temp.defense = def;
 	}
 	// Gradius' Option
-	for (int32_t i = 0; i < effects_atk_option.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects_atk_option.size(); ++i) {
 		atk = effects_atk_option[i]->get_value(this);
 		if (atk < 0)
 			atk = 0;
 		temp.attack = atk;
 	}
-	for (int32_t i = 0; i < effects_def_option.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects_def_option.size(); ++i) {
 		def = effects_def_option[i]->get_value(this);
 		if (def < 0)
 			def = 0;
@@ -961,7 +961,7 @@ uint32_t card::get_level() {
 	int32_t up = 0;
 	filter_effect(EFFECT_UPDATE_LEVEL, &effects, FALSE);
 	filter_effect(EFFECT_CHANGE_LEVEL, &effects);
-	for (int32_t i = 0; i < effects.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects.size(); ++i) {
 		switch (effects[i]->code) {
 		case EFFECT_UPDATE_LEVEL:
 			up += effects[i]->get_value(this);
@@ -994,7 +994,7 @@ uint32_t card::get_rank() {
 	int32_t up = 0;
 	filter_effect(EFFECT_UPDATE_RANK, &effects, FALSE);
 	filter_effect(EFFECT_CHANGE_RANK, &effects);
-	for (int32_t i = 0; i < effects.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects.size(); ++i) {
 		switch (effects[i]->code) {
 		case EFFECT_UPDATE_RANK:
 			up += effects[i]->get_value(this);
@@ -1064,7 +1064,7 @@ uint32_t card::check_xyz_level(card* pcard, uint32_t lv) {
 			return (card_lv & MAX_XYZ_LEVEL) | ((uint32_t)min_count << 12);
 		return 0;
 	}
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(this, PARAM_TYPE_CARD);
 		pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
 		uint32_t lev = eset[i]->get_value(2);
@@ -1097,7 +1097,7 @@ uint32_t card::get_attribute() {
 	filter_effect(EFFECT_ADD_ATTRIBUTE, &effects, FALSE);
 	filter_effect(EFFECT_REMOVE_ATTRIBUTE, &effects, FALSE);
 	filter_effect(EFFECT_CHANGE_ATTRIBUTE, &effects);
-	for (int32_t i = 0; i < effects.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects.size(); ++i) {
 		if (effects[i]->code == EFFECT_ADD_ATTRIBUTE)
 			attribute |= effects[i]->get_value(this);
 		else if (effects[i]->code == EFFECT_REMOVE_ATTRIBUTE)
@@ -1115,7 +1115,7 @@ uint32_t card::get_fusion_attribute(uint8_t playerid) {
 	if(!effects.size() || pduel->game_field->core.not_material)
 		return get_attribute();
 	uint32_t attribute = 0;
-	for(int32_t i = 0; i < effects.size(); ++i) {
+	for(effect_set::size_type i = 0; i < effects.size(); ++i) {
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		attribute = effects[i]->get_value(this, 1);
 	}
@@ -1125,7 +1125,7 @@ uint32_t card::get_link_attribute(uint8_t playerid) {
 	effect_set effects;
 	filter_effect(EFFECT_ADD_LINK_ATTRIBUTE, &effects);
 	uint32_t attribute = get_attribute();
-	for (int32_t i = 0; i < effects.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects.size(); ++i) {
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		attribute |= effects[i]->get_value(this, 1);
 	}
@@ -1139,7 +1139,7 @@ uint32_t card::get_grave_attribute(uint8_t playerid) {
 	uint32_t attribute = data.attribute;
 	effect_set eset;
 	pduel->game_field->filter_player_effect(playerid, EFFECT_CHANGE_GRAVE_ATTRIBUTE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			attribute = eset[i]->get_value(this);
 		else {
@@ -1164,7 +1164,7 @@ uint32_t card::get_race() {
 	filter_effect(EFFECT_ADD_RACE, &effects, FALSE);
 	filter_effect(EFFECT_REMOVE_RACE, &effects, FALSE);
 	filter_effect(EFFECT_CHANGE_RACE, &effects);
-	for (int32_t i = 0; i < effects.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects.size(); ++i) {
 		if (effects[i]->code == EFFECT_ADD_RACE)
 			race |= effects[i]->get_value(this);
 		else if (effects[i]->code == EFFECT_REMOVE_RACE)
@@ -1180,7 +1180,7 @@ uint32_t card::get_link_race(uint8_t playerid) {
 	effect_set effects;
 	filter_effect(EFFECT_ADD_LINK_RACE, &effects);
 	uint32_t race = get_race();
-	for (int32_t i = 0; i < effects.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects.size(); ++i) {
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		race |= effects[i]->get_value(this, 1);
 	}
@@ -1194,7 +1194,7 @@ uint32_t card::get_grave_race(uint8_t playerid) {
 	uint32_t race = data.race;
 	effect_set eset;
 	pduel->game_field->filter_player_effect(playerid, EFFECT_CHANGE_GRAVE_RACE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			race = eset[i]->get_value(this);
 		else {
@@ -1217,7 +1217,7 @@ uint32_t card::get_lscale() {
 	int32_t up = 0, upc = 0;
 	filter_effect(EFFECT_UPDATE_LSCALE, &effects, FALSE);
 	filter_effect(EFFECT_CHANGE_LSCALE, &effects);
-	for (int32_t i = 0; i < effects.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects.size(); ++i) {
 		if (effects[i]->code == EFFECT_UPDATE_LSCALE) {
 			if ((effects[i]->type & EFFECT_TYPE_SINGLE) && !effects[i]->is_flag(EFFECT_FLAG_SINGLE_RANGE))
 				up += effects[i]->get_value(this);
@@ -1246,7 +1246,7 @@ uint32_t card::get_rscale() {
 	int32_t up = 0, upc = 0;
 	filter_effect(EFFECT_UPDATE_RSCALE, &effects, FALSE);
 	filter_effect(EFFECT_CHANGE_RSCALE, &effects);
-	for (int32_t i = 0; i < effects.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects.size(); ++i) {
 		if (effects[i]->code == EFFECT_UPDATE_RSCALE) {
 			if ((effects[i]->type & EFFECT_TYPE_SINGLE) && !effects[i]->is_flag(EFFECT_FLAG_SINGLE_RANGE))
 				up += effects[i]->get_value(this);
@@ -2276,7 +2276,7 @@ int32_t card::leave_field_redirect(uint32_t reason) {
 	if(data.type & TYPE_TOKEN)
 		return 0;
 	filter_effect(EFFECT_LEAVE_FIELD_REDIRECT, &es);
-	for(int32_t i = 0; i < es.size(); ++i) {
+	for(effect_set::size_type i = 0; i < es.size(); ++i) {
 		redirect = es[i]->get_value(this, 0);
 		if((redirect & LOCATION_HAND) && !is_affected_by_effect(EFFECT_CANNOT_TO_HAND) && pduel->game_field->is_player_can_send_to_hand(es[i]->get_handler_player(), this))
 			redirects |= redirect;
@@ -2314,7 +2314,7 @@ int32_t card::destination_redirect(uint8_t destination, uint32_t reason) {
 		filter_effect(EFFECT_REMOVE_REDIRECT, &es);
 	else
 		return 0;
-	for(int32_t i = 0; i < es.size(); ++i) {
+	for(effect_set::size_type i = 0; i < es.size(); ++i) {
 		redirect = es[i]->get_value(this, 0);
 		if((redirect & LOCATION_HAND) && !is_affected_by_effect(EFFECT_CANNOT_TO_HAND) && pduel->game_field->is_player_can_send_to_hand(es[i]->get_handler_player(), this))
 			return redirect;
@@ -2389,7 +2389,7 @@ int32_t card::is_can_add_counter(uint8_t playerid, uint16_t countertype, uint16_
 	uint32_t check = countertype & COUNTER_WITHOUT_PERMIT;
 	if(!check) {
 		filter_effect(EFFECT_COUNTER_PERMIT + countertype, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			uint32_t prange = eset[i]->range;
 			if(loc)
 				check = loc & prange;
@@ -2422,7 +2422,7 @@ int32_t card::is_can_have_counter(uint16_t countertype) {
 	else {
 		filter_self_effect(EFFECT_COUNTER_PERMIT + countertype, &eset);
 		if (current.is_location(LOCATION_ONFIELD)) {
-			for (int32_t i = 0; i < eset.size(); ++i) {
+			for (effect_set::size_type i = 0; i < eset.size(); ++i) {
 				if (eset[i]->is_single_ready())
 					return TRUE;
 			}
@@ -2450,7 +2450,7 @@ void card::set_material(card_set* materials) {
 		pcard->current.reason_card = this;
 	effect_set eset;
 	filter_effect(EFFECT_MATERIAL_CHECK, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		eset[i]->get_value(this);
 	}
 }
@@ -2544,7 +2544,7 @@ void card::set_special_summon_status(effect* peffect) {
 		spsummon.setcode.clear();
 		effect_set eset;
 		pcard->filter_effect(EFFECT_ADD_SETCODE, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			spsummon.setcode.push_back(eset[i]->get_value(pcard) & 0xffffU);
 		}
 		spsummon.reason_effect = peffect;
@@ -2566,7 +2566,7 @@ void card::set_special_summon_status(effect* peffect) {
 		spsummon.setcode.clear();
 		effect_set eset;
 		pcard->filter_effect(EFFECT_ADD_SETCODE, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			spsummon.setcode.push_back(eset[i]->get_value(pcard) & 0xffffU);
 		}
 		spsummon.reason_effect = cait->triggering_effect;
@@ -2698,7 +2698,7 @@ int32_t card::filter_summon_procedure(uint8_t playerid, effect_set* peset, uint8
 	effect_set eset;
 	filter_effect(EFFECT_LIMIT_SUMMON_PROC, &eset);
 	if(eset.size()) {
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			if(check_summon_procedure(eset[i], playerid, ignore_count, min_tribute, zone))
 				peset->push_back(eset[i]);
 		}
@@ -2708,7 +2708,7 @@ int32_t card::filter_summon_procedure(uint8_t playerid, effect_set* peset, uint8
 	}
 	eset.clear();
 	filter_effect(EFFECT_SUMMON_PROC, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(check_summon_procedure(eset[i], playerid, ignore_count, min_tribute, zone))
 			peset->push_back(eset[i]);
 	}
@@ -2730,7 +2730,7 @@ int32_t card::filter_summon_procedure(uint8_t playerid, effect_set* peset, uint8
 			&& pduel->game_field->core.summon_count[playerid] >= pduel->game_field->get_summon_count_limit(playerid)) {
 		effect_set extra_count;
 		filter_effect(EFFECT_EXTRA_SUMMON_COUNT, &extra_count);
-		for(int32_t i = 0; i < extra_count.size(); ++i) {
+		for(effect_set::size_type i = 0; i < extra_count.size(); ++i) {
 			std::vector<lua_Integer> retval;
 			extra_count[i]->get_value(this, 0, retval);
 			int32_t new_min = retval.size() > 0 ? static_cast<int32_t>(retval[0]) : 0;
@@ -2763,7 +2763,7 @@ int32_t card::check_summon_procedure(effect* proc, uint8_t playerid, uint8_t ign
 			&& pduel->game_field->core.summon_count[playerid] >= pduel->game_field->get_summon_count_limit(playerid)) {
 		effect_set eset;
 		filter_effect(EFFECT_EXTRA_SUMMON_COUNT, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			std::vector<lua_Integer> retval;
 			eset[i]->get_value(this, 0, retval);
 			int32_t new_min_tribute = retval.size() > 0 ? static_cast<int32_t>(retval[0]) : 0;
@@ -2784,7 +2784,7 @@ int32_t card::filter_set_procedure(uint8_t playerid, effect_set* peset, uint8_t 
 	effect_set eset;
 	filter_effect(EFFECT_LIMIT_SET_PROC, &eset);
 	if(eset.size()) {
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			if(check_set_procedure(eset[i], playerid, ignore_count, min_tribute, zone))
 				peset->push_back(eset[i]);
 		}
@@ -2794,7 +2794,7 @@ int32_t card::filter_set_procedure(uint8_t playerid, effect_set* peset, uint8_t 
 	}
 	eset.clear();
 	filter_effect(EFFECT_SET_PROC, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(check_set_procedure(eset[i], playerid, ignore_count, min_tribute, zone))
 			peset->push_back(eset[i]);
 	}
@@ -2813,7 +2813,7 @@ int32_t card::filter_set_procedure(uint8_t playerid, effect_set* peset, uint8_t 
 			&& pduel->game_field->core.summon_count[playerid] >= pduel->game_field->get_summon_count_limit(playerid)) {
 		effect_set extra_count;
 		filter_effect(EFFECT_EXTRA_SET_COUNT, &extra_count);
-		for(int32_t i = 0; i < extra_count.size(); ++i) {
+		for(effect_set::size_type i = 0; i < extra_count.size(); ++i) {
 			std::vector<lua_Integer> retval;
 			extra_count[i]->get_value(this, 0, retval);
 			int32_t new_min = retval.size() > 0 ? static_cast<int32_t>(retval[0]) : 0;
@@ -2843,7 +2843,7 @@ int32_t card::check_set_procedure(effect* proc, uint8_t playerid, uint8_t ignore
 			&& pduel->game_field->core.summon_count[playerid] >= pduel->game_field->get_summon_count_limit(playerid)) {
 		effect_set eset;
 		filter_effect(EFFECT_EXTRA_SET_COUNT, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			std::vector<lua_Integer> retval;
 			eset[i]->get_value(this, 0, retval);
 			int32_t new_min_tribute = retval.size() > 0 ? static_cast<int32_t>(retval[0]) : 0;
@@ -3001,7 +3001,7 @@ int32_t card::fusion_check(group* fusion_m, card* cg, uint32_t chkf, uint8_t not
 		for(auto cit = matgroup->container.begin(); cit != matgroup->container.end();) {
 			card* pcard = *cit;
 			bool is_erase = false;
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
 				pduel->lua->add_param(this, PARAM_TYPE_CARD);
 				pduel->lua->add_param(summon_type, PARAM_TYPE_INT);
@@ -3051,7 +3051,7 @@ void card::fusion_select(uint8_t playerid, group* fusion_m, card* cg, uint32_t c
 		for(auto cit = matgroup->container.begin(); cit != matgroup->container.end();) {
 			card* pcard = *cit;
 			bool is_erase = false;
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
 				pduel->lua->add_param(this, PARAM_TYPE_CARD);
 				pduel->lua->add_param(summon_type, PARAM_TYPE_INT);
@@ -3079,7 +3079,7 @@ int32_t card::check_fusion_substitute(card* fcard) {
 	filter_effect(EFFECT_FUSION_SUBSTITUTE, &eset);
 	if(eset.size() == 0)
 		return FALSE;
-	for(int32_t i = 0; i < eset.size(); ++i)
+	for(effect_set::size_type i = 0; i < eset.size(); ++i)
 		if(!eset[i]->value || eset[i]->get_value(fcard))
 			return TRUE;
 	return FALSE;
@@ -3089,7 +3089,7 @@ int32_t card::is_not_tuner(card* scard) {
 		return TRUE;
 	effect_set eset;
 	filter_effect(EFFECT_NONTUNER, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i)
+	for(effect_set::size_type i = 0; i < eset.size(); ++i)
 		if(!eset[i]->value || eset[i]->get_value(scard))
 			return TRUE;
 	return FALSE;
@@ -3099,7 +3099,7 @@ int32_t card::is_tuner(card* scard) {
 		return TRUE;
 	effect_set eset;
 	filter_effect(EFFECT_TUNER, &eset);
-	for (int32_t i = 0; i < eset.size(); ++i)
+	for (effect_set::size_type i = 0; i < eset.size(); ++i)
 		if (!eset[i]->value || eset[i]->get_value(scard))
 			return TRUE;
 	return FALSE;
@@ -3145,7 +3145,7 @@ int32_t card::check_cost_condition(int32_t ecode, int32_t playerid) {
 	int32_t res = TRUE;
 	effect* oreason = pduel->game_field->core.reason_effect;
 	uint8_t op = pduel->game_field->core.reason_player;
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		effect* peffect = eset[i];
 		pduel->game_field->core.reason_effect = peffect;
 		pduel->game_field->core.reason_player = playerid;
@@ -3168,7 +3168,7 @@ int32_t card::check_cost_condition(int32_t ecode, int32_t playerid, int32_t sumt
 	int32_t res = TRUE;
 	effect* oreason = pduel->game_field->core.reason_effect;
 	uint8_t op = pduel->game_field->core.reason_player;
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		effect* peffect = eset[i];
 		pduel->game_field->core.reason_effect = peffect;
 		pduel->game_field->core.reason_player = playerid;
@@ -3203,7 +3203,7 @@ int32_t card::is_spsummonable_card() {
 	}
 	effect_set eset;
 	filter_effect(EFFECT_SPSUMMON_CONDITION, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(pduel->game_field->core.reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(pduel->game_field->core.reason_player, PARAM_TYPE_INT);
 		pduel->lua->add_param(SUMMON_TYPE_SPECIAL, PARAM_TYPE_INT);
@@ -3222,7 +3222,7 @@ int32_t card::is_fusion_summonable_card(uint32_t summon_type) {
 	summon_type |= SUMMON_TYPE_FUSION;
 	effect_set eset;
 	filter_effect(EFFECT_SPSUMMON_CONDITION, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(pduel->game_field->core.reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(pduel->game_field->core.reason_player, PARAM_TYPE_INT);
 		pduel->lua->add_param(summon_type, PARAM_TYPE_INT);
@@ -3385,7 +3385,7 @@ int32_t card::get_summon_tribute_count() {
 	std::vector<int32_t> duplicate;
 	effect_set eset;
 	filter_effect(EFFECT_DECREASE_TRIBUTE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(eset[i]->is_flag(EFFECT_FLAG_COUNT_LIMIT) && eset[i]->count_limit == 0)
 			continue;
 		std::vector<lua_Integer> retval;
@@ -3418,7 +3418,7 @@ int32_t card::get_set_tribute_count() {
 	std::vector<int32_t> duplicate;
 	effect_set eset;
 	filter_effect(EFFECT_DECREASE_TRIBUTE_SET, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(eset[i]->is_flag(EFFECT_FLAG_COUNT_LIMIT) && eset[i]->count_limit == 0)
 			continue;
 		std::vector<lua_Integer> retval;
@@ -3527,7 +3527,7 @@ int32_t card::is_can_be_special_summoned(effect* reason_effect, uint32_t sumtype
 			return FALSE;
 		}
 		filter_effect(EFFECT_SPSUMMON_CONDITION, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 			pduel->lua->add_param(sumplayer, PARAM_TYPE_INT);
 			pduel->lua->add_param(sumtype, PARAM_TYPE_INT);
@@ -3553,7 +3553,7 @@ uint8_t card::get_spsummonable_position(effect* reason_effect, uint32_t sumtype,
 		if((data.type & (TYPE_TOKEN | TYPE_LINK)) && (positions[p] & POS_FACEDOWN))
 			continue;
 		pduel->game_field->filter_player_effect(sumplayer, EFFECT_LIMIT_SPECIAL_SUMMON_POSITION, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			if(!eset[i]->target)
 				continue;
 			pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3661,7 +3661,7 @@ effect* card::check_indestructable_by_effect(effect* reason_effect, uint8_t play
 		return nullptr;
 	effect_set eset;
 	filter_effect(EFFECT_INDESTRUCTABLE_EFFECT, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		pduel->lua->add_param(this, PARAM_TYPE_CARD);
@@ -3678,7 +3678,7 @@ int32_t card::is_destructable_by_effect(effect* reason_effect, uint8_t playerid)
 	effect_set eset;
 	eset.clear();
 	filter_effect(EFFECT_INDESTRUCTABLE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(REASON_EFFECT, PARAM_TYPE_INT);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
@@ -3689,7 +3689,7 @@ int32_t card::is_destructable_by_effect(effect* reason_effect, uint8_t playerid)
 	}
 	eset.clear();
 	filter_effect(EFFECT_INDESTRUCTABLE_COUNT, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(eset[i]->is_flag(EFFECT_FLAG_COUNT_LIMIT)) {
 			if(eset[i]->count_limit == 0)
 				continue;
@@ -3788,7 +3788,7 @@ int32_t card::is_releasable_by_effect(uint8_t playerid, effect* reason_effect) {
 		return TRUE;
 	effect_set eset;
 	filter_effect(EFFECT_UNRELEASABLE_EFFECT, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		pduel->lua->add_param(this, PARAM_TYPE_CARD);
@@ -4031,14 +4031,14 @@ int32_t card::is_capable_be_effect_target(effect* reason_effect, uint8_t playeri
 		return FALSE;
 	effect_set eset;
 	filter_effect(EFFECT_CANNOT_BE_EFFECT_TARGET, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		if(eset[i]->get_value(reason_effect, 1))
 			return FALSE;
 	}
 	eset.clear();
 	reason_effect->get_handler()->filter_effect(EFFECT_CANNOT_SELECT_EFFECT_TARGET, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(this, PARAM_TYPE_CARD);
 		if(eset[i]->get_value(reason_effect, 1))
 			return FALSE;
@@ -4061,7 +4061,7 @@ int32_t card::is_can_be_fusion_material(card* fcard, uint32_t summon_type) {
 		return TRUE;
 	effect_set eset;
 	filter_effect(EFFECT_CANNOT_BE_FUSION_MATERIAL, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(summon_type, PARAM_TYPE_INT);
 		if(eset[i]->get_value(fcard, 1))
 			return FALSE;
@@ -4069,7 +4069,7 @@ int32_t card::is_can_be_fusion_material(card* fcard, uint32_t summon_type) {
 	eset.clear();
 	filter_effect(EFFECT_EXTRA_FUSION_MATERIAL, &eset);
 	if(eset.size()) {
-		for(int32_t i = 0; i < eset.size(); ++i)
+		for(effect_set::size_type i = 0; i < eset.size(); ++i)
 			if(eset[i]->get_value(fcard))
 				return TRUE;
 		return FALSE;
@@ -4090,14 +4090,14 @@ int32_t card::is_can_be_synchro_material(card* scard, card* tuner) {
 	}
 	effect_set eset;
 	filter_effect(EFFECT_CANNOT_BE_SYNCHRO_MATERIAL, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i)
+	for(effect_set::size_type i = 0; i < eset.size(); ++i)
 		if(eset[i]->get_value(scard))
 			return FALSE;
 	if(scard && !(current.location == LOCATION_MZONE && current.controler == scard->current.controler)) {
 		eset.clear();
 		filter_effect(EFFECT_EXTRA_SYNCHRO_MATERIAL, &eset);
 		if(eset.size()) {
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				if(!eset[i]->check_count_limit(scard->current.controler))
 					continue;
 				if(eset[i]->get_value(scard))
@@ -4114,7 +4114,7 @@ int32_t card::is_can_be_ritual_material(card* scard) {
 	if(current.location == LOCATION_GRAVE) {
 		effect_set eset;
 		filter_effect(EFFECT_EXTRA_RITUAL_MATERIAL, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i)
+		for(effect_set::size_type i = 0; i < eset.size(); ++i)
 			if(eset[i]->get_value(scard))
 				return TRUE;
 		return FALSE;
@@ -4130,7 +4130,7 @@ int32_t card::is_can_be_xyz_material(card* scard) {
 		return FALSE;
 	effect_set eset;
 	filter_effect(EFFECT_CANNOT_BE_XYZ_MATERIAL, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i)
+	for(effect_set::size_type i = 0; i < eset.size(); ++i)
 		if(eset[i]->get_value(scard))
 			return FALSE;
 	return TRUE;
@@ -4142,7 +4142,7 @@ int32_t card::is_can_be_link_material(card* scard) {
 		return FALSE;
 	effect_set eset;
 	filter_effect(EFFECT_CANNOT_BE_LINK_MATERIAL, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i)
+	for(effect_set::size_type i = 0; i < eset.size(); ++i)
 		if(eset[i]->get_value(scard))
 			return FALSE;
 	return TRUE;

--- a/card.cpp
+++ b/card.cpp
@@ -1047,10 +1047,10 @@ uint32_t card::check_xyz_level(card* pcard, uint32_t lv) {
 	int32_t min_count = 0;
 	effect_set mset;
 	filter_effect(EFFECT_XYZ_MIN_COUNT, &mset);
-	for (int32_t i = 0; i < mset.size(); ++i) {
+	for (auto& peffect: mset) {
 		pduel->lua->add_param(this, PARAM_TYPE_CARD);
 		pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
-		int32_t count = mset[i]->get_value(2);
+		int32_t count = peffect->get_value(2);
 		if (count > min_count)
 			min_count = count;
 	}
@@ -1064,10 +1064,10 @@ uint32_t card::check_xyz_level(card* pcard, uint32_t lv) {
 			return (card_lv & MAX_XYZ_LEVEL) | ((uint32_t)min_count << 12);
 		return 0;
 	}
-	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
+	for (auto& peffect: mset) {
 		pduel->lua->add_param(this, PARAM_TYPE_CARD);
 		pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
-		uint32_t lev = eset[i]->get_value(2);
+		uint32_t lev = peffect->get_value(2);
 		uint16_t lv1 = lev & MAX_XYZ_LEVEL;
 		uint16_t count1 = (lev & 0xf000) >> 12;
 		if (count1 < min_count)

--- a/card.cpp
+++ b/card.cpp
@@ -1023,9 +1023,9 @@ uint32_t card::get_mat_level_from_effect(card* pcard, uint32_t effect_code) {
 		return 0;
 	effect_set eset;
 	filter_effect(effect_code, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
-		uint32_t lev = eset[i]->get_value(pcard);
-		if(lev)
+	for (auto& peffect : eset) {
+		uint32_t lev = peffect->get_value(pcard);
+		if (lev)
 			return lev;
 	}
 	return 0;

--- a/effect.cpp
+++ b/effect.cpp
@@ -216,7 +216,7 @@ int32_t effect::get_required_handorset_effects(effect_set* eset, uint8_t playeri
 	uint8_t op = pduel->game_field->core.reason_player;
 	pduel->game_field->core.reason_player = playerid;
 	pduel->game_field->save_lp_cost();
-	for(int32_t i = 0; i < tmp_eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < tmp_eset.size(); ++i) {
 		auto peffect = tmp_eset[i];
 		if(peffect->check_count_limit(playerid)) {
 			pduel->game_field->core.reason_effect = peffect;
@@ -378,7 +378,7 @@ int32_t effect::is_activateable(uint8_t playerid, const tevent& e, int32_t negle
 int32_t effect::is_action_check(uint8_t playerid) {
 	effect_set eset;
 	pduel->game_field->filter_player_effect(playerid, EFFECT_CANNOT_ACTIVATE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(this, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		if(eset[i]->check_value_condition(2))
@@ -386,7 +386,7 @@ int32_t effect::is_action_check(uint8_t playerid) {
 	}
 	eset.clear();
 	pduel->game_field->filter_player_effect(playerid, EFFECT_ACTIVATE_COST, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(this, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
@@ -574,7 +574,7 @@ int32_t effect::is_player_effect_target(card* pcard) {
 }
 int32_t effect::is_immuned(card* pcard) {
 	const effect_set_v& effects = pcard->immune_effect;
-	for (int32_t i = 0; i < effects.size(); ++i) {
+	for (effect_set::size_type i = 0; i < effects.size(); ++i) {
 		effect* peffect = effects[i];
 		if(peffect->is_available() && peffect->value) {
 			pduel->lua->add_param(this, PARAM_TYPE_EFFECT);

--- a/effect.cpp
+++ b/effect.cpp
@@ -232,7 +232,7 @@ int32_t effect::get_required_handorset_effects(effect_set* eset, uint8_t playeri
 			pduel->lua->add_param(this, PARAM_TYPE_EFFECT);
 			if(pduel->lua->check_condition(peffect->cost, 10)) {
 				available = 2;
-				eset->add_item(peffect);
+				eset->push_back(peffect);
 			}
 		}
 	}

--- a/effect.h
+++ b/effect.h
@@ -18,8 +18,6 @@ class duel;
 class group;
 class effect;
 struct tevent;
-struct effect_set;
-struct effect_set_v;
 enum effect_flag : uint64_t;
 enum effect_flag2 : uint64_t;
 enum effect_category :uint64_t;

--- a/effectset.h
+++ b/effectset.h
@@ -8,7 +8,6 @@
 #ifndef EFFECTSET_H_
 #define EFFECTSET_H_
 
-#include <array>
 #include <vector>
 #include <algorithm>
 
@@ -16,96 +15,7 @@ class effect;
 
 bool effect_sort_id(const effect* e1, const effect* e2);
 
-// std::array<effect*, 64>
-struct effect_set {
-	void add_item(effect* peffect) {
-		if (count >= 64)
-			return;
-		container[count++] = peffect;
-	}
-	void remove_item(int index) {
-		if (index < 0 || index >= count)
-			return;
-		for(int i = index; i < count - 1; ++i)
-			container[i] = container[i + 1];
-		--count;
-	}
-	void clear() {
-		count = 0;
-	}
-	int size() const {
-		return count;
-	}
-	void sort() {
-		if(count < 2)
-			return;
-		std::sort(container.begin(), container.begin() + count, effect_sort_id);
-	}
-	effect* const& get_last() const {
-		assert(count);
-		return container[count - 1];
-	}
-	effect*& get_last() {
-		assert(count);
-		return container[count - 1];
-	}
-	effect* const& operator[] (int index) const {
-		return container[index];
-	}
-	effect*& operator[] (int index) {
-		return container[index];
-	}
-	effect* const& at(int index) const {
-		return container[index];
-	}
-	effect*& at(int index) {
-		return container[index];
-	}
-private:
-	std::array<effect*, 64> container{ nullptr };
-	int count{ 0 };
-};
-
-struct effect_set_v {
-	void add_item(effect* peffect) {
-		container.push_back(peffect);
-	}
-	void remove_item(int index) {
-		if (index < 0 || index >= (int)container.size())
-			return;
-		container.erase(container.begin() + index);
-	}
-	void clear() {
-		container.clear();
-	}
-	int size() const {
-		return (int)container.size();
-	}
-	void sort() {
-		std::sort(container.begin(), container.end(), effect_sort_id);
-	}
-	effect* const& get_last() const {
-		assert(container.size());
-		return container.back();
-	}
-	effect*& get_last() {
-		assert(container.size());
-		return container.back();
-	}
-	effect* const& operator[] (int index) const {
-		return container[index];
-	}
-	effect*& operator[] (int index) {
-		return container[index];
-	}
-	effect* const& at(int index) const {
-		return container[index];
-	}
-	effect*& at(int index) {
-		return container[index];
-	}
-private:
-	std::vector<effect*> container;
-};
+using effect_set = std::vector<effect*>;
+using effect_set_v = effect_set;
 
 #endif //EFFECTSET_H_

--- a/field.cpp
+++ b/field.cpp
@@ -763,7 +763,7 @@ int32_t field::get_mzone_limit(uint8_t playerid, uint8_t uplayer, uint32_t reaso
 	effect_set eset;
 	if(uplayer < 2)
 		filter_player_effect(playerid, EFFECT_MAX_MZONE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		pduel->lua->add_param(uplayer, PARAM_TYPE_INT);
 		pduel->lua->add_param(reason, PARAM_TYPE_INT);
@@ -788,7 +788,7 @@ int32_t field::get_szone_limit(uint8_t playerid, uint8_t uplayer, uint32_t reaso
 	if(uplayer < 2)
 		filter_player_effect(playerid, EFFECT_MAX_SZONE, &eset);
 	int32_t max = 5;
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		pduel->lua->add_param(uplayer, PARAM_TYPE_INT);
 		pduel->lua->add_param(reason, PARAM_TYPE_INT);
@@ -835,7 +835,7 @@ void field::filter_must_use_mzone(uint8_t playerid, uint8_t uplayer, uint32_t re
 		filter_player_effect(uplayer, EFFECT_MUST_USE_MZONE, &eset);
 	if(pcard)
 		pcard->filter_effect(EFFECT_MUST_USE_MZONE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(eset[i]->is_flag(EFFECT_FLAG_COUNT_LIMIT) && eset[i]->count_limit == 0)
 			continue;
 		uint32_t value = 0x1f;
@@ -1752,7 +1752,7 @@ int32_t field::get_summon_release_list(card* target, card_set* release_list, car
 	card_set ex_tribute;
 	effect_set eset;
 	target->filter_effect(EFFECT_ADD_EXTRA_TRIBUTE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(eset[i]->get_value() & pos)
 			filter_inrange_cards(eset[i], &ex_tribute);
 	}
@@ -1815,7 +1815,7 @@ int32_t field::get_summon_count_limit(uint8_t playerid) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_SET_SUMMON_COUNT_LIMIT, &eset);
 	int32_t count = 1;
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		int32_t c = eset[i]->get_value();
 		if(c > count)
 			count = c;
@@ -1829,7 +1829,7 @@ int32_t field::get_draw_count(uint8_t playerid) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_DRAW_COUNT, &eset);
 	int32_t count = player[playerid].draw_count;
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		int32_t c = eset[i]->get_value();
 		if(c == 0)
 			return 0;
@@ -2303,7 +2303,7 @@ int32_t field::check_lp_cost(uint8_t playerid, int32_t cost, uint32_t must_pay) 
 	effect_set eset;
 	int32_t val = cost;
 	filter_player_effect(playerid, EFFECT_LPCOST_CHANGE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(core.reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		pduel->lua->add_param(val, PARAM_TYPE_INT);
@@ -2416,7 +2416,7 @@ int32_t field::get_attack_target(card* pcard, card_vector* v, uint8_t chain_atta
 	int32_t extra_count = 0;
 	effect_set eset;
 	pcard->filter_effect(EFFECT_EXTRA_ATTACK, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		int32_t val = eset[i]->get_value(pcard);
 		if(val > extra_count)
 			extra_count = val;
@@ -2424,7 +2424,7 @@ int32_t field::get_attack_target(card* pcard, card_vector* v, uint8_t chain_atta
 	int32_t extra_count_m = 0;
 	eset.clear();
 	pcard->filter_effect(EFFECT_EXTRA_ATTACK_MONSTER, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		int32_t val = eset[i]->get_value(pcard);
 		if(val > extra_count_m)
 			extra_count_m = val;
@@ -2504,7 +2504,7 @@ void field::attack_all_target_check() {
 int32_t field::get_must_material_list(uint8_t playerid, uint32_t limit, card_set* must_list) {
 	effect_set eset;
 	filter_player_effect(playerid, limit, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i)
+	for(effect_set::size_type i = 0; i < eset.size(); ++i)
 		must_list->insert(eset[i]->handler);
 	return (int32_t)must_list->size();
 }
@@ -3083,7 +3083,7 @@ int32_t field::is_player_can_discard_deck_as_cost(uint8_t playerid, int32_t coun
 	bool cant_remove_o = !is_player_can_action(1 - playerid, EFFECT_CANNOT_REMOVE);
 	effect_set eset;
 	filter_field_effect(EFFECT_TO_GRAVE_REDIRECT, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		uint32_t redirect = eset[i]->get_value();
 		uint8_t p = eset[i]->get_handler_player();
 		if(redirect & LOCATION_REMOVED) {
@@ -3102,7 +3102,7 @@ int32_t field::is_player_can_discard_hand(uint8_t playerid, card * pcard, effect
 		return FALSE;
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_DISCARD_HAND, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3117,7 +3117,7 @@ int32_t field::is_player_can_discard_hand(uint8_t playerid, card * pcard, effect
 int32_t field::is_player_can_action(uint8_t playerid, uint32_t actionlimit) {
 	effect_set eset;
 	filter_player_effect(playerid, actionlimit, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 	}
@@ -3127,7 +3127,7 @@ int32_t field::is_player_can_summon(uint32_t sumtype, uint8_t playerid, card * p
 	effect_set eset;
 	sumtype |= SUMMON_TYPE_NORMAL;
 	filter_player_effect(playerid, EFFECT_CANNOT_SUMMON, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3145,7 +3145,7 @@ int32_t field::is_player_can_mset(uint32_t sumtype, uint8_t playerid, card * pca
 	effect_set eset;
 	sumtype |= SUMMON_TYPE_NORMAL;
 	filter_player_effect(playerid, EFFECT_CANNOT_MSET, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3162,7 +3162,7 @@ int32_t field::is_player_can_mset(uint32_t sumtype, uint8_t playerid, card * pca
 int32_t field::is_player_can_sset(uint8_t playerid, card * pcard) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_SSET, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3177,7 +3177,7 @@ int32_t field::is_player_can_sset(uint8_t playerid, card * pcard) {
 int32_t field::is_player_can_spsummon(uint8_t playerid) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_SPECIAL_SUMMON, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 	}
@@ -3206,7 +3206,7 @@ int32_t field::is_player_can_spsummon(effect* reason_effect, uint32_t sumtype, u
 		position = (position & POS_FACEUP) | ((position & POS_FACEDOWN) >> 1);
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_SPECIAL_SUMMON, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3228,7 +3228,7 @@ int32_t field::is_player_can_spsummon(effect* reason_effect, uint32_t sumtype, u
 int32_t field::is_player_can_flipsummon(uint8_t playerid, card * pcard) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_FLIP_SUMMON, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3248,7 +3248,7 @@ int32_t field::is_player_can_spsummon_monster(uint8_t playerid, uint8_t toplayer
 int32_t field::is_player_can_release(uint8_t playerid, card* pcard, uint32_t reason) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_RELEASE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3263,7 +3263,7 @@ int32_t field::is_player_can_release(uint8_t playerid, card* pcard, uint32_t rea
 int32_t field::is_player_can_spsummon_count(uint8_t playerid, uint32_t count) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_LEFT_SPSUMMON_COUNT, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(core.reason_effect, PARAM_TYPE_EFFECT);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		int32_t v = eset[i]->get_value(2);
@@ -3275,7 +3275,7 @@ int32_t field::is_player_can_spsummon_count(uint8_t playerid, uint32_t count) {
 int32_t field::is_player_can_place_counter(uint8_t playerid, card * pcard, uint16_t countertype, uint16_t count) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_PLACE_COUNTER, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3327,7 +3327,7 @@ int32_t field::is_player_can_remove_overlay_card(uint8_t playerid, card * pcard,
 int32_t field::is_player_can_send_to_grave(uint8_t playerid, card * pcard) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_TO_GRAVE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3341,7 +3341,7 @@ int32_t field::is_player_can_send_to_grave(uint8_t playerid, card * pcard) {
 int32_t field::is_player_can_send_to_hand(uint8_t playerid, card * pcard) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_TO_HAND, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3358,7 +3358,7 @@ int32_t field::is_player_can_send_to_hand(uint8_t playerid, card * pcard) {
 int32_t field::is_player_can_send_to_deck(uint8_t playerid, card * pcard) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_TO_DECK, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3372,7 +3372,7 @@ int32_t field::is_player_can_send_to_deck(uint8_t playerid, card * pcard) {
 int32_t field::is_player_can_remove(uint8_t playerid, card * pcard, uint32_t reason) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_REMOVE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(!eset[i]->target)
 			return FALSE;
 		pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
@@ -3397,7 +3397,7 @@ int32_t field::is_chain_negatable(uint8_t chaincount) {
 	if(peffect->is_flag(EFFECT_FLAG_CANNOT_INACTIVATE))
 		return FALSE;
 	filter_field_effect(EFFECT_CANNOT_INACTIVATE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		pduel->lua->add_param(chaincount, PARAM_TYPE_INT);
 		if(eset[i]->check_value_condition(1))
 			return FALSE;
@@ -3417,7 +3417,7 @@ int32_t field::is_chain_disablable(uint8_t chaincount) {
 		if(peffect->is_flag(EFFECT_FLAG_CANNOT_DISABLE))
 			return FALSE;
 		filter_field_effect(EFFECT_CANNOT_DISEFFECT, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			pduel->lua->add_param(chaincount, PARAM_TYPE_INT);
 			if(eset[i]->check_value_condition(1))
 				return FALSE;

--- a/field.cpp
+++ b/field.cpp
@@ -1372,10 +1372,10 @@ void field::filter_field_effect(uint32_t code, effect_set* eset, uint8_t sort) {
 		effect* peffect = rg.first->second;
 		++rg.first;
 		if (peffect->is_available())
-			eset->add_item(peffect);
+			eset->push_back(peffect);
 	}
 	if(sort)
-		eset->sort();
+		std::sort(eset->begin(), eset->end(), effect_sort_id);
 }
 //Get all cards in the target range of a EFFECT_TYPE_FIELD effect
 void field::filter_affected_cards(effect* peffect, card_set* cset) {
@@ -1451,10 +1451,10 @@ void field::filter_player_effect(uint8_t playerid, uint32_t code, effect_set* es
 	for (; rg.first != rg.second; ++rg.first) {
 		effect* peffect = rg.first->second;
 		if (peffect->is_target_player(playerid) && peffect->is_available())
-			eset->add_item(peffect);
+			eset->push_back(peffect);
 	}
 	if(sort)
-		eset->sort();
+		std::sort(eset->begin(), eset->end(), effect_sort_id);
 }
 int32_t field::filter_matching_card(lua_State* L, int32_t findex, uint8_t self, uint32_t location1, uint32_t location2, group* pgroup, card* pexception, group* pexgroup, uint32_t extraargs, card** pret, int32_t fcount, int32_t is_target) {
 	if(self != 0 && self != 1)

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -63,7 +63,7 @@ int32_t scriptlib::card_get_fusion_code(lua_State *L) {
 		return count;
 	effect_set eset;
 	pcard->filter_effect(EFFECT_ADD_FUSION_CODE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i)
+	for(effect_set::size_type i = 0; i < eset.size(); ++i)
 		lua_pushinteger(L, eset[i]->get_value(pcard));
 	return count + eset.size();
 }
@@ -80,7 +80,7 @@ int32_t scriptlib::card_get_link_code(lua_State *L) {
 	}
 	effect_set eset;
 	pcard->filter_effect(EFFECT_ADD_LINK_CODE, &eset);
-	for(int32_t i = 0; i < eset.size(); ++i)
+	for(effect_set::size_type i = 0; i < eset.size(); ++i)
 		lua_pushinteger(L, eset[i]->get_value(pcard));
 	return count + eset.size();
 }
@@ -98,7 +98,7 @@ int32_t scriptlib::card_is_fusion_code(lua_State *L) {
 	fcode.insert(code1);
 	if(code2)
 		fcode.insert(code2);
-	for(int32_t i = 0; i < eset.size(); ++i)
+	for(effect_set::size_type i = 0; i < eset.size(); ++i)
 		fcode.insert(eset[i]->get_value(pcard));
 	uint32_t count = lua_gettop(L) - 1;
 	uint32_t result = FALSE;
@@ -128,7 +128,7 @@ int32_t scriptlib::card_is_link_code(lua_State *L) {
 	fcode.insert(code1);
 	if(code2)
 		fcode.insert(code2);
-	for(int32_t i = 0; i < eset.size(); ++i)
+	for(effect_set::size_type i = 0; i < eset.size(); ++i)
 		fcode.insert(eset[i]->get_value(pcard));
 	uint32_t count = lua_gettop(L) - 1;
 	uint32_t result = FALSE;
@@ -1858,7 +1858,7 @@ int32_t scriptlib::card_is_has_effect(lua_State *L) {
 			check_player = PLAYER_NONE;
 	}
 	int32_t size = 0;
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(check_player == PLAYER_NONE || eset[i]->check_count_limit(check_player)) {
 			interpreter::effect2value(L, eset[i]);
 			++size;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1249,7 +1249,7 @@ int32_t scriptlib::duel_is_environment(lua_State *L) {
 		effect_set eset;
 		pduel->game_field->filter_field_effect(EFFECT_CHANGE_ENVIRONMENT, &eset);
 		if(eset.size()) {
-			effect* peffect = eset.get_last();
+			effect* peffect = eset.back();
 			if(code == (uint32_t)peffect->get_value() && (playerid == peffect->get_handler_player() || playerid == PLAYER_ALL))
 				ret = 1;
 		}

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -183,7 +183,7 @@ int32_t scriptlib::duel_get_flag_effect_label(lua_State *L) {
 		lua_pushnil(L);
 		return 1;
 	}
-	for(int32_t i = 0; i < eset.size(); ++i)
+	for(effect_set::size_type i = 0; i < eset.size(); ++i)
 		lua_pushinteger(L, eset[i]->label.size() ? eset[i]->label[0] : 0);
 	return eset.size();
 }
@@ -4281,7 +4281,7 @@ int32_t scriptlib::duel_is_player_affected_by_effect(lua_State *L) {
 	effect_set eset;
 	pduel->game_field->filter_player_effect(playerid, code, &eset);
 	int32_t size = 0;
-	for(int32_t i = 0; i < eset.size(); ++i) {
+	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 		if(eset[i]->check_count_limit(playerid)) {
 			interpreter::effect2value(L, eset[i]);
 			++size;

--- a/operations.cpp
+++ b/operations.cpp
@@ -453,7 +453,7 @@ int32_t field::damage(uint16_t step, effect* reason_effect, uint32_t reason, uin
 			return TRUE;
 		if(!(reason & REASON_RDAMAGE)) {
 			filter_player_effect(playerid, EFFECT_REVERSE_DAMAGE, &eset);
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 				pduel->lua->add_param(reason, PARAM_TYPE_INT);
 				pduel->lua->add_param(reason_player, PARAM_TYPE_INT);
@@ -467,7 +467,7 @@ int32_t field::damage(uint16_t step, effect* reason_effect, uint32_t reason, uin
 		}
 		eset.clear();
 		filter_player_effect(playerid, EFFECT_REFLECT_DAMAGE, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 			pduel->lua->add_param(amount, PARAM_TYPE_INT);
 			pduel->lua->add_param(reason, PARAM_TYPE_INT);
@@ -482,7 +482,7 @@ int32_t field::damage(uint16_t step, effect* reason_effect, uint32_t reason, uin
 		int32_t val = amount;
 		eset.clear();
 		filter_player_effect(playerid, EFFECT_CHANGE_DAMAGE, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 			pduel->lua->add_param(val, PARAM_TYPE_INT);
 			pduel->lua->add_param(reason, PARAM_TYPE_INT);
@@ -495,7 +495,7 @@ int32_t field::damage(uint16_t step, effect* reason_effect, uint32_t reason, uin
 		}
 		eset.clear();
 		filter_player_effect(playerid, EFFECT_REPLACE_DAMAGE, &eset);
-		for (int32_t i = 0; i < eset.size(); ++i) {
+		for (effect_set::size_type i = 0; i < eset.size(); ++i) {
 			pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 			pduel->lua->add_param(val, PARAM_TYPE_INT);
 			pduel->lua->add_param(reason, PARAM_TYPE_INT);
@@ -561,7 +561,7 @@ int32_t field::recover(uint16_t step, effect* reason_effect, uint32_t reason, ui
 			return TRUE;
 		if(!(reason & REASON_RRECOVER)) {
 			filter_player_effect(playerid, EFFECT_REVERSE_RECOVER, &eset);
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 				pduel->lua->add_param(reason, PARAM_TYPE_INT);
 				pduel->lua->add_param(reason_player, PARAM_TYPE_INT);
@@ -619,7 +619,7 @@ int32_t field::pay_lp_cost(uint32_t step, uint8_t playerid, uint32_t cost, uint3
 		effect_set eset;
 		int32_t val = cost;
 		filter_player_effect(playerid, EFFECT_LPCOST_CHANGE, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			pduel->lua->add_param(core.reason_effect, PARAM_TYPE_EFFECT);
 			pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 			pduel->lua->add_param(val, PARAM_TYPE_INT);
@@ -1481,7 +1481,7 @@ int32_t field::summon(uint16_t step, uint8_t sumplayer, card* target, effect* pr
 					core.select_effects.push_back(nullptr);
 					core.select_options.push_back(1);
 				}
-				for(int32_t i = 0; i < eset.size(); ++i) {
+				for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 					core.select_effects.push_back(eset[i]);
 					core.select_options.push_back(eset[i]->description);
 				}
@@ -1505,7 +1505,7 @@ int32_t field::summon(uint16_t step, uint8_t sumplayer, card* target, effect* pr
 		if(target->current.location == LOCATION_MZONE) {
 			core.units.begin()->step = 3;
 			if(!ignore_count && !core.extra_summon[sumplayer]) {
-				for(int32_t i = 0; i < eset.size(); ++i) {
+				for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 					core.units.begin()->ptr1 = eset[i];
 					return FALSE;
 				}
@@ -1524,7 +1524,7 @@ int32_t field::summon(uint16_t step, uint8_t sumplayer, card* target, effect* pr
 			core.select_options.push_back(1);
 		}
 		if(!ignore_count && !core.extra_summon[sumplayer]) {
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				std::vector<lua_Integer> retval;
 				eset[i]->get_value(target, 0, retval);
 				int32_t new_min_tribute = retval.size() > 0 ? static_cast<int32_t>(retval[0]) : 0;
@@ -1646,7 +1646,7 @@ int32_t field::summon(uint16_t step, uint8_t sumplayer, card* target, effect* pr
 		effect_set eset;
 		target->filter_effect(EFFECT_SUMMON_COST, &eset);
 		if(eset.size()) {
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				if(eset[i]->operation) {
 					core.sub_solving_event.push_back(nil_event);
 					add_process(PROCESSOR_EXECUTE_OPERATION, 0, eset[i], 0, sumplayer, 0);
@@ -1674,7 +1674,7 @@ int32_t field::summon(uint16_t step, uint8_t sumplayer, card* target, effect* pr
 			std::vector<int32_t> duplicate;
 			effect_set eset;
 			target->filter_effect(EFFECT_DECREASE_TRIBUTE, &eset);
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				if(eset[i]->is_flag(EFFECT_FLAG_COUNT_LIMIT))
 					continue;
 				std::vector<lua_Integer> retval;
@@ -1694,7 +1694,7 @@ int32_t field::summon(uint16_t step, uint8_t sumplayer, card* target, effect* pr
 				pduel->write_buffer8(0);
 				pduel->write_buffer32(eset[i]->handler->data.code);
 			}
-			for(int32_t i = 0; i < eset.size() && min > 0; ++i) {
+			for(effect_set::size_type i = 0; i < eset.size() && min > 0; ++i) {
 				if(!eset[i]->is_flag(EFFECT_FLAG_COUNT_LIMIT) || eset[i]->count_limit == 0 || !eset[i]->target)
 					continue;
 				std::vector<lua_Integer> retval;
@@ -1715,7 +1715,7 @@ int32_t field::summon(uint16_t step, uint8_t sumplayer, card* target, effect* pr
 				pduel->write_buffer8(0);
 				pduel->write_buffer32(eset[i]->handler->data.code);
 			}
-			for(int32_t i = 0; i < eset.size() && min > 0; ++i) {
+			for(effect_set::size_type i = 0; i < eset.size() && min > 0; ++i) {
 				if(!eset[i]->is_flag(EFFECT_FLAG_COUNT_LIMIT) || eset[i]->count_limit == 0 || eset[i]->target)
 					continue;
 				std::vector<lua_Integer> retval;
@@ -1910,7 +1910,7 @@ int32_t field::summon(uint16_t step, uint8_t sumplayer, card* target, effect* pr
 				}
 			}
 			if (effect_set* peset = (effect_set*)core.units.begin()->ptr2) {
-				for (int32_t i = 0; i < peset->size(); ++i)
+				for (effect_set::size_type i = 0; i < peset->size(); ++i)
 					remove_oath_effect(peset->at(i));
 				delete peset;
 				core.units.begin()->ptr2 = 0;
@@ -1930,7 +1930,7 @@ int32_t field::summon(uint16_t step, uint8_t sumplayer, card* target, effect* pr
 			release_oath_relation(proc);
 		}
 		if(effect_set* peset = (effect_set*)core.units.begin()->ptr2) {
-			for(int32_t i = 0; i < peset->size(); ++i)
+			for(effect_set::size_type i = 0; i < peset->size(); ++i)
 				release_oath_relation(peset->at(i));
 			delete peset;
 			core.units.begin()->ptr2 = 0;
@@ -1987,7 +1987,7 @@ int32_t field::flip_summon(uint16_t step, uint8_t sumplayer, card * target, uint
 		effect_set eset;
 		target->filter_effect(EFFECT_FLIPSUMMON_COST, &eset);
 		if(eset.size()) {
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				if(eset[i]->operation) {
 					core.sub_solving_event.push_back(nil_event);
 					add_process(PROCESSOR_EXECUTE_OPERATION, 0, eset[i], 0, sumplayer, 0);
@@ -2025,7 +2025,7 @@ int32_t field::flip_summon(uint16_t step, uint8_t sumplayer, card * target, uint
 			return FALSE;
 		if (core.is_summon_negated) {
 			if (effect_set* peset = (effect_set*)core.units.begin()->ptr1) {
-				for (int32_t i = 0; i < peset->size(); ++i)
+				for (effect_set::size_type i = 0; i < peset->size(); ++i)
 					remove_oath_effect(peset->at(i));
 				delete peset;
 				core.units.begin()->ptr1 = 0;
@@ -2039,7 +2039,7 @@ int32_t field::flip_summon(uint16_t step, uint8_t sumplayer, card * target, uint
 	}
 	case 3: {
 		if(effect_set* peset = (effect_set*)core.units.begin()->ptr1) {
-			for(int32_t i = 0; i < peset->size(); ++i)
+			for(effect_set::size_type i = 0; i < peset->size(); ++i)
 				release_oath_relation(peset->at(i));
 			delete peset;
 			core.units.begin()->ptr1 = 0;
@@ -2100,7 +2100,7 @@ int32_t field::mset(uint16_t step, uint8_t setplayer, card* target, effect* proc
 				core.select_effects.push_back(nullptr);
 				core.select_options.push_back(1);
 			}
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				core.select_effects.push_back(eset[i]);
 				core.select_options.push_back(eset[i]->description);
 			}
@@ -2126,7 +2126,7 @@ int32_t field::mset(uint16_t step, uint8_t setplayer, card* target, effect* proc
 			core.select_options.push_back(1);
 		}
 		if(!ignore_count && !core.extra_summon[setplayer]) {
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				std::vector<lua_Integer> retval;
 				eset[i]->get_value(target, 0, retval);
 				int32_t new_min_tribute = retval.size() > 0 ? static_cast<int32_t>(retval[0]) : 0;
@@ -2243,7 +2243,7 @@ int32_t field::mset(uint16_t step, uint8_t setplayer, card* target, effect* proc
 		}
 		effect_set eset;
 		target->filter_effect(EFFECT_MSET_COST, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			if(eset[i]->operation) {
 				core.sub_solving_event.push_back(nil_event);
 				add_process(PROCESSOR_EXECUTE_OPERATION, 0, eset[i], 0, setplayer, 0);
@@ -2267,7 +2267,7 @@ int32_t field::mset(uint16_t step, uint8_t setplayer, card* target, effect* proc
 			std::vector<int32_t> duplicate;
 			effect_set eset;
 			target->filter_effect(EFFECT_DECREASE_TRIBUTE_SET, &eset);
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				if(eset[i]->is_flag(EFFECT_FLAG_COUNT_LIMIT))
 					continue;
 				std::vector<lua_Integer> retval;
@@ -2287,7 +2287,7 @@ int32_t field::mset(uint16_t step, uint8_t setplayer, card* target, effect* proc
 				pduel->write_buffer8(0);
 				pduel->write_buffer32(eset[i]->handler->data.code);
 			}
-			for(int32_t i = 0; i < eset.size() && min > 0; ++i) {
+			for(effect_set::size_type i = 0; i < eset.size() && min > 0; ++i) {
 				if(!eset[i]->is_flag(EFFECT_FLAG_COUNT_LIMIT) || eset[i]->count_limit == 0 || !eset[i]->target)
 					continue;
 				std::vector<lua_Integer> retval;
@@ -2308,7 +2308,7 @@ int32_t field::mset(uint16_t step, uint8_t setplayer, card* target, effect* proc
 				pduel->write_buffer8(0);
 				pduel->write_buffer32(eset[i]->handler->data.code);
 			}
-			for(int32_t i = 0; i < eset.size() && min > 0; ++i) {
+			for(effect_set::size_type i = 0; i < eset.size() && min > 0; ++i) {
 				if(!eset[i]->is_flag(EFFECT_FLAG_COUNT_LIMIT) || eset[i]->count_limit == 0 || eset[i]->target)
 					continue;
 				std::vector<lua_Integer> retval;
@@ -2449,7 +2449,7 @@ int32_t field::sset(uint16_t step, uint8_t setplayer, uint8_t toplayer, card * t
 		target->to_field_param = returns.bvalue[2];
 		effect_set eset;
 		target->filter_effect(EFFECT_SSET_COST, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			if(eset[i]->operation) {
 				core.sub_solving_event.push_back(nil_event);
 				add_process(PROCESSOR_EXECUTE_OPERATION, 0, eset[i], 0, setplayer, 0);
@@ -2520,7 +2520,7 @@ int32_t field::sset_g(uint16_t step, uint8_t setplayer, uint8_t toplayer, group*
  		for(auto& pcard : *set_cards) {
 			eset.clear();
 			pcard->filter_effect(EFFECT_SSET_COST, &eset);
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				if(eset[i]->operation) {
 					core.sub_solving_event.push_back(nil_event);
 					add_process(PROCESSOR_EXECUTE_OPERATION, 0, eset[i], 0, setplayer, 0);
@@ -2706,7 +2706,7 @@ int32_t field::special_summon_rule(uint16_t step, uint8_t sumplayer, card* targe
 			return TRUE;
 		core.select_effects.clear();
 		core.select_options.clear();
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			core.select_effects.push_back(eset[i]);
 			core.select_options.push_back(eset[i]->description);
 		}
@@ -2758,7 +2758,7 @@ int32_t field::special_summon_rule(uint16_t step, uint8_t sumplayer, card* targe
 		effect_set eset;
 		target->filter_effect(EFFECT_SPSUMMON_COST, &eset);
 		if(eset.size()) {
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				if(eset[i]->operation) {
 					core.sub_solving_event.push_back(nil_event);
 					add_process(PROCESSOR_EXECUTE_OPERATION, 0, eset[i], 0, sumplayer, 0);
@@ -2911,7 +2911,7 @@ int32_t field::special_summon_rule(uint16_t step, uint8_t sumplayer, card* targe
 			dec_effect_code(peffect->count_code, sumplayer);
 		}
 		if(effect_set* peset = (effect_set*)core.units.begin()->ptr1) {
-			for(int32_t i = 0; i < peset->size(); ++i)
+			for(effect_set::size_type i = 0; i < peset->size(); ++i)
 				remove_oath_effect(peset->at(i));
 			delete peset;
 			core.units.begin()->ptr1 = 0;
@@ -2925,7 +2925,7 @@ int32_t field::special_summon_rule(uint16_t step, uint8_t sumplayer, card* targe
 	case 15: {
 		release_oath_relation(core.units.begin()->peffect);
 		if(effect_set* peset = (effect_set*)core.units.begin()->ptr1) {
-			for(int32_t i = 0; i < peset->size(); ++i)
+			for(effect_set::size_type i = 0; i < peset->size(); ++i)
 				release_oath_relation(peset->at(i));
 			delete peset;
 			core.units.begin()->ptr1 = 0;
@@ -3003,7 +3003,7 @@ int32_t field::special_summon_rule(uint16_t step, uint8_t sumplayer, card* targe
 			effect_set eset;
 			pcard->filter_effect(EFFECT_SPSUMMON_COST, &eset);
 			if(eset.size()) {
-				for(int32_t i = 0; i < eset.size(); ++i) {
+				for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 					if(eset[i]->operation) {
 						core.sub_solving_event.push_back(nil_event);
 						add_process(PROCESSOR_EXECUTE_OPERATION, 0, eset[i], 0, sumplayer, 0);
@@ -3118,7 +3118,7 @@ int32_t field::special_summon_rule(uint16_t step, uint8_t sumplayer, card* targe
 				dec_effect_code(peffect->count_code, sumplayer);
 			}
 			if(effect_set* peset = (effect_set*)core.units.begin()->ptr1) {
-				for(int32_t i = 0; i < peset->size(); ++i)
+				for(effect_set::size_type i = 0; i < peset->size(); ++i)
 					remove_oath_effect(peset->at(i));
 				delete peset;
 				core.units.begin()->ptr1 = 0;
@@ -3132,7 +3132,7 @@ int32_t field::special_summon_rule(uint16_t step, uint8_t sumplayer, card* targe
 		group* pgroup = core.units.begin()->ptarget;
 		release_oath_relation(core.units.begin()->peffect);
 		if(effect_set* peset = (effect_set*)core.units.begin()->ptr1) {
-			for(int32_t i = 0; i < peset->size(); ++i)
+			for(effect_set::size_type i = 0; i < peset->size(); ++i)
 				release_oath_relation(peset->at(i));
 			delete peset;
 			core.units.begin()->ptr1 = 0;
@@ -3212,7 +3212,7 @@ int32_t field::special_summon_step(uint16_t step, group* targets, card* target, 
 		}
 		if(!nocheck) {
 			target->filter_effect(EFFECT_SPSUMMON_CONDITION, &eset);
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				pduel->lua->add_param(core.reason_effect, PARAM_TYPE_EFFECT);
 				pduel->lua->add_param(target->summon_player, PARAM_TYPE_INT);
 				pduel->lua->add_param(target->summon_info & DEFAULT_SUMMON_TYPE, PARAM_TYPE_INT);
@@ -3227,7 +3227,7 @@ int32_t field::special_summon_step(uint16_t step, group* targets, card* target, 
 		eset.clear();
 		target->filter_effect(EFFECT_SPSUMMON_COST, &eset);
 		if(eset.size()) {
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				if(eset[i]->operation) {
 					core.sub_solving_event.push_back(nil_event);
 					add_process(PROCESSOR_EXECUTE_OPERATION, 0, eset[i], 0, target->summon_player, 0);
@@ -3241,7 +3241,7 @@ int32_t field::special_summon_step(uint16_t step, group* targets, card* target, 
 	}
 	case 1: {
 		if(effect_set* peset = (effect_set*)core.units.begin()->ptr2) {
-			for(int32_t i = 0; i < peset->size(); ++i)
+			for(effect_set::size_type i = 0; i < peset->size(); ++i)
 				release_oath_relation(peset->at(i));
 			delete peset;
 			core.units.begin()->ptr2 = 0;
@@ -3422,10 +3422,10 @@ int32_t field::destroy_replace(uint16_t step, group* targets, card* target, uint
 	effect_set eset;
 	target->filter_single_continuous_effect(EFFECT_DESTROY_REPLACE, &eset);
 	if(!battle) {
-		for (int32_t i = 0; i < eset.size(); ++i)
+		for (effect_set::size_type i = 0; i < eset.size(); ++i)
 			add_process(PROCESSOR_OPERATION_REPLACE, 0, eset[i], targets, 1, 0, 0, 0, target);
 	} else {
-		for (int32_t i = 0; i < eset.size(); ++i)
+		for (effect_set::size_type i = 0; i < eset.size(); ++i)
 			add_process(PROCESSOR_OPERATION_REPLACE, 10, eset[i], targets, 1, 0, 0, 0, target);
 	}
 	return TRUE;
@@ -3465,7 +3465,7 @@ int32_t field::destroy(uint16_t step, group * targets, effect * reason_effect, u
 			pcard->filter_effect(EFFECT_INDESTRUCTABLE, &eset);
 			if(eset.size()) {
 				bool is_destructable = true;
-				for(int32_t i = 0; i < eset.size(); ++i) {
+				for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 					pduel->lua->add_param(pcard->current.reason_effect, PARAM_TYPE_EFFECT);
 					pduel->lua->add_param(pcard->current.reason, PARAM_TYPE_INT);
 					pduel->lua->add_param(pcard->current.reason_player, PARAM_TYPE_INT);
@@ -3487,7 +3487,7 @@ int32_t field::destroy(uint16_t step, group * targets, effect * reason_effect, u
 			pcard->filter_effect(EFFECT_INDESTRUCTABLE_COUNT, &eset);
 			if (eset.size()) {
 				bool is_destructable = true;
-				for(int32_t i = 0; i < eset.size(); ++i) {
+				for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 					if(eset[i]->is_flag(EFFECT_FLAG_COUNT_LIMIT)) {
 						if(eset[i]->count_limit == 0)
 							continue;
@@ -3522,7 +3522,7 @@ int32_t field::destroy(uint16_t step, group * targets, effect * reason_effect, u
 			pcard->filter_effect(EFFECT_DESTROY_SUBSTITUTE, &eset);
 			if (eset.size()) {
 				bool sub = false;
-				for (int32_t i = 0; i < eset.size(); ++i) {
+				for (effect_set::size_type i = 0; i < eset.size(); ++i) {
 					pduel->lua->add_param(pcard->current.reason_effect, PARAM_TYPE_EFFECT);
 					pduel->lua->add_param(pcard->current.reason, PARAM_TYPE_INT);
 					pduel->lua->add_param(pcard->current.reason_player, PARAM_TYPE_INT);
@@ -3667,7 +3667,7 @@ int32_t field::destroy(uint16_t step, group * targets, effect * reason_effect, u
 			pcard->filter_effect(EFFECT_INDESTRUCTABLE, &eset);
 			if(eset.size()) {
 				bool indes = false;
-				for(int32_t i = 0; i < eset.size(); ++i) {
+				for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 					pduel->lua->add_param(pcard->current.reason_effect, PARAM_TYPE_EFFECT);
 					pduel->lua->add_param(pcard->current.reason, PARAM_TYPE_INT);
 					pduel->lua->add_param(pcard->current.reason_player, PARAM_TYPE_INT);
@@ -3693,7 +3693,7 @@ int32_t field::destroy(uint16_t step, group * targets, effect * reason_effect, u
 			pcard->filter_effect(EFFECT_INDESTRUCTABLE_COUNT, &eset);
 			if (eset.size()) {
 				bool indes = false;
-				for (int32_t i = 0; i < eset.size(); ++i) {
+				for (effect_set::size_type i = 0; i < eset.size(); ++i) {
 					if(eset[i]->is_flag(EFFECT_FLAG_COUNT_LIMIT)) {
 						if(eset[i]->count_limit == 0)
 							continue;
@@ -3738,7 +3738,7 @@ int32_t field::destroy(uint16_t step, group * targets, effect * reason_effect, u
 			pcard->filter_effect(EFFECT_DESTROY_SUBSTITUTE, &eset);
 			if (eset.size()) {
 				bool sub = false;
-				for (int32_t i = 0; i < eset.size(); ++i) {
+				for (effect_set::size_type i = 0; i < eset.size(); ++i) {
 					pduel->lua->add_param(pcard->current.reason_effect, PARAM_TYPE_EFFECT);
 					pduel->lua->add_param(pcard->current.reason, PARAM_TYPE_INT);
 					pduel->lua->add_param(pcard->current.reason_player, PARAM_TYPE_INT);
@@ -3792,7 +3792,7 @@ int32_t field::release_replace(uint16_t step, group* targets, card* target) {
 		returns.ivalue[0] = FALSE;
 		effect_set eset;
 		target->filter_single_continuous_effect(EFFECT_RELEASE_REPLACE, &eset);
-		for (int32_t i = 0; i < eset.size(); ++i)
+		for (effect_set::size_type i = 0; i < eset.size(); ++i)
 			add_process(PROCESSOR_OPERATION_REPLACE, 0, eset[i], targets, 0, 0, 0, 0, target);
 	}
 	return TRUE;
@@ -3884,7 +3884,7 @@ int32_t field::send_replace(uint16_t step, group * targets, card * target) {
 		returns.ivalue[0] = FALSE;
 		effect_set eset;
 		target->filter_single_continuous_effect(EFFECT_SEND_REPLACE, &eset);
-		for (int32_t i = 0; i < eset.size(); ++i)
+		for (effect_set::size_type i = 0; i < eset.size(); ++i)
 			add_process(PROCESSOR_OPERATION_REPLACE, 0, eset[i], targets, 0, 0, 0, 0, target);
 	}
 	return TRUE;
@@ -3973,7 +3973,7 @@ int32_t field::send_to(uint16_t step, group * targets, effect * reason_effect, u
 				pcard->previous.setcode.clear();
 				effect_set eset;
 				pcard->filter_effect(EFFECT_ADD_SETCODE, &eset);
-				for(int32_t i = 0; i < eset.size(); ++i) {
+				for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 					pcard->previous.setcode.push_back((uint32_t)eset[i]->get_value(pcard) & 0xffff);
 				}
 			}
@@ -4725,7 +4725,7 @@ int32_t field::move_to_field(uint16_t step, card* target, uint32_t enable, uint3
 			filter_player_effect(0, EFFECT_MUST_USE_MZONE, &eset, FALSE);
 			filter_player_effect(1, EFFECT_MUST_USE_MZONE, &eset, FALSE);
 			target->filter_effect(EFFECT_MUST_USE_MZONE, &eset);
-			for(int32_t i = 0; i < eset.size(); i++) {
+			for(effect_set::size_type i = 0; i < eset.size(); i++) {
 				effect* peffect = eset[i];
 				if(peffect->is_flag(EFFECT_FLAG_COUNT_LIMIT) && peffect->count_limit == 0)
 					continue;

--- a/processor.cpp
+++ b/processor.cpp
@@ -1233,7 +1233,7 @@ int32_t field::process_phase_event(int16_t step, int32_t phase) {
 		effect_set eset;
 		filter_player_effect(infos.turn_player, EFFECT_HAND_LIMIT, &eset);
 		if(eset.size())
-			limit = eset.get_last()->get_value();
+			limit = eset.back()->get_value();
 		int32_t hd = (int32_t)player[infos.turn_player].list_hand.size();
 		if(hd <= limit) {
 			core.units.begin()->step = 24;
@@ -3479,7 +3479,7 @@ void field::calculate_battle_damage(effect** pdamchange, card** preason_card, ui
 					core.attack_target->filter_effect(EFFECT_CHANGE_INVOLVING_BATTLE_DAMAGE, &change_effects, FALSE);
 					filter_player_effect(pa, EFFECT_CHANGE_BATTLE_DAMAGE, &change_effects, FALSE);
 					filter_player_effect(1 - pa, EFFECT_CHANGE_BATTLE_DAMAGE, &change_effects, FALSE);
-					change_effects.sort();
+					std::sort(change_effects.begin(), change_effects.end(), effect_sort_id);
 					for(uint8_t p = 0; p < 2; ++p) {
 						bool double_dam = false;
 						bool half_dam = false;
@@ -3600,7 +3600,7 @@ void field::calculate_battle_damage(effect** pdamchange, card** preason_card, ui
 			dam_card->filter_effect(EFFECT_CHANGE_INVOLVING_BATTLE_DAMAGE, &eset, FALSE);
 		filter_player_effect(damaged_player, EFFECT_CHANGE_BATTLE_DAMAGE, &eset, FALSE);
 		filter_player_effect(1 - damaged_player, EFFECT_CHANGE_BATTLE_DAMAGE, &eset, FALSE);
-		eset.sort();
+		std::sort(eset.begin(), eset.end(), effect_sort_id);
 		for(uint8_t p = 0; p < 2; ++p) {
 			bool double_dam = false;
 			bool half_dam = false;
@@ -4653,7 +4653,7 @@ int32_t field::refresh_location_info(uint16_t step) {
 				player[0].disabled_location |= value & 0x1f7f;
 				player[1].disabled_location |= (value >> 16) & 0x1f7f;
 			} else
-				core.disfield_effects.add_item(eset[i]);
+				core.disfield_effects.push_back(eset[i]);
 		}
 		eset.clear();
 		filter_field_effect(EFFECT_USE_EXTRA_MZONE, &eset);
@@ -4662,7 +4662,7 @@ int32_t field::refresh_location_info(uint16_t step) {
 			uint32_t value = eset[i]->get_value();
 			player[p].disabled_location |= (value >> 16) & 0x1f;
 			if((uint32_t)field_used_count[(value >> 16) & 0x1f] < (value & 0xffff))
-				core.extra_mzone_effects.add_item(eset[i]);
+				core.extra_mzone_effects.push_back(eset[i]);
 		}
 		eset.clear();
 		filter_field_effect(EFFECT_USE_EXTRA_SZONE, &eset);
@@ -4671,7 +4671,7 @@ int32_t field::refresh_location_info(uint16_t step) {
 			uint32_t value = eset[i]->get_value();
 			player[p].disabled_location |= (value >> 8) & 0x1f00;
 			if((uint32_t)field_used_count[(value >> 16) & 0x1f] < (value & 0xffff))
-				core.extra_szone_effects.add_item(eset[i]);
+				core.extra_szone_effects.push_back(eset[i]);
 		}
 		return FALSE;
 	}
@@ -4682,7 +4682,7 @@ int32_t field::refresh_location_info(uint16_t step) {
 		}
 		effect* peffect = core.disfield_effects[0];
 		core.units.begin()->peffect = peffect;
-		core.disfield_effects.remove_item(0);
+		core.disfield_effects.erase(core.disfield_effects.begin());
 		if(!peffect->operation) {
 			peffect->value = 0x80;
 			core.units.begin()->step = 0;
@@ -4715,7 +4715,7 @@ int32_t field::refresh_location_info(uint16_t step) {
 		}
 		effect* peffect = core.extra_mzone_effects[0];
 		core.units.begin()->peffect = peffect;
-		core.extra_mzone_effects.remove_item(0);
+		core.extra_mzone_effects.erase(core.extra_mzone_effects.begin());
 		uint32_t p = peffect->get_handler_player();
 		uint32_t mzone_flag = (player[p].disabled_location | player[p].used_location) & 0x1f;
 		if(mzone_flag == 0x1f) {
@@ -4754,7 +4754,7 @@ int32_t field::refresh_location_info(uint16_t step) {
 		}
 		effect* peffect = core.extra_szone_effects[0];
 		core.units.begin()->peffect = peffect;
-		core.extra_szone_effects.remove_item(0);
+		core.extra_szone_effects.erase(core.extra_szone_effects.begin());
 		uint32_t p = peffect->get_handler_player();
 		uint32_t szone_flag = ((player[p].disabled_location | player[p].used_location) >> 8) & 0x1f;
 		if(szone_flag == 0x1f) {
@@ -4997,7 +4997,7 @@ int32_t field::adjust_step(uint16_t step) {
 				eset.clear();
 				pcard->filter_effect(EFFECT_SET_POSITION, &eset);
 				if(eset.size()) {
-					pos = eset.get_last()->get_value();
+					pos = eset.back()->get_value();
 					if((pos & 0xff) != pcard->current.position) {
 						pos_adjust.insert(pcard);
 						pcard->position_param = pos;

--- a/processor.cpp
+++ b/processor.cpp
@@ -2148,7 +2148,7 @@ int32_t field::process_idle_command(uint16_t step) {
 		core.spsummonable_cards.clear();
 		effect_set eset;
 		filter_field_effect(EFFECT_SPSUMMON_PROC, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			card* pcard = eset[i]->get_handler();
 			if(!eset[i]->check_count_limit(pcard->current.controler))
 				continue;
@@ -2157,7 +2157,7 @@ int32_t field::process_idle_command(uint16_t step) {
 		}
 		eset.clear();
 		filter_field_effect(EFFECT_SPSUMMON_PROC_G, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			card* pcard = eset[i]->get_handler();
 			if(!eset[i]->check_count_limit(infos.turn_player))
 				continue;
@@ -2526,7 +2526,7 @@ int32_t field::process_battle_command(uint16_t step) {
 			effect_set eset;
 			filter_player_effect(infos.turn_player, EFFECT_ATTACK_COST, &eset, FALSE);
 			core.attacker->filter_effect(EFFECT_ATTACK_COST, &eset);
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				if(eset[i]->operation) {
 					core.attack_cancelable = FALSE;
 					core.sub_solving_event.push_back(nil_event);
@@ -3386,7 +3386,7 @@ void field::calculate_battle_damage(effect** pdamchange, card** preason_card, ui
 				if(eset.size()) {
 					pierce = true;
 					uint8_t dp[2] = {};
-					for(int32_t i = 0; i < eset.size(); ++i)
+					for(effect_set::size_type i = 0; i < eset.size(); ++i)
 						dp[1 - eset[i]->get_handler_player()] = 1;
 					if(dp[0])
 						core.battle_damage[0] = attacker_value - defender_value;
@@ -3394,7 +3394,7 @@ void field::calculate_battle_damage(effect** pdamchange, card** preason_card, ui
 						core.battle_damage[1] = attacker_value - defender_value;
 					bool double_damage = false;
 					//bool half_damage = false;
-					for(int32_t i = 0; i < eset.size(); ++i) {
+					for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 						if(eset[i]->get_value() == DOUBLE_DAMAGE)
 							double_damage = true;
 						//if(eset[i]->get_value() == HALF_DAMAGE)
@@ -3484,7 +3484,7 @@ void field::calculate_battle_damage(effect** pdamchange, card** preason_card, ui
 						bool double_dam = false;
 						bool half_dam = false;
 						int32_t dam_value = -1;
-						for(int32_t i = 0; i < change_effects.size(); ++i) {
+						for(effect_set::size_type i = 0; i < change_effects.size(); ++i) {
 							int32_t val = -1;
 							if(!change_effects[i]->is_flag(EFFECT_FLAG_PLAYER_TARGET)) {
 								pduel->lua->add_param(p, PARAM_TYPE_INT);
@@ -3606,7 +3606,7 @@ void field::calculate_battle_damage(effect** pdamchange, card** preason_card, ui
 			bool half_dam = false;
 			int32_t dam_value = -1;
 			int32_t current_min = INT32_MAX;
-			for(int32_t i = 0; i < eset.size(); ++i) {
+			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 				int32_t val = -1;
 				if(!eset[i]->is_flag(EFFECT_FLAG_PLAYER_TARGET)) {
 					pduel->lua->add_param(p, PARAM_TYPE_INT);
@@ -3992,7 +3992,7 @@ int32_t field::add_chain(uint16_t step) {
 		card* phandler = peffect->get_handler();
 		effect_set eset;
 		filter_player_effect(clit.triggering_player, EFFECT_ACTIVATE_COST, &eset);
-		for(int32_t i = 0; i < eset.size(); ++i) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i) {
 			pduel->lua->add_param(eset[i], PARAM_TYPE_EFFECT);
 			pduel->lua->add_param(clit.triggering_effect, PARAM_TYPE_EFFECT);
 			pduel->lua->add_param(clit.triggering_player, PARAM_TYPE_INT);
@@ -4163,7 +4163,7 @@ int32_t field::add_chain(uint16_t step) {
 			auto peffect = clit.triggering_effect;
 			auto playerid = clit.triggering_player;
 			int32_t ceffect_unique_id = 0;
-			for(int32_t i = 0; i < clit.required_handorset_effects.size(); ++i) {
+			for(effect_set::size_type i = 0; i < clit.required_handorset_effects.size(); ++i) {
 				pduel->lua->add_param(peffect, PARAM_TYPE_EFFECT);
 				pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 				auto id = clit.required_handorset_effects[i]->get_value(2);
@@ -4182,7 +4182,7 @@ int32_t field::add_chain(uint16_t step) {
 			}
 		}
 		core.select_options.clear();
-		for(int32_t i = 0; i < clit.required_handorset_effects.size(); ++i) {
+		for(effect_set::size_type i = 0; i < clit.required_handorset_effects.size(); ++i) {
 			core.select_options.push_back(clit.required_handorset_effects[i]->description);
 		}
 		add_process(PROCESSOR_SELECT_OPTION, 0, 0, 0, clit.triggering_player, 0);
@@ -4609,21 +4609,21 @@ void field::refresh_location_info_instant() {
 	player[0].disabled_location = 0;
 	player[1].disabled_location = 0;
 	filter_field_effect(EFFECT_DISABLE_FIELD, &eset);
-	for (int32_t i = 0; i < eset.size(); ++i) {
+	for (effect_set::size_type i = 0; i < eset.size(); ++i) {
 		uint32_t value = eset[i]->get_value();
 		player[0].disabled_location |= value & 0x1f7f;
 		player[1].disabled_location |= (value >> 16) & 0x1f7f;
 	}
 	eset.clear();
 	filter_field_effect(EFFECT_USE_EXTRA_MZONE, &eset);
-	for (int32_t i = 0; i < eset.size(); ++i) {
+	for (effect_set::size_type i = 0; i < eset.size(); ++i) {
 		uint8_t p = eset[i]->get_handler_player();
 		uint32_t value = eset[i]->get_value();
 		player[p].disabled_location |= (value >> 16) & 0x1f;
 	}
 	eset.clear();
 	filter_field_effect(EFFECT_USE_EXTRA_SZONE, &eset);
-	for (int32_t i = 0; i < eset.size(); ++i) {
+	for (effect_set::size_type i = 0; i < eset.size(); ++i) {
 		uint8_t p = eset[i]->get_handler_player();
 		uint32_t value = eset[i]->get_value();
 		player[p].disabled_location |= (value >> 8) & 0x1f00;
@@ -4647,7 +4647,7 @@ int32_t field::refresh_location_info(uint16_t step) {
 		core.extra_mzone_effects.clear();
 		core.extra_szone_effects.clear();
 		filter_field_effect(EFFECT_DISABLE_FIELD, &eset);
-		for (int32_t i = 0; i < eset.size(); ++i) {
+		for (effect_set::size_type i = 0; i < eset.size(); ++i) {
 			uint32_t value = eset[i]->get_value();
 			if(value) {
 				player[0].disabled_location |= value & 0x1f7f;
@@ -4657,7 +4657,7 @@ int32_t field::refresh_location_info(uint16_t step) {
 		}
 		eset.clear();
 		filter_field_effect(EFFECT_USE_EXTRA_MZONE, &eset);
-		for (int32_t i = 0; i < eset.size(); ++i) {
+		for (effect_set::size_type i = 0; i < eset.size(); ++i) {
 			uint8_t p = eset[i]->get_handler_player();
 			uint32_t value = eset[i]->get_value();
 			player[p].disabled_location |= (value >> 16) & 0x1f;
@@ -4666,7 +4666,7 @@ int32_t field::refresh_location_info(uint16_t step) {
 		}
 		eset.clear();
 		filter_field_effect(EFFECT_USE_EXTRA_SZONE, &eset);
-		for (int32_t i = 0; i < eset.size(); ++i) {
+		for (effect_set::size_type i = 0; i < eset.size(); ++i) {
 			uint8_t p = eset[i]->get_handler_player();
 			uint32_t value = eset[i]->get_value();
 			player[p].disabled_location |= (value >> 8) & 0x1f00;


### PR DESCRIPTION
Replace effect_set with std::vector.
C++11 introduces range-based for loop and many std container interfaces, so keeping a user-defined container (which is still a std container inside) is unnecessary.

改成直接使用 std::vector
C++11加入range-based for loop以及各種作用於標準庫容器的函式
現代已經沒有必要使用自定義容器增加維護難度


except b757aa31965f378269ba165553bf7f0bcb0b93ca 
all commits are string replacements.

add_item => push_back
eset.remove_item(i) => eset.erase(eset.begin() + i)
get_last => back
eset.sort() => std::sort(eset.begin(), eset.end(), effect_sort_id);


Reference
https://github.com/edo9300/ygopro-core/commit/be30a5151a9592cd7c129f098c411ad861f94eea


@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust