### PR TITLE
Update change_position

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -4959,6 +4959,7 @@ int32_t field::change_position(uint16_t step, group * targets, effect * reason_e
 				move_to_field(pcard, pcard->current.controler, pcard->current.controler, LOCATION_SZONE, POS_FACEDOWN, FALSE, RETURN_TRAP_MONSTER_TO_SZONE);
 				raise_single_event(pcard, 0, EVENT_SSET, reason_effect, 0, reason_player, 0, 0);
 				ssets.insert(pcard);
+				targets->container.erase(pcard);
 			}
 		}
 		adjust_instant();

--- a/operations.cpp
+++ b/operations.cpp
@@ -4959,15 +4959,18 @@ int32_t field::change_position(uint16_t step, group * targets, effect * reason_e
 				move_to_field(pcard, pcard->current.controler, pcard->current.controler, LOCATION_SZONE, POS_FACEDOWN, FALSE, RETURN_TRAP_MONSTER_TO_SZONE);
 				raise_single_event(pcard, 0, EVENT_SSET, reason_effect, 0, reason_player, 0, 0);
 				ssets.insert(pcard);
-				targets->container.erase(pcard);
 			}
 		}
 		adjust_instant();
 		process_single_event();
 		if(flips.size())
 			raise_event(flips, EVENT_FLIP, reason_effect, 0, reason_player, 0, 0);
-		if(ssets.size())
+		if(ssets.size()) {
+			for(auto& pcard : ssets) {
+				targets->container.erase(pcard);
+			}
 			raise_event(ssets, EVENT_SSET, reason_effect, 0, reason_player, 0, 0);
+		}
 		if(pos_changed.size())
 			raise_event(pos_changed, EVENT_CHANGE_POS, reason_effect, 0, reason_player, 0, 0);
 		process_instant_event();


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=24145&keyword=&tag=-1&request_locale=ja

> Question
「黄金郷のコンキスタドール」とリンクモンスターの２体のみが相手のモンスターゾーンに存在し、自分のモンスターゾーンに表側表示モンスターが存在しない状況で自分が「魔砲戦機ダルマ・カルマ」を発動した場合、「魔砲戦機ダルマ・カルマ」の『その後、フィールドに表側表示でモンスターが存在する場合、そのコントローラーは自身のフィールドの表側表示モンスターを全て墓地へ送らなければならない』処理を行いますか？
Answer
行いません。
「黄金郷のコンキスタドール」のようなモンスターゾーンで罠カードとしても扱われるカードは、裏側守備表示になる際は魔法&罠ゾーンにセットされるため、『裏側守備表示にする』処理に成功した扱いにはなりません。
以下のカードの効果で「黄金郷のコンキスタドール」のようなモンスターゾーンで罠カードとしても扱われるカードにのみ裏側守備表示にする効果が適用された場合でも、裏側守備表示にする処理に成功した扱いにはなりません。
「結晶神ティスティナ」①
「ティスティナの息吹」②
「ティスティナの半神」②
「壱世壊に軋む爪音」①
「森のざわめき」
「リバースポッド」
「ゴーストリック・フロスト 」
「サブテラーの妖魔」②