### PR TITLE
remove unsafe functions by default

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -32,6 +32,15 @@ interpreter::interpreter(duel* pd): coroutines(256) {
 	lua_pop(lua_state, 1);
 	luaL_requiref(lua_state, "math", luaopen_math, 1);
 	lua_pop(lua_state, 1);
+	auto nil_out = [&](const char* name) {
+		lua_pushnil(lua_state);
+		lua_setglobal(lua_state, name);
+	};
+	nil_out("collectgarbage");
+#ifndef ENABLE_UNSAFE_LIBRARIES
+	nil_out("dofile");
+	nil_out("loadfile");
+#endif // ENABLE_UNSAFE_LIBRARIES
 	//open all libs
 	scriptlib::open_cardlib(lua_state);
 	scriptlib::open_effectlib(lua_state);


### PR DESCRIPTION
You can choose to define macro `ENABLE_UNSAFE_LIBRARIES` and take full responsibilities for the safety of that branch.
I suggest not, but there is nothing I can do for the safety of such branches.

你可以選擇定義巨集「ENABLE_UNSAFE_LIBRARIES」並對該分支的安全負全部責任。
我建議不要，但是對於這些分支的安全我無能為力。

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust 
@jwyxym 

Reference
https://github.com/edo9300/ygopro-core/pull/126
by @edo9300 
