### PR TITLE
update premake5.lua of Lua

### DIFF
--- a/premake/dll.lua
+++ b/premake/dll.lua
@@ -50,6 +50,7 @@ include(LUA_DIR)
 project "ocgcore"
 
     kind "SharedLib"
+    cppdialect "C++14"
 
     files { "*.cpp", "*.h" }
     links { "lua" }

--- a/premake/lua.lua
+++ b/premake/lua.lua
@@ -1,15 +1,9 @@
 project "lua"
     kind "StaticLib"
-    cppdialect "C++14"
+    compileas "C++"
 
-    files { "src/*.c", "src/*.h", "src/*.hpp" }
-    removefiles { "src/lua.c", "src/luac.c" }
-
-    filter "action:vs*"
-        buildoptions { "/TP" }
-
-    filter "not action:vs*"
-        buildoptions { "-x c++" }
+    files { "src/*.c", "src/*.h" }
+    removefiles { "src/lua.c", "src/luac.c", "src/linit.c" }
 
     filter "configurations:Debug"
         defines { "LUA_USE_APICHECK" }

--- a/premake/lua.lua
+++ b/premake/lua.lua
@@ -3,7 +3,7 @@ project "lua"
     compileas "C++"
 
     files { "src/*.c", "src/*.h" }
-    removefiles { "src/lua.c", "src/luac.c", "src/linit.c" }
+    removefiles { "src/lua.c", "src/luac.c", "src/linit.c", "src/onelua.c" }
 
     filter "configurations:Debug"
         defines { "LUA_USE_APICHECK" }


### PR DESCRIPTION
https://premake.github.io/docs/compileas/

lua.lua
- command line options:
use compileas

- files
lua.hpp
This file is for "building in C, including in C++ project"
We compile Lua as C++, so we does not need it.


- removefiles 
src/linit.c
initialization for lua.c
We do not need this file.
src/onelua.c
unnecessary

@mercury233 





