### PR TITLE
apply EFFECT_SYNCHRO_LEVEL to Xyz/Link monsters

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1020,14 +1020,14 @@ uint32_t card::get_link() {
 uint32_t card::get_synchro_level(card* pcard) {
 	if (status & STATUS_NO_LEVEL)
 		return 0;
-	uint32_t lev;
 	effect_set eset;
 	filter_effect(EFFECT_SYNCHRO_LEVEL, &eset);
-	if(eset.size())
-		lev = eset[0]->get_value(pcard);
-	else
-		lev = get_level();
-	return lev;
+	for (int i = 0; i < eset.size(); ++i) {
+		uint32_t lev = eset[i]->get_value(pcard);
+		if (lev)
+			return lev;
+	}
+	return get_level();
 }
 uint32_t card::get_ritual_level(card* pcard) {
 	if (status & STATUS_NO_LEVEL)

--- a/card.cpp
+++ b/card.cpp
@@ -4077,7 +4077,7 @@ int32_t card::is_can_be_fusion_material(card* fcard, uint32_t summon_type) {
 	return TRUE;
 }
 int32_t card::is_can_be_synchro_material(card* scard, card* tuner) {
-	if ((data.type & (TYPE_XYZ | TYPE_LINK)) && !is_affected_by_effect(EFFECT_SYNCHRO_LEVEL))
+	if ((data.type & (TYPE_XYZ | TYPE_LINK)) && !is_affected_by_effect(EFFECT_ALLOW_FOR_SYNCHRO))
 		return FALSE;
 	if(!(get_synchro_type() & TYPE_MONSTER))
 		return FALSE;

--- a/card.cpp
+++ b/card.cpp
@@ -1018,7 +1018,7 @@ uint32_t card::get_link() {
 	return data.level;
 }
 uint32_t card::get_synchro_level(card* pcard) {
-	if((data.type & (TYPE_XYZ | TYPE_LINK)) || (status & STATUS_NO_LEVEL))
+	if (status & STATUS_NO_LEVEL)
 		return 0;
 	uint32_t lev;
 	effect_set eset;
@@ -1030,7 +1030,7 @@ uint32_t card::get_synchro_level(card* pcard) {
 	return lev;
 }
 uint32_t card::get_ritual_level(card* pcard) {
-	if((data.type & (TYPE_XYZ | TYPE_LINK)) || (status & STATUS_NO_LEVEL))
+	if (status & STATUS_NO_LEVEL)
 		return 0;
 	uint32_t lev;
 	effect_set eset;
@@ -4077,7 +4077,7 @@ int32_t card::is_can_be_fusion_material(card* fcard, uint32_t summon_type) {
 	return TRUE;
 }
 int32_t card::is_can_be_synchro_material(card* scard, card* tuner) {
-	if(data.type & (TYPE_XYZ | TYPE_LINK))
+	if ((data.type & (TYPE_XYZ | TYPE_LINK)) && !is_affected_by_effect(EFFECT_SYNCHRO_LEVEL))
 		return FALSE;
 	if(!(get_synchro_type() & TYPE_MONSTER))
 		return FALSE;

--- a/card.cpp
+++ b/card.cpp
@@ -1032,14 +1032,14 @@ uint32_t card::get_synchro_level(card* pcard) {
 uint32_t card::get_ritual_level(card* pcard) {
 	if (status & STATUS_NO_LEVEL)
 		return 0;
-	uint32_t lev;
 	effect_set eset;
 	filter_effect(EFFECT_RITUAL_LEVEL, &eset);
-	if(eset.size())
-		lev = eset[0]->get_value(pcard);
-	else
-		lev = get_level();
-	return lev;
+	for (int i = 0; i < eset.size(); ++i) {
+		uint32_t lev = eset[i]->get_value(pcard);
+		if (lev)
+			return lev;
+	}
+	return get_level();
 }
 uint32_t card::check_xyz_level(card* pcard, uint32_t lv) {
 	if(status & STATUS_NO_LEVEL)

--- a/effect.h
+++ b/effect.h
@@ -530,6 +530,7 @@ const std::map<uint64_t, uint64_t> category_checklist{
 #define EFFECT_KAISER_COLOSSEUM			370
 #define EFFECT_REPLACE_DAMAGE			371
 #define EFFECT_XYZ_MIN_COUNT			372
+#define EFFECT_ALLOW_FOR_SYNCHRO		373
 
 //#define EVENT_STARTUP		1000
 #define EVENT_FLIP			1001


### PR DESCRIPTION
EFFECT_ALLOW_FOR_SYNCHRO
The monster without level can be used for Synchro Summon.

EFFECT_SYNCHRO_LEVEL
If the monster can be used for Synchro Summon, the Synchro level becomes X.


```lua
local s,io,o=GetID()
function s.initial_effect(c)
	--synchro summon
	c:EnableReviveLimit()
	aux.AddSynchroMixProcedure(c,s.matfilter1,nil,nil,s.matfilter2,1,1)
	local e1=Effect.CreateEffect(c)
	e1:SetType(EFFECT_TYPE_FIELD)
	e1:SetCode(373)
	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_IGNORE_IMMUNE)
	e1:SetRange(LOCATION_EXTRA)
	e1:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
	e1:SetTarget(s.syntg)
	c:RegisterEffect(e1)
	local e2=e1:Clone()
	e2:SetCode(EFFECT_SYNCHRO_LEVEL)
	e2:SetValue(s.synval)
	c:RegisterEffect(e2)
end
---@param c Card
---@param syncard Card
function s.matfilter1(c,syncard)
	return c:IsTuner(syncard) or c:IsType(TYPE_LINK) and c:IsLink(1)
end
function s.matfilter2(c,syncard)
	return c:IsNotTuner(syncard) and not c:IsType(TYPE_LINK)
end
function s.syntg(e,c)
	return c:IsType(TYPE_LINK) and c:IsLink(1)
end
function s.synval(e,syncard)
	if e:GetHandler()==syncard then
		return 1
	else
		return 0
	end
end
```


@mercury233 
@purerosefallen 