### PR TITLE
update reason & add reason_effect for field::is_player_can_remove

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -2280,12 +2280,13 @@ int32_t card::leave_field_redirect(uint32_t reason) {
 		return 0;
 	filter_effect(EFFECT_LEAVE_FIELD_REDIRECT, &es);
 	for(effect_set::size_type i = 0; i < es.size(); ++i) {
-		redirect = es[i]->get_value(this, 0);
+		effect* peffect = es[i];
+		redirect = peffect->get_value(this, 0);
 		if((redirect & LOCATION_HAND) && !is_affected_by_effect(EFFECT_CANNOT_TO_HAND) && pduel->game_field->is_player_can_send_to_hand(es[i]->get_handler_player(), this))
 			redirects |= redirect;
 		else if((redirect & LOCATION_DECK) && !is_affected_by_effect(EFFECT_CANNOT_TO_DECK) && pduel->game_field->is_player_can_send_to_deck(es[i]->get_handler_player(), this))
 			redirects |= redirect;
-		else if((redirect & LOCATION_REMOVED) && !is_affected_by_effect(EFFECT_CANNOT_REMOVE) && pduel->game_field->is_player_can_remove(es[i]->get_handler_player(), this, REASON_EFFECT))
+		else if((redirect & LOCATION_REMOVED) && !is_affected_by_effect(EFFECT_CANNOT_REMOVE) && pduel->game_field->is_player_can_remove(es[i]->get_handler_player(), this, REASON_EFFECT, peffect))
 			redirects |= redirect;
 	}
 	if(redirects & LOCATION_REMOVED)
@@ -2318,12 +2319,13 @@ int32_t card::destination_redirect(uint8_t destination, uint32_t reason) {
 	else
 		return 0;
 	for(effect_set::size_type i = 0; i < es.size(); ++i) {
-		redirect = es[i]->get_value(this, 0);
+		effect* peffect = es[i];
+		redirect = peffect->get_value(this, 0);
 		if((redirect & LOCATION_HAND) && !is_affected_by_effect(EFFECT_CANNOT_TO_HAND) && pduel->game_field->is_player_can_send_to_hand(es[i]->get_handler_player(), this))
 			return redirect;
 		if((redirect & LOCATION_DECK) && !is_affected_by_effect(EFFECT_CANNOT_TO_DECK) && pduel->game_field->is_player_can_send_to_deck(es[i]->get_handler_player(), this))
 			return redirect;
-		if((redirect & LOCATION_REMOVED) && !is_affected_by_effect(EFFECT_CANNOT_REMOVE) && pduel->game_field->is_player_can_remove(es[i]->get_handler_player(), this, REASON_EFFECT))
+		if((redirect & LOCATION_REMOVED) && !is_affected_by_effect(EFFECT_CANNOT_REMOVE) && pduel->game_field->is_player_can_remove(es[i]->get_handler_player(), this, REASON_EFFECT, peffect))
 			return redirect;
 		if((redirect & LOCATION_GRAVE) && !is_affected_by_effect(EFFECT_CANNOT_TO_GRAVE) && pduel->game_field->is_player_can_send_to_grave(es[i]->get_handler_player(), this))
 			return redirect;

--- a/card.cpp
+++ b/card.cpp
@@ -2286,7 +2286,7 @@ int32_t card::leave_field_redirect(uint32_t reason) {
 			redirects |= redirect;
 		else if((redirect & LOCATION_DECK) && !is_affected_by_effect(EFFECT_CANNOT_TO_DECK) && pduel->game_field->is_player_can_send_to_deck(es[i]->get_handler_player(), this))
 			redirects |= redirect;
-		else if((redirect & LOCATION_REMOVED) && !is_affected_by_effect(EFFECT_CANNOT_REMOVE) && pduel->game_field->is_player_can_remove(es[i]->get_handler_player(), this, REASON_EFFECT, peffect))
+		else if((redirect & LOCATION_REMOVED) && !is_affected_by_effect(EFFECT_CANNOT_REMOVE) && pduel->game_field->is_player_can_remove(es[i]->get_handler_player(), this, REASON_EFFECT | REASON_REDIRECT, peffect))
 			redirects |= redirect;
 	}
 	if(redirects & LOCATION_REMOVED)
@@ -2325,7 +2325,7 @@ int32_t card::destination_redirect(uint8_t destination, uint32_t reason) {
 			return redirect;
 		if((redirect & LOCATION_DECK) && !is_affected_by_effect(EFFECT_CANNOT_TO_DECK) && pduel->game_field->is_player_can_send_to_deck(es[i]->get_handler_player(), this))
 			return redirect;
-		if((redirect & LOCATION_REMOVED) && !is_affected_by_effect(EFFECT_CANNOT_REMOVE) && pduel->game_field->is_player_can_remove(es[i]->get_handler_player(), this, REASON_EFFECT, peffect))
+		if((redirect & LOCATION_REMOVED) && !is_affected_by_effect(EFFECT_CANNOT_REMOVE) && pduel->game_field->is_player_can_remove(es[i]->get_handler_player(), this, REASON_EFFECT | REASON_REDIRECT, peffect))
 			return redirect;
 		if((redirect & LOCATION_GRAVE) && !is_affected_by_effect(EFFECT_CANNOT_TO_GRAVE) && pduel->game_field->is_player_can_send_to_grave(es[i]->get_handler_player(), this))
 			return redirect;

--- a/field.cpp
+++ b/field.cpp
@@ -3370,7 +3370,9 @@ int32_t field::is_player_can_send_to_deck(uint8_t playerid, card * pcard) {
 	}
 	return TRUE;
 }
-int32_t field::is_player_can_remove(uint8_t playerid, card * pcard, uint32_t reason) {
+int32_t field::is_player_can_remove(uint8_t playerid, card* pcard, uint32_t reason, effect* reason_effect) {
+	if(!reason_effect)
+		reason_effect = core.reason_effect;
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_REMOVE, &eset);
 	for(effect_set::size_type i = 0; i < eset.size(); ++i) {
@@ -3380,7 +3382,7 @@ int32_t field::is_player_can_remove(uint8_t playerid, card * pcard, uint32_t rea
 		pduel->lua->add_param(pcard, PARAM_TYPE_CARD);
 		pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 		pduel->lua->add_param(reason, PARAM_TYPE_INT);
-		pduel->lua->add_param(core.reason_effect, PARAM_TYPE_EFFECT);
+		pduel->lua->add_param(reason_effect, PARAM_TYPE_EFFECT);
 		if(pduel->lua->check_condition(eset[i]->target, 5))
 			return FALSE;
 	}

--- a/field.h
+++ b/field.h
@@ -500,7 +500,7 @@ public:
 	int32_t is_player_can_send_to_grave(uint8_t playerid, card* pcard);
 	int32_t is_player_can_send_to_hand(uint8_t playerid, card* pcard);
 	int32_t is_player_can_send_to_deck(uint8_t playerid, card* pcard);
-	int32_t is_player_can_remove(uint8_t playerid, card* pcard, uint32_t reason);
+	int32_t is_player_can_remove(uint8_t playerid, card* pcard, uint32_t reason, effect* reason_effect = nullptr);
 	int32_t is_chain_negatable(uint8_t chaincount);
 	int32_t is_chain_disablable(uint8_t chaincount);
 	int32_t is_chain_disabled(uint8_t chaincount);


### PR DESCRIPTION
[Crystron Cluster nil re.zip](https://github.com/user-attachments/files/20361994/Crystron.Cluster.nil.re.zip)

When checking `EFFECT_LEAVE_FIELD_REDIRECT`, the reason effect should be that instead of the current reason effect.
Btw, advance summon and battle destroy don't have reason effect.

Require https://github.com/Fluorohydride/ygopro-scripts/pull/2953 to work fully.