### PR TITLE
workwround: check last_handler after chain resolution

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -805,10 +805,14 @@ effect* effect::clone() {
 	return ceffect;
 }
 card* effect::get_owner() const {
-	if(active_handler)
-		return active_handler;
-	if(type & EFFECT_TYPE_XMATERIAL)
-		return handler->overlay_target;
+	if (type & EFFECT_TYPE_XMATERIAL) {
+		if (active_handler)
+			return active_handler;
+		if (handler->overlay_target)
+			return handler->overlay_target;
+		if (last_handler)
+			return last_handler;
+	}
 	return owner;
 }
 uint8_t effect::get_owner_player() const {
@@ -817,10 +821,14 @@ uint8_t effect::get_owner_player() const {
 	return get_owner()->current.controler;
 }
 card* effect::get_handler() const {
-	if(active_handler)
-		return active_handler;
-	if(type & EFFECT_TYPE_XMATERIAL)
-		return handler->overlay_target;
+	if (type & EFFECT_TYPE_XMATERIAL) {
+		if (active_handler)
+			return active_handler;
+		if (handler->overlay_target)
+			return handler->overlay_target;
+		if (last_handler)
+			return last_handler;
+	}
 	return handler;
 }
 uint8_t effect::get_handler_player() const {

--- a/effect.h
+++ b/effect.h
@@ -54,6 +54,7 @@ public:
 	uint16_t active_location{ 0 };
 	uint16_t active_sequence{ 0 };
 	card* active_handler{ nullptr };
+	card* last_handler{ nullptr };
 	std::vector<lua_Integer> label;
 	int32_t label_object{ 0 };
 	int32_t condition{ 0 };

--- a/processor.cpp
+++ b/processor.cpp
@@ -4056,7 +4056,10 @@ int32_t field::add_chain(uint16_t step) {
 		if((peffect->card_type & (TYPE_TRAP | TYPE_MONSTER)) == (TYPE_TRAP | TYPE_MONSTER))
 			peffect->card_type -= TYPE_TRAP;
 		peffect->set_active_type();
-		peffect->active_handler = peffect->handler->overlay_target;
+		if (peffect->type & EFFECT_TYPE_XMATERIAL) {
+			peffect->active_handler = peffect->handler->overlay_target;
+			peffect->last_handler = peffect->handler->overlay_target;
+		}
 		clit.chain_count = (uint8_t)core.current_chain.size() + 1;
 		clit.target_cards = 0;
 		clit.target_player = PLAYER_NONE;


### PR DESCRIPTION
workaround fix for https://github.com/Fluorohydride/ygopro/issues/2805

# Problem
Xyz monster X
material: Zoodiac Ratpier

X activate the effect gained from Zoodiac Ratpier
detach Zoodiac Ratpier

After the chain resolves:
active_handler is NULL
handler->overlay_target is NULL
so get_handler() retrunrs NULL

# Solution
It cannot be fully solved in current ocgcore structure.
A workaround solution:
last_handler
the last Xyz Monster where the effect is activated

Priority:
active_handler
handler->overlay_target
last_handler

@mercury233 
@Wind2009-Louse 