### PR TITLE
make ocgapi.h a C-compatible header

### DIFF
--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -28,13 +28,13 @@ static message_handler mhandler = default_message_handler;
 static byte buffer[0x100000];
 static std::set<duel*> duel_set;
 
-OCGAPI void set_script_reader(script_reader f) {
+OCGCORE_API void set_script_reader(script_reader f) {
 	sreader = f;
 }
-OCGAPI void set_card_reader(card_reader f) {
+OCGCORE_API void set_card_reader(card_reader f) {
 	creader = f;
 }
-OCGAPI void set_message_handler(message_handler f) {
+OCGCORE_API void set_message_handler(message_handler f) {
 	mhandler = f;
 }
 byte* read_script(const char* script_name, int* len) {
@@ -50,7 +50,7 @@ uint32_t read_card(uint32_t code, card_data* data) {
 uint32_t handle_message(void* pduel, uint32_t message_type) {
 	return mhandler((intptr_t)pduel, message_type);
 }
-OCGAPI byte* default_script_reader(const char* script_name, int* slen) {
+OCGCORE_API byte* default_script_reader(const char* script_name, int* slen) {
 	FILE *fp;
 	fp = std::fopen(script_name, "rb");
 	if (!fp)
@@ -62,13 +62,13 @@ OCGAPI byte* default_script_reader(const char* script_name, int* slen) {
 	*slen = (int)len;
 	return buffer;
 }
-OCGAPI intptr_t create_duel(uint_fast32_t seed) {
+OCGCORE_API intptr_t create_duel(uint_fast32_t seed) {
 	duel* pduel = new duel();
 	duel_set.insert(pduel);
 	pduel->random.reset(seed);
 	return (intptr_t)pduel;
 }
-OCGAPI void start_duel(intptr_t pduel, uint32_t options) {
+OCGCORE_API void start_duel(intptr_t pduel, uint32_t options) {
 	duel* pd = (duel*)pduel;
 	uint16_t duel_rule = options >> 16;
 	uint16_t duel_options = options & 0xffff;
@@ -113,14 +113,14 @@ OCGAPI void start_duel(intptr_t pduel, uint32_t options) {
 	}
 	pd->game_field->add_process(PROCESSOR_TURN, 0, 0, 0, 0, 0);
 }
-OCGAPI void end_duel(intptr_t pduel) {
+OCGCORE_API void end_duel(intptr_t pduel) {
 	duel* pd = (duel*)pduel;
 	if(duel_set.count(pd)) {
 		duel_set.erase(pd);
 		delete pd;
 	}
 }
-OCGAPI void set_player_info(intptr_t pduel, int32_t playerid, int32_t lp, int32_t startcount, int32_t drawcount) {
+OCGCORE_API void set_player_info(intptr_t pduel, int32_t playerid, int32_t lp, int32_t startcount, int32_t drawcount) {
 	if (!check_playerid(playerid))
 		return;
 	duel* pd = (duel*)pduel;
@@ -131,17 +131,17 @@ OCGAPI void set_player_info(intptr_t pduel, int32_t playerid, int32_t lp, int32_
 	if(drawcount >= 0)
 		pd->game_field->player[playerid].draw_count = drawcount;
 }
-OCGAPI void get_log_message(intptr_t pduel, char* buf) {
+OCGCORE_API void get_log_message(intptr_t pduel, char* buf) {
 	duel* pd = (duel*)pduel;
 	buf[0] = '\0';
 	std::strncat(buf, pd->strbuffer, sizeof pd->strbuffer - 1);
 }
-OCGAPI int32_t get_message(intptr_t pduel, byte* buf) {
+OCGCORE_API int32_t get_message(intptr_t pduel, byte* buf) {
 	int32_t len = ((duel*)pduel)->read_buffer(buf);
 	((duel*)pduel)->clear_buffer();
 	return len;
 }
-OCGAPI uint32_t process(intptr_t pduel) {
+OCGCORE_API uint32_t process(intptr_t pduel) {
 	duel* pd = (duel*)pduel;
 	uint32_t result = 0; 
 	do {
@@ -149,7 +149,7 @@ OCGAPI uint32_t process(intptr_t pduel) {
 	} while ((result & PROCESSOR_BUFFER_LEN) == 0 && (result & PROCESSOR_FLAG) == 0);
 	return result;
 }
-OCGAPI void new_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t playerid, uint8_t location, uint8_t sequence, uint8_t position) {
+OCGCORE_API void new_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t playerid, uint8_t location, uint8_t sequence, uint8_t position) {
 	if (!check_playerid(owner) || !check_playerid(playerid))
 		return;
 	duel* ptduel = (duel*)pduel;
@@ -167,7 +167,7 @@ OCGAPI void new_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t playe
 		}
 	}
 }
-OCGAPI void new_tag_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t location) {
+OCGCORE_API void new_tag_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t location) {
 	duel* ptduel = (duel*)pduel;
 	if(owner > 1 || !(location & (LOCATION_DECK | LOCATION_EXTRA)))
 		return;
@@ -196,7 +196,7 @@ OCGAPI void new_tag_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t l
 * @param buf int32_t array
 * @return buffer length in bytes
 */
-OCGAPI int32_t query_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint8_t sequence, int32_t query_flag, byte* buf, int32_t use_cache) {
+OCGCORE_API int32_t query_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint8_t sequence, int32_t query_flag, byte* buf, int32_t use_cache) {
 	if (!check_playerid(playerid))
 		return LEN_FAIL;
 	duel* ptduel = (duel*)pduel;
@@ -230,7 +230,7 @@ OCGAPI int32_t query_card(intptr_t pduel, uint8_t playerid, uint8_t location, ui
 		return LEN_EMPTY;
 	}
 }
-OCGAPI int32_t query_field_count(intptr_t pduel, uint8_t playerid, uint8_t location) {
+OCGCORE_API int32_t query_field_count(intptr_t pduel, uint8_t playerid, uint8_t location) {
 	duel* ptduel = (duel*)pduel;
 	if (!check_playerid(playerid))
 		return 0;
@@ -261,7 +261,7 @@ OCGAPI int32_t query_field_count(intptr_t pduel, uint8_t playerid, uint8_t locat
 	}
 	return 0;
 }
-OCGAPI int32_t query_field_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint32_t query_flag, byte* buf, int32_t use_cache) {
+OCGCORE_API int32_t query_field_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint32_t query_flag, byte* buf, int32_t use_cache) {
 	if (!check_playerid(playerid))
 		return LEN_FAIL;
 	duel* ptduel = (duel*)pduel;
@@ -308,7 +308,7 @@ OCGAPI int32_t query_field_card(intptr_t pduel, uint8_t playerid, uint8_t locati
 	}
 	return (int32_t)(p - buf);
 }
-OCGAPI int32_t query_field_info(intptr_t pduel, byte* buf) {
+OCGCORE_API int32_t query_field_info(intptr_t pduel, byte* buf) {
 	duel* ptduel = (duel*)pduel;
 	byte* p = buf;
 	*p++ = MSG_RELOAD_FIELD;
@@ -352,12 +352,12 @@ OCGAPI int32_t query_field_info(intptr_t pduel, byte* buf) {
 	}
 	return (int32_t)(p - buf);
 }
-OCGAPI void set_responsei(intptr_t pduel, int32_t value) {
+OCGCORE_API void set_responsei(intptr_t pduel, int32_t value) {
 	((duel*)pduel)->set_responsei(value);
 }
-OCGAPI void set_responseb(intptr_t pduel, byte* buf) {
+OCGCORE_API void set_responseb(intptr_t pduel, byte* buf) {
 	((duel*)pduel)->set_responseb(buf);
 }
-OCGAPI int32_t preload_script(intptr_t pduel, const char* script_name) {
+OCGCORE_API int32_t preload_script(intptr_t pduel, const char* script_name) {
 	return ((duel*)pduel)->lua->load_script(script_name);
 }

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -25,16 +25,16 @@ static uint32_t default_message_handler(intptr_t pduel, uint32_t message_type) {
 static script_reader sreader = default_script_reader;
 static card_reader creader = default_card_reader;
 static message_handler mhandler = default_message_handler;
-static byte buffer[0x20000];
+static byte buffer[0x100000];
 static std::set<duel*> duel_set;
 
-extern "C" DECL_DLLEXPORT void set_script_reader(script_reader f) {
+OCGAPI void set_script_reader(script_reader f) {
 	sreader = f;
 }
-extern "C" DECL_DLLEXPORT void set_card_reader(card_reader f) {
+OCGAPI void set_card_reader(card_reader f) {
 	creader = f;
 }
-extern "C" DECL_DLLEXPORT void set_message_handler(message_handler f) {
+OCGAPI void set_message_handler(message_handler f) {
 	mhandler = f;
 }
 byte* read_script(const char* script_name, int* len) {
@@ -50,7 +50,7 @@ uint32_t read_card(uint32_t code, card_data* data) {
 uint32_t handle_message(void* pduel, uint32_t message_type) {
 	return mhandler((intptr_t)pduel, message_type);
 }
-byte* default_script_reader(const char* script_name, int* slen) {
+OCGAPI byte* default_script_reader(const char* script_name, int* slen) {
 	FILE *fp;
 	fp = std::fopen(script_name, "rb");
 	if (!fp)
@@ -62,13 +62,13 @@ byte* default_script_reader(const char* script_name, int* slen) {
 	*slen = (int)len;
 	return buffer;
 }
-extern "C" DECL_DLLEXPORT intptr_t create_duel(uint_fast32_t seed) {
+OCGAPI intptr_t create_duel(uint_fast32_t seed) {
 	duel* pduel = new duel();
 	duel_set.insert(pduel);
 	pduel->random.reset(seed);
 	return (intptr_t)pduel;
 }
-extern "C" DECL_DLLEXPORT void start_duel(intptr_t pduel, uint32_t options) {
+OCGAPI void start_duel(intptr_t pduel, uint32_t options) {
 	duel* pd = (duel*)pduel;
 	uint16_t duel_rule = options >> 16;
 	uint16_t duel_options = options & 0xffff;
@@ -113,14 +113,14 @@ extern "C" DECL_DLLEXPORT void start_duel(intptr_t pduel, uint32_t options) {
 	}
 	pd->game_field->add_process(PROCESSOR_TURN, 0, 0, 0, 0, 0);
 }
-extern "C" DECL_DLLEXPORT void end_duel(intptr_t pduel) {
+OCGAPI void end_duel(intptr_t pduel) {
 	duel* pd = (duel*)pduel;
 	if(duel_set.count(pd)) {
 		duel_set.erase(pd);
 		delete pd;
 	}
 }
-extern "C" DECL_DLLEXPORT void set_player_info(intptr_t pduel, int32_t playerid, int32_t lp, int32_t startcount, int32_t drawcount) {
+OCGAPI void set_player_info(intptr_t pduel, int32_t playerid, int32_t lp, int32_t startcount, int32_t drawcount) {
 	if (!check_playerid(playerid))
 		return;
 	duel* pd = (duel*)pduel;
@@ -131,17 +131,17 @@ extern "C" DECL_DLLEXPORT void set_player_info(intptr_t pduel, int32_t playerid,
 	if(drawcount >= 0)
 		pd->game_field->player[playerid].draw_count = drawcount;
 }
-extern "C" DECL_DLLEXPORT void get_log_message(intptr_t pduel, char* buf) {
+OCGAPI void get_log_message(intptr_t pduel, char* buf) {
 	duel* pd = (duel*)pduel;
 	buf[0] = '\0';
 	std::strncat(buf, pd->strbuffer, sizeof pd->strbuffer - 1);
 }
-extern "C" DECL_DLLEXPORT int32_t get_message(intptr_t pduel, byte* buf) {
+OCGAPI int32_t get_message(intptr_t pduel, byte* buf) {
 	int32_t len = ((duel*)pduel)->read_buffer(buf);
 	((duel*)pduel)->clear_buffer();
 	return len;
 }
-extern "C" DECL_DLLEXPORT uint32_t process(intptr_t pduel) {
+OCGAPI uint32_t process(intptr_t pduel) {
 	duel* pd = (duel*)pduel;
 	uint32_t result = 0; 
 	do {
@@ -149,7 +149,7 @@ extern "C" DECL_DLLEXPORT uint32_t process(intptr_t pduel) {
 	} while ((result & PROCESSOR_BUFFER_LEN) == 0 && (result & PROCESSOR_FLAG) == 0);
 	return result;
 }
-extern "C" DECL_DLLEXPORT void new_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t playerid, uint8_t location, uint8_t sequence, uint8_t position) {
+OCGAPI void new_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t playerid, uint8_t location, uint8_t sequence, uint8_t position) {
 	if (!check_playerid(owner) || !check_playerid(playerid))
 		return;
 	duel* ptduel = (duel*)pduel;
@@ -167,7 +167,7 @@ extern "C" DECL_DLLEXPORT void new_card(intptr_t pduel, uint32_t code, uint8_t o
 		}
 	}
 }
-extern "C" DECL_DLLEXPORT void new_tag_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t location) {
+OCGAPI void new_tag_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t location) {
 	duel* ptduel = (duel*)pduel;
 	if(owner > 1 || !(location & (LOCATION_DECK | LOCATION_EXTRA)))
 		return;
@@ -196,7 +196,7 @@ extern "C" DECL_DLLEXPORT void new_tag_card(intptr_t pduel, uint32_t code, uint8
 * @param buf int32_t array
 * @return buffer length in bytes
 */
-extern "C" DECL_DLLEXPORT int32_t query_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint8_t sequence, int32_t query_flag, byte* buf, int32_t use_cache) {
+OCGAPI int32_t query_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint8_t sequence, int32_t query_flag, byte* buf, int32_t use_cache) {
 	if (!check_playerid(playerid))
 		return LEN_FAIL;
 	duel* ptduel = (duel*)pduel;
@@ -230,7 +230,7 @@ extern "C" DECL_DLLEXPORT int32_t query_card(intptr_t pduel, uint8_t playerid, u
 		return LEN_EMPTY;
 	}
 }
-extern "C" DECL_DLLEXPORT int32_t query_field_count(intptr_t pduel, uint8_t playerid, uint8_t location) {
+OCGAPI int32_t query_field_count(intptr_t pduel, uint8_t playerid, uint8_t location) {
 	duel* ptduel = (duel*)pduel;
 	if (!check_playerid(playerid))
 		return 0;
@@ -261,7 +261,7 @@ extern "C" DECL_DLLEXPORT int32_t query_field_count(intptr_t pduel, uint8_t play
 	}
 	return 0;
 }
-extern "C" DECL_DLLEXPORT int32_t query_field_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint32_t query_flag, byte* buf, int32_t use_cache) {
+OCGAPI int32_t query_field_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint32_t query_flag, byte* buf, int32_t use_cache) {
 	if (!check_playerid(playerid))
 		return LEN_FAIL;
 	duel* ptduel = (duel*)pduel;
@@ -308,7 +308,7 @@ extern "C" DECL_DLLEXPORT int32_t query_field_card(intptr_t pduel, uint8_t playe
 	}
 	return (int32_t)(p - buf);
 }
-extern "C" DECL_DLLEXPORT int32_t query_field_info(intptr_t pduel, byte* buf) {
+OCGAPI int32_t query_field_info(intptr_t pduel, byte* buf) {
 	duel* ptduel = (duel*)pduel;
 	byte* p = buf;
 	*p++ = MSG_RELOAD_FIELD;
@@ -352,12 +352,12 @@ extern "C" DECL_DLLEXPORT int32_t query_field_info(intptr_t pduel, byte* buf) {
 	}
 	return (int32_t)(p - buf);
 }
-extern "C" DECL_DLLEXPORT void set_responsei(intptr_t pduel, int32_t value) {
+OCGAPI void set_responsei(intptr_t pduel, int32_t value) {
 	((duel*)pduel)->set_responsei(value);
 }
-extern "C" DECL_DLLEXPORT void set_responseb(intptr_t pduel, byte* buf) {
+OCGAPI void set_responseb(intptr_t pduel, byte* buf) {
 	((duel*)pduel)->set_responseb(buf);
 }
-extern "C" DECL_DLLEXPORT int32_t preload_script(intptr_t pduel, const char* script_name) {
+OCGAPI int32_t preload_script(intptr_t pduel, const char* script_name) {
 	return ((duel*)pduel)->lua->load_script(script_name);
 }

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -16,6 +16,12 @@
 #include "interpreter.h"
 #include "buffer.h"
 
+static uint32_t default_card_reader(uint32_t code, card_data* data) {
+	return 0;
+}
+static uint32_t default_message_handler(intptr_t pduel, uint32_t message_type) {
+	return 0;
+}
 static script_reader sreader = default_script_reader;
 static card_reader creader = default_card_reader;
 static message_handler mhandler = default_message_handler;
@@ -55,12 +61,6 @@ byte* default_script_reader(const char* script_name, int* slen) {
 		return nullptr;
 	*slen = (int)len;
 	return buffer;
-}
-uint32_t default_card_reader(uint32_t code, card_data* data) {
-	return 0;
-}
-uint32_t default_message_handler(intptr_t pduel, uint32_t message_type) {
-	return 0;
 }
 extern "C" DECL_DLLEXPORT intptr_t create_duel(uint_fast32_t seed) {
 	duel* pduel = new duel();

--- a/ocgapi.h
+++ b/ocgapi.h
@@ -19,7 +19,7 @@
 #ifdef _WIN32
 #define OCGCORE_API EXTERN_C __declspec(dllexport)
 #else
-#define OCGAPI EXTERN_C __attribute__ ((visibility ("default")))
+#define OCGCORE_API EXTERN_C __attribute__ ((visibility ("default")))
 #endif
 
 #define LEN_FAIL	0

--- a/ocgapi.h
+++ b/ocgapi.h
@@ -17,7 +17,7 @@
 #endif
 
 #ifdef _WIN32
-#define OCGAPI EXTERN_C __declspec(dllexport)
+#define OCGCORE_API EXTERN_C __declspec(dllexport)
 #else
 #define OCGAPI EXTERN_C __attribute__ ((visibility ("default")))
 #endif
@@ -33,30 +33,30 @@ typedef byte* (*script_reader)(const char* script_name, int* len);
 typedef uint32_t (*card_reader)(uint32_t code, card_data* data);
 typedef uint32_t (*message_handler)(intptr_t pduel, uint32_t msg_type);
 
-OCGAPI void set_script_reader(script_reader f);
-OCGAPI void set_card_reader(card_reader f);
-OCGAPI void set_message_handler(message_handler f);
+OCGCORE_API void set_script_reader(script_reader f);
+OCGCORE_API void set_card_reader(card_reader f);
+OCGCORE_API void set_message_handler(message_handler f);
 
 byte* read_script(const char* script_name, int* len);
 uint32_t read_card(uint32_t code, card_data* data);
 uint32_t handle_message(void* pduel, uint32_t message_type);
 
-OCGAPI intptr_t create_duel(uint_fast32_t seed);
-OCGAPI void start_duel(intptr_t pduel, uint32_t options);
-OCGAPI void end_duel(intptr_t pduel);
-OCGAPI void set_player_info(intptr_t pduel, int32_t playerid, int32_t lp, int32_t startcount, int32_t drawcount);
-OCGAPI void get_log_message(intptr_t pduel, char* buf);
-OCGAPI int32_t get_message(intptr_t pduel, byte* buf);
-OCGAPI uint32_t process(intptr_t pduel);
-OCGAPI void new_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t playerid, uint8_t location, uint8_t sequence, uint8_t position);
-OCGAPI void new_tag_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t location);
-OCGAPI int32_t query_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint8_t sequence, int32_t query_flag, byte* buf, int32_t use_cache);
-OCGAPI int32_t query_field_count(intptr_t pduel, uint8_t playerid, uint8_t location);
-OCGAPI int32_t query_field_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint32_t query_flag, byte* buf, int32_t use_cache);
-OCGAPI int32_t query_field_info(intptr_t pduel, byte* buf);
-OCGAPI void set_responsei(intptr_t pduel, int32_t value);
-OCGAPI void set_responseb(intptr_t pduel, byte* buf);
-OCGAPI int32_t preload_script(intptr_t pduel, const char* script_name);
-OCGAPI byte* default_script_reader(const char* script_name, int* len);
+OCGCORE_API intptr_t create_duel(uint_fast32_t seed);
+OCGCORE_API void start_duel(intptr_t pduel, uint32_t options);
+OCGCORE_API void end_duel(intptr_t pduel);
+OCGCORE_API void set_player_info(intptr_t pduel, int32_t playerid, int32_t lp, int32_t startcount, int32_t drawcount);
+OCGCORE_API void get_log_message(intptr_t pduel, char* buf);
+OCGCORE_API int32_t get_message(intptr_t pduel, byte* buf);
+OCGCORE_API uint32_t process(intptr_t pduel);
+OCGCORE_API void new_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t playerid, uint8_t location, uint8_t sequence, uint8_t position);
+OCGCORE_API void new_tag_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t location);
+OCGCORE_API int32_t query_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint8_t sequence, int32_t query_flag, byte* buf, int32_t use_cache);
+OCGCORE_API int32_t query_field_count(intptr_t pduel, uint8_t playerid, uint8_t location);
+OCGCORE_API int32_t query_field_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint32_t query_flag, byte* buf, int32_t use_cache);
+OCGCORE_API int32_t query_field_info(intptr_t pduel, byte* buf);
+OCGCORE_API void set_responsei(intptr_t pduel, int32_t value);
+OCGCORE_API void set_responseb(intptr_t pduel, byte* buf);
+OCGCORE_API int32_t preload_script(intptr_t pduel, const char* script_name);
+OCGCORE_API byte* default_script_reader(const char* script_name, int* len);
 
 #endif /* OCGAPI_H_ */

--- a/ocgapi.h
+++ b/ocgapi.h
@@ -10,10 +10,16 @@
 
 #include "common.h"
 
-#ifdef _WIN32
-#define DECL_DLLEXPORT __declspec(dllexport)
+#ifdef __cplusplus
+#define EXTERN_C extern "C"
 #else
-#define DECL_DLLEXPORT
+#define EXTERN_C
+#endif
+
+#ifdef _WIN32
+#define OCGAPI EXTERN_C __declspec(dllexport)
+#else
+#define OCGAPI EXTERN_C
 #endif
 
 #define LEN_FAIL	0
@@ -27,30 +33,30 @@ typedef byte* (*script_reader)(const char* script_name, int* len);
 typedef uint32_t (*card_reader)(uint32_t code, card_data* data);
 typedef uint32_t (*message_handler)(intptr_t pduel, uint32_t msg_type);
 
-extern "C" DECL_DLLEXPORT void set_script_reader(script_reader f);
-extern "C" DECL_DLLEXPORT void set_card_reader(card_reader f);
-extern "C" DECL_DLLEXPORT void set_message_handler(message_handler f);
+OCGAPI void set_script_reader(script_reader f);
+OCGAPI void set_card_reader(card_reader f);
+OCGAPI void set_message_handler(message_handler f);
 
 byte* read_script(const char* script_name, int* len);
 uint32_t read_card(uint32_t code, card_data* data);
 uint32_t handle_message(void* pduel, uint32_t message_type);
 
-extern "C" DECL_DLLEXPORT intptr_t create_duel(uint_fast32_t seed);
-extern "C" DECL_DLLEXPORT void start_duel(intptr_t pduel, uint32_t options);
-extern "C" DECL_DLLEXPORT void end_duel(intptr_t pduel);
-extern "C" DECL_DLLEXPORT void set_player_info(intptr_t pduel, int32_t playerid, int32_t lp, int32_t startcount, int32_t drawcount);
-extern "C" DECL_DLLEXPORT void get_log_message(intptr_t pduel, char* buf);
-extern "C" DECL_DLLEXPORT int32_t get_message(intptr_t pduel, byte* buf);
-extern "C" DECL_DLLEXPORT uint32_t process(intptr_t pduel);
-extern "C" DECL_DLLEXPORT void new_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t playerid, uint8_t location, uint8_t sequence, uint8_t position);
-extern "C" DECL_DLLEXPORT void new_tag_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t location);
-extern "C" DECL_DLLEXPORT int32_t query_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint8_t sequence, int32_t query_flag, byte* buf, int32_t use_cache);
-extern "C" DECL_DLLEXPORT int32_t query_field_count(intptr_t pduel, uint8_t playerid, uint8_t location);
-extern "C" DECL_DLLEXPORT int32_t query_field_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint32_t query_flag, byte* buf, int32_t use_cache);
-extern "C" DECL_DLLEXPORT int32_t query_field_info(intptr_t pduel, byte* buf);
-extern "C" DECL_DLLEXPORT void set_responsei(intptr_t pduel, int32_t value);
-extern "C" DECL_DLLEXPORT void set_responseb(intptr_t pduel, byte* buf);
-extern "C" DECL_DLLEXPORT int32_t preload_script(intptr_t pduel, const char* script_name);
-byte* default_script_reader(const char* script_name, int* len);
+OCGAPI intptr_t create_duel(uint_fast32_t seed);
+OCGAPI void start_duel(intptr_t pduel, uint32_t options);
+OCGAPI void end_duel(intptr_t pduel);
+OCGAPI void set_player_info(intptr_t pduel, int32_t playerid, int32_t lp, int32_t startcount, int32_t drawcount);
+OCGAPI void get_log_message(intptr_t pduel, char* buf);
+OCGAPI int32_t get_message(intptr_t pduel, byte* buf);
+OCGAPI uint32_t process(intptr_t pduel);
+OCGAPI void new_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t playerid, uint8_t location, uint8_t sequence, uint8_t position);
+OCGAPI void new_tag_card(intptr_t pduel, uint32_t code, uint8_t owner, uint8_t location);
+OCGAPI int32_t query_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint8_t sequence, int32_t query_flag, byte* buf, int32_t use_cache);
+OCGAPI int32_t query_field_count(intptr_t pduel, uint8_t playerid, uint8_t location);
+OCGAPI int32_t query_field_card(intptr_t pduel, uint8_t playerid, uint8_t location, uint32_t query_flag, byte* buf, int32_t use_cache);
+OCGAPI int32_t query_field_info(intptr_t pduel, byte* buf);
+OCGAPI void set_responsei(intptr_t pduel, int32_t value);
+OCGAPI void set_responseb(intptr_t pduel, byte* buf);
+OCGAPI int32_t preload_script(intptr_t pduel, const char* script_name);
+OCGAPI byte* default_script_reader(const char* script_name, int* len);
 
 #endif /* OCGAPI_H_ */

--- a/ocgapi.h
+++ b/ocgapi.h
@@ -21,15 +21,11 @@
 #define LEN_HEADER	8
 #define TEMP_CARD_ID	0
 
-class card;
 struct card_data;
-class group;
-class effect;
-class interpreter;
 
-typedef byte* (*script_reader)(const char*, int*);
-typedef uint32_t (*card_reader)(uint32_t, card_data*);
-typedef uint32_t (*message_handler)(intptr_t, uint32_t);
+typedef byte* (*script_reader)(const char* script_name, int* len);
+typedef uint32_t (*card_reader)(uint32_t code, card_data* data);
+typedef uint32_t (*message_handler)(intptr_t pduel, uint32_t msg_type);
 
 extern "C" DECL_DLLEXPORT void set_script_reader(script_reader f);
 extern "C" DECL_DLLEXPORT void set_card_reader(card_reader f);

--- a/ocgapi.h
+++ b/ocgapi.h
@@ -19,7 +19,7 @@
 #ifdef _WIN32
 #define OCGAPI EXTERN_C __declspec(dllexport)
 #else
-#define OCGAPI EXTERN_C
+#define OCGAPI EXTERN_C __attribute__ ((visibility ("default")))
 #endif
 
 #define LEN_FAIL	0

--- a/ocgapi.h
+++ b/ocgapi.h
@@ -52,7 +52,5 @@ extern "C" DECL_DLLEXPORT void set_responsei(intptr_t pduel, int32_t value);
 extern "C" DECL_DLLEXPORT void set_responseb(intptr_t pduel, byte* buf);
 extern "C" DECL_DLLEXPORT int32_t preload_script(intptr_t pduel, const char* script_name);
 byte* default_script_reader(const char* script_name, int* len);
-uint32_t default_card_reader(uint32_t code, card_data* data);
-uint32_t default_message_handler(intptr_t pduel, uint32_t msg_type);
 
 #endif /* OCGAPI_H_ */


### PR DESCRIPTION
- C-compatible header
C does not have `extern "C"`, so we have to change the macro.
```cpp
#ifdef __cplusplus
#define EXTERN_C extern "C"
#else
#define EXTERN_C
#endif

#ifdef _WIN32
#define OCGCORE_API EXTERN_C __declspec(dllexport)
#else
#define OCGCORE_API EXTERN_C __attribute__ ((visibility ("default")))
#endif
```

- default_card_reader, default_message_handler
They are placeholder functions doing nothing.
Now they are changed to static function inside `ocgapi.cpp`.

- add new function default_script_reader
use fopen to read script file


@mercury233 
@purerosefallen 
@Wind2009-Louse 

