### PR TITLE
workaround: set active_handler in xyz_add()

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1665,6 +1665,8 @@ void card::xyz_add(card* mat) {
 		effect* peffect = eit.second;
 		if(peffect->type & EFFECT_TYPE_FIELD)
 			pduel->game_field->add_effect(peffect);
+		if (peffect->type & EFFECT_TYPES_CHAIN_LINK)
+			peffect->active_handler = this;
 	}
 }
 void card::xyz_remove(card* mat) {

--- a/effect.cpp
+++ b/effect.cpp
@@ -805,10 +805,12 @@ effect* effect::clone() {
 	return ceffect;
 }
 card* effect::get_owner() const {
-	if(active_handler)
-		return active_handler;
-	if(type & EFFECT_TYPE_XMATERIAL)
-		return handler->overlay_target;
+	if (type & EFFECT_TYPE_XMATERIAL) {
+		if (active_handler)
+			return active_handler;
+		if (handler->overlay_target)
+			return handler->overlay_target;
+	}
 	return owner;
 }
 uint8_t effect::get_owner_player() const {
@@ -817,10 +819,12 @@ uint8_t effect::get_owner_player() const {
 	return get_owner()->current.controler;
 }
 card* effect::get_handler() const {
-	if(active_handler)
-		return active_handler;
-	if(type & EFFECT_TYPE_XMATERIAL)
-		return handler->overlay_target;
+	if (type & EFFECT_TYPE_XMATERIAL) {
+		if (active_handler)
+			return active_handler;
+		if (handler->overlay_target)
+			return handler->overlay_target;
+	}
 	return handler;
 }
 uint8_t effect::get_handler_player() const {

--- a/processor.cpp
+++ b/processor.cpp
@@ -4056,7 +4056,6 @@ int32_t field::add_chain(uint16_t step) {
 		if((peffect->card_type & (TYPE_TRAP | TYPE_MONSTER)) == (TYPE_TRAP | TYPE_MONSTER))
 			peffect->card_type -= TYPE_TRAP;
 		peffect->set_active_type();
-		peffect->active_handler = peffect->handler->overlay_target;
 		clit.chain_count = (uint8_t)core.current_chain.size() + 1;
 		clit.target_cards = 0;
 		clit.target_player = PLAYER_NONE;
@@ -4504,7 +4503,6 @@ int32_t field::solve_chain(uint16_t step, uint32_t chainend_arg1, uint32_t chain
 		}
 		// keep last active_type until the next activate, for the using in script
 		// peffect->active_type = 0;
-		peffect->active_handler = 0;
 		pcard->release_relation(*cait);
 		if(cait->target_cards)
 			pduel->delete_group(cait->target_cards);


### PR DESCRIPTION
workaround fix for https://github.com/Fluorohydride/ygopro/issues/2805

# Problem
Xyz monster X
material: Zoodiac Ratpier

X activate the effect gained from Zoodiac Ratpier
detach Zoodiac Ratpier

After the chain resolves:
active_handler is NULL
handler->overlay_target is NULL
so get_handler() retrunrs NULL

# Solution
It cannot be fully solved in current ocgcore structure.
A workaround solution:
For activated EFFECT_TYPE_XMATERIAL effects, set active_handler to "the last Xyz Monster it is attached to".
When we call `get_handler()` of EFFECT_TYPE_XMATERIAL effects, we are looking for that monster in most cases.

@mercury233 


