### PR TITLE
fix draw 0

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -343,6 +343,10 @@ int32_t field::draw(uint16_t step, effect* reason_effect, uint32_t reason, uint8
 			returns.ivalue[0] = 0;
 			return TRUE;
 		}
+		if(count == 0) {
+			returns.ivalue[0] = 0;
+			return TRUE;
+		}
 		core.overdraw[playerid] = FALSE;
 		for(int32_t i = 0; i < count; ++i) {
 			if(player[playerid].list_main.empty()) {


### PR DESCRIPTION
Fix: if the draw count is 0, the `core.overdraw` shouldn't be reset.

Partly fix the scene described in https://github.com/Fluorohydride/ygopro-scripts/pull/2924