### PR TITLE
 fix EFFECT_COUNT_CODE_SINGLE activation count 

### DIFF
--- a/card.h
+++ b/card.h
@@ -170,7 +170,7 @@ public:
 	uint8_t attack_controler{};
 	uint64_t cardid{};
 	uint32_t fieldid{};
-	uint32_t fieldid_r{};
+	uint32_t fieldid_r{};	//real field id, updated when moving to new location
 	uint16_t turnid{};
 	uint16_t turn_counter{};
 	uint8_t unique_pos[2]{};

--- a/card.h
+++ b/card.h
@@ -171,6 +171,7 @@ public:
 	uint64_t cardid{};
 	uint32_t fieldid{};
 	uint32_t fieldid_r{};	//real field id, updated when moving to new location
+	uint32_t activate_count_id{};	//updated when moving to new location or flipping
 	uint16_t turnid{};
 	uint16_t turn_counter{};
 	uint8_t unique_pos[2]{};

--- a/effect.cpp
+++ b/effect.cpp
@@ -168,7 +168,7 @@ int32_t effect::check_count_limit(uint8_t playerid) {
 			uint32_t limit_type = count_code & 0xf0000000U;
 			int32_t count = count_limit_max;
 			if(limit_code == EFFECT_COUNT_CODE_SINGLE) {
-				if(pduel->game_field->get_effect_code(limit_type | get_handler()->fieldid, PLAYER_NONE) >= count)
+				if(pduel->game_field->get_effect_code(limit_type | get_handler()->activate_count_id, PLAYER_NONE) >= count)
 					return FALSE;
 			} else {
 				if(pduel->game_field->get_effect_code(count_code, playerid) >= count)
@@ -677,7 +677,7 @@ void effect::dec_count(uint8_t playerid) {
 		uint32_t limit_code = count_code & MAX_CARD_ID;
 		uint32_t limit_type = count_code & 0xf0000000;
 		if(limit_code == EFFECT_COUNT_CODE_SINGLE)
-			pduel->game_field->add_effect_code(limit_type | get_handler()->fieldid, PLAYER_NONE);
+			pduel->game_field->add_effect_code(limit_type | get_handler()->activate_count_id, PLAYER_NONE);
 		else
 			pduel->game_field->add_effect_code(count_code, playerid);
 	}

--- a/effect.cpp
+++ b/effect.cpp
@@ -159,9 +159,6 @@ int32_t effect::is_single_ready() {
 	int32_t res = pduel->lua->check_condition(condition, 1);
 	return res;
 }
-// reset_count: count of effect reset
-// count_limit: left count of activation
-// count_limit_max: max count of activation
 int32_t effect::check_count_limit(uint8_t playerid) {
 	if(is_flag(EFFECT_FLAG_COUNT_LIMIT)) {
 		if(count_limit == 0)

--- a/effect.h
+++ b/effect.h
@@ -42,8 +42,8 @@ public:
 	uint16_t range{ 0 };
 	uint16_t s_range{ 0 };
 	uint16_t o_range{ 0 };
-	uint8_t count_limit{ 0 };
-	uint8_t count_limit_max{ 0 };
+	uint8_t count_limit{ 0 };	//left count of activation
+	uint8_t count_limit_max{ 0 };	//max count of activation
 	uint16_t status{ 0 };
 	int32_t reset_count{ 0 };
 	uint32_t reset_flag{ 0 };

--- a/field.cpp
+++ b/field.cpp
@@ -183,6 +183,7 @@ void field::add_card(uint8_t playerid, card* pcard, uint8_t location, uint8_t se
 	pcard->apply_field_effect();
 	pcard->fieldid = infos.field_id++;
 	pcard->fieldid_r = pcard->fieldid;
+	pcard->activate_count_id = pcard->fieldid;
 	if(check_unique_onfield(pcard, pcard->current.controler, pcard->current.location))
 		pcard->unique_fieldid = UINT_MAX;
 	pcard->turnid = infos.turn_id;

--- a/operations.cpp
+++ b/operations.cpp
@@ -2005,6 +2005,7 @@ int32_t field::flip_summon(uint16_t step, uint8_t sumplayer, card * target, uint
 		target->summon_player = sumplayer;
 		target->summon_info |= SUMMON_TYPE_FLIP;
 		target->fieldid = infos.field_id++;
+		target->activate_count_id = target->fieldid;
 		core.phase_action = TRUE;
 		pduel->write_buffer8(MSG_FLIPSUMMONING);
 		pduel->write_buffer32(target->data.code);
@@ -4909,6 +4910,7 @@ int32_t field::change_position(uint16_t step, group * targets, effect * reason_e
 			core.hint_timing[pcard->current.controler] |= TIMING_POS_CHANGE;
 			if((opos & POS_FACEDOWN) && (npos & POS_FACEUP)) {
 				pcard->fieldid = infos.field_id++;
+				pcard->activate_count_id = pcard->fieldid;
 				if(check_unique_onfield(pcard, pcard->current.controler, pcard->current.location))
 					pcard->unique_fieldid = UINT_MAX;
 				if(pcard->current.location == LOCATION_MZONE) {


### PR DESCRIPTION
fix #724 

Test
```lua
--[[message bug_test]]
Debug.SetAIName("Bug")
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(4031928,0,0,LOCATION_HAND,0,POS_FACEDOWN_DEFENSE)
Debug.AddCard(7672244,0,0,LOCATION_HAND,1,POS_FACEDOWN_DEFENSE)

Debug.AddCard(86346643,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK)

Debug.AddCard(15259703,0,0,LOCATION_SZONE,0,POS_FACEDOWN_DEFENSE)

Debug.AddCard(89631139,0,0,LOCATION_GRAVE,0,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,0,0,LOCATION_GRAVE,1,POS_FACEUP_ATTACK)

Debug.AddCard(3549275,0,0,LOCATION_DECK,0,POS_FACEDOWN)
Debug.AddCard(89631139,0,0,LOCATION_DECK,1,POS_FACEDOWN)
Debug.AddCard(94259633,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)

--opponent
Debug.AddCard(73148972,1,1,LOCATION_HAND,0,POS_FACEDOWN)
Debug.AddCard(22702055,1,1,LOCATION_HAND,1,POS_FACEDOWN)

Debug.AddCard(89631139,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,1,1,LOCATION_MZONE,2,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,1,1,LOCATION_MZONE,4,POS_FACEUP_ATTACK)

Debug.AddCard(15259703,1,1,LOCATION_SZONE,0,POS_FACEDOWN_DEFENSE)

Debug.AddCard(89631139,1,1,LOCATION_GRAVE,0,POS_FACEUP_ATTACK)
Debug.AddCard(89631139,1,1,LOCATION_GRAVE,1,POS_FACEUP_ATTACK)

Debug.AddCard(66570171,1,1,LOCATION_DECK,0,POS_FACEDOWN)
Debug.AddCard(40044918,1,1,LOCATION_DECK,1,POS_FACEDOWN)
Debug.AddCard(27660735,1,1,LOCATION_DECK,2,POS_FACEDOWN)

Debug.ReloadFieldEnd()

```

