### PR TITLE
 Refactor random integer generation and shuffling

### DIFF
--- a/duel.cpp
+++ b/duel.cpp
@@ -143,10 +143,7 @@ void duel::set_responseb(byte* resp) {
 	std::memcpy(game_field->returns.bvalue, resp, SIZE_RETURN_VALUE);
 }
 int32_t duel::get_next_integer(int32_t l, int32_t h) {
-	if (game_field->core.duel_options & DUEL_OLD_REPLAY) {
-		return random.get_random_integer_old(l, h);
-	}
-	else {
-		return random.get_random_integer(l, h);
-	}
+	if (rng_version == 1)
+		return random.get_random_integer_v1(l, h);
+	return random.get_random_integer_v2(l, h);
 }

--- a/duel.h
+++ b/duel.h
@@ -25,11 +25,13 @@ using card_set = std::set<card*, card_sort>;
 
 class duel {
 public:
-	char strbuffer[256];
-	std::vector<byte> message_buffer;
+	char strbuffer[256]{};
+	int32_t rng_version{ 2 };
 	interpreter* lua;
 	field* game_field;
 	mt19937 random;
+
+	std::vector<byte> message_buffer;
 	std::unordered_set<card*> cards;
 	std::unordered_set<card*> assumes;
 	std::unordered_set<group*> groups;

--- a/field.cpp
+++ b/field.cpp
@@ -957,10 +957,7 @@ void field::shuffle(uint8_t playerid, uint8_t location) {
 		if(location == LOCATION_EXTRA)
 			s = s - (int32_t)player[playerid].extra_p_count;
 		if(s > 1) {
-			if (core.duel_options & DUEL_OLD_REPLAY)
-				pduel->random.shuffle_vector_old(svector, 0, s - 1);
-			else
-				pduel->random.shuffle_vector(svector, 0, s - 1);
+			pduel->random.shuffle_vector(svector, 0, s, pduel->rng_version);
 			reset_sequence(playerid, location);
 		}
 	}

--- a/mtrandom.h
+++ b/mtrandom.h
@@ -14,25 +14,39 @@
 
 class mt19937 {
 public:
-	const unsigned int rand_max;
+	const unsigned int rand_max{ std::mt19937::max() };
 
 	mt19937() :
-		rng(), rand_max(rng.max()) {}
-	explicit mt19937(uint_fast32_t seed) :
-		rng(seed), rand_max(rng.max()) {}
+		rng() {}
+	explicit mt19937(uint_fast32_t value) :
+		rng(value) {}
+	mt19937(uint32_t seq[], size_t len) {
+		std::seed_seq q(seq, seq + len);
+		rng.seed(q);
+	}
+	
+	mt19937(const mt19937& other) = delete;
+	void operator=(const mt19937& other) = delete;
 
 	// mersenne_twister_engine
-	void reset(uint_fast32_t seed) {
-		rng.seed(seed);
+	void seed(uint32_t seq[], size_t len) {
+		std::seed_seq q(seq, seq + len);
+		rng.seed(q);
+	}
+	void seed(uint_fast32_t value) {
+		rng.seed(value);
 	}
 	uint_fast32_t rand() {
 		return rng();
 	}
+	void discard(unsigned long long z) {
+		rng.discard(z);
+	}
 
-	// uniform_int_distribution
-	int get_random_integer(int l, int h) {
-		uint_fast32_t range = (uint_fast32_t)(h - l + 1);
-		uint_fast32_t secureMax = rng.max() - rng.max() % range;
+	// old vesion, discard too many numbers
+	int get_random_integer_v1(int l, int h) {
+		uint32_t range = (h - l + 1);
+		uint32_t secureMax = rand_max - rand_max % range;
 		uint_fast32_t x;
 		do {
 			x = rng();

--- a/mtrandom.h
+++ b/mtrandom.h
@@ -53,33 +53,28 @@ public:
 		} while (x >= secureMax);
 		return l + (int)(x % range);
 	}
-	int get_random_integer_old(int l, int h) {
-		int result = (int)((double)rng() / rng.max() * ((double)h - l + 1)) + l;
-		if (result > h)
-			result = h;
-		return result;
-	}
-	
-	// Fisher-Yates shuffle v[a]~v[b]
-	template<typename T>
-	void shuffle_vector(std::vector<T>& v, int a = -1, int b = -1) {
-		if (a < 0)
-			a = 0;
-		if (b < 0)
-			b = (int)v.size() - 1;
-		for (int i = a; i < b; ++i) {
-			int r = get_random_integer(i, b);
-			std::swap(v[i], v[r]);
+
+	// N % k == (N - k) % k, discard the leftmost numbers
+	int get_random_integer_v2(int l, int h) {
+		uint32_t range = (h - l + 1);
+		uint32_t bound = -range % range;
+		auto x = rng();
+		while (x < bound) {
+			x = rng();
 		}
+		return l + (int)(x % range);
 	}
+
+	// Fisher-Yates shuffle [first, last)
 	template<typename T>
-	void shuffle_vector_old(std::vector<T>& v, int a = -1, int b = -1) {
-		if (a < 0)
-			a = 0;
-		if (b < 0)
-			b = (int)v.size() - 1;
-		for (int i = a; i < b; ++i) {
-			int r = get_random_integer_old(i, b);
+	void shuffle_vector(std::vector<T>& v, int first = 0, int last = INT32_MAX, int version = 2) {
+		if ((size_t)last > v.size())
+			last = v.size();
+		auto distribution = &mt19937::get_random_integer_v2;
+		if (version == 1)
+			distribution = &mt19937::get_random_integer_v1;
+		for (int i = first; i < last - 1; ++i) {
+			int r = (this->*distribution)(i, last - 1);
 			std::swap(v[i], v[r]);
 		}
 	}

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -65,7 +65,7 @@ OCGCORE_API byte* default_script_reader(const char* script_name, int* slen) {
 OCGCORE_API intptr_t create_duel(uint_fast32_t seed) {
 	duel* pduel = new duel();
 	duel_set.insert(pduel);
-	pduel->random.reset(seed);
+	pduel->random.seed(seed);
 	return (intptr_t)pduel;
 }
 OCGCORE_API void start_duel(intptr_t pduel, uint32_t options) {
@@ -83,6 +83,8 @@ OCGCORE_API void start_duel(intptr_t pduel, uint32_t options) {
 		pd->game_field->player[0].szone_size = 8;
 		pd->game_field->player[1].szone_size = 8;
 	}
+	if (options & DUEL_OLD_REPLAY)
+		pd->rng_version = 1;
 	pd->game_field->core.shuffle_hand_check[0] = FALSE;
 	pd->game_field->core.shuffle_hand_check[1] = FALSE;
 	pd->game_field->core.shuffle_deck_check[0] = FALSE;

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -68,6 +68,12 @@ OCGCORE_API intptr_t create_duel(uint_fast32_t seed) {
 	pduel->random.seed(seed);
 	return (intptr_t)pduel;
 }
+OCGCORE_API intptr_t create_duel_v2(uint32_t seed_sequence[]) {
+	duel* pduel = new duel();
+	duel_set.insert(pduel);
+	pduel->random.seed(seed_sequence, SEED_COUNT);
+	return (intptr_t)pduel;
+}
 OCGCORE_API void start_duel(intptr_t pduel, uint32_t options) {
 	duel* pd = (duel*)pduel;
 	uint16_t duel_rule = options >> 16;

--- a/ocgapi.h
+++ b/ocgapi.h
@@ -22,6 +22,8 @@
 #define OCGCORE_API EXTERN_C __attribute__ ((visibility ("default")))
 #endif
 
+#define SEED_COUNT	8
+
 #define LEN_FAIL	0
 #define LEN_EMPTY	4
 #define LEN_HEADER	8
@@ -42,6 +44,7 @@ uint32_t read_card(uint32_t code, card_data* data);
 uint32_t handle_message(void* pduel, uint32_t message_type);
 
 OCGCORE_API intptr_t create_duel(uint_fast32_t seed);
+OCGCORE_API intptr_t create_duel_v2(uint32_t seed_sequence[]);
 OCGCORE_API void start_duel(intptr_t pduel, uint32_t options);
 OCGCORE_API void end_duel(intptr_t pduel);
 OCGCORE_API void set_player_info(intptr_t pduel, int32_t playerid, int32_t lp, int32_t startcount, int32_t drawcount);


### PR DESCRIPTION
Background:
https://github.com/Fluorohydride/ygopro/pull/2820

# mersenne_twister_engine
C++14
26.5.3.2 Class template mersenne_twister_engine
```cpp
template<class UIntType, size_t w, size_t n, size_t m, size_t r,
UIntType a, size_t u, UIntType d, size_t s,
UIntType b, size_t t,
UIntType c, size_t l, UIntType f>
class mersenne_twister_engine {
  // engine characteristics
  static constexpr size_t word_size = w;
  static constexpr size_t state_size = n;
  static constexpr size_t shift_size = m;
  static constexpr size_t mask_bits = r;
  static constexpr UIntType xor_mask = a;
  static constexpr size_t tempering_u = u;
  static constexpr UIntType tempering_d = d;
  static constexpr size_t tempering_s = s;
  static constexpr UIntType tempering_b = b;
  static constexpr size_t tempering_t = t;
  static constexpr UIntType tempering_c = c;
  static constexpr size_t tempering_l = l;
  static constexpr UIntType initialization_multiplier = f;
  static constexpr result_type min() { return 0; }
  static constexpr result_type max() { return 2**w − 1; }
  static constexpr result_type default_seed = 5489u;

  // constructors and seeding functions
  explicit mersenne_twister_engine(result_type value = default_seed);
  template<class Sseq> explicit mersenne_twister_engine(Sseq& q);

  void seed(result_type value = default_seed);
  template<class Sseq> void seed(Sseq& q);

  // generating functions
  result_type operator()();
  void discard(unsigned long long z);
}
```
```cpp
typedef mersenne_twister_engine<uint_fast32_t,32,624,397,31,
0x9908b0df,11,0xffffffff,7,0x9d2c5680,15,0xefc60000,18,1812433253>
mt19937;
```
mt19937:
w=32, n=624


![mt19937](https://github.com/user-attachments/assets/ff93b6ed-5fe5-4b10-b56a-bc216051c1d5)


# Constructor of mersenne_twister_engine 
The state xi of a mersenne_twister_engine object x is of size n and consists of a sequence X of n values of the type delivered by x; all subscripts applied to X are to be taken modulo n. 
```cpp
explicit mersenne_twister_engine(result_type value = default_seed);
```
Briefly speaking, set X0 to `value` and calculate other initial states from X0.

```cpp
template<class Sseq> explicit mersenne_twister_engine(Sseq& q);
```
Briefly speaking, set X0~X_n-1 by `q.generate(a, a+n)`.


# Changes in constructor
```cpp
mt19937() :
	rng() {}
explicit mt19937(uint_fast32_t value) :
	rng(value) {}
mt19937(uint32_t seq[], size_t len) {
	std::seed_seq q(seq, seq + len);
	rng.seed(q);
}
```
Now it can take multiple `uint32_t` seeds.

# Changes in RNG functions
```cpp
void seed(uint32_t seq[], size_t len) {
	std::seed_seq q(seq, seq + len);
	rng.seed(q);
}
void seed(uint_fast32_t value) {
	rng.seed(value);
}
uint_fast32_t rand() {
	return rng();
}
void discard(unsigned long long z) {
	rng.discard(z);
}
```
Rename the `seed` functions to the name in std library.
Add `discard`

# Changes in uniform distribution
```cpp
// old vesion, discard too many numbers
int get_random_integer_v1(int l, int h) {
	uint32_t range = (h - l + 1);
	uint32_t secureMax = rand_max - rand_max % range;
	uint_fast32_t x;
	do {
		x = rng();
	} while (x >= secureMax);
	return l + (int)(x % range);
}
```
V1 is the uniform distribution we used before.
It was based on an answer of stackoverflow.
It takes the whole range of mt19937 as `0 ~ 2^32-2` (size = 2^32-1).

If the distribution range is 2^k, it will discard 1 section of length 2^k unnecessarily.
It is uniform, but it discard too many numbers.
Discarding from the right also makes it hard to understand.


```cpp
// N % k == (N - k) % k, discard the leftmost numbers
int get_random_integer_v2(int l, int h) {
	uint32_t range = (h - l + 1);
	uint32_t bound = -range % range;
	auto x = rng();
	while (x < bound) {
		x = rng();
	}
	return l + (int)(x % range);
}
```
V2 is the new uniform distribution.
We have to discard `bound = N % range` values, so discarding the leftmost `bound` values is much easier.


# Changes in shuffling
```cpp
// Fisher-Yates shuffle [first, last)
template<typename T>
void shuffle_vector(std::vector<T>& v, int first = 0, int last = INT32_MAX, int version = 2) {
	if ((size_t)last > v.size())
		last = v.size();
	auto distribution = &mt19937::get_random_integer_v2;
	if (version == 1)
		distribution = &mt19937::get_random_integer_v1;
	for (int i = first; i < last - 1; ++i) {
		int r = (this->*distribution)(i, last - 1);
		std::swap(v[i], v[r]);
	}
}
```
The range is chanced to `[first, last)` like the shuffle function in std library.
It use distribution V2 by default, but it can be set to V1 to support the shuffling in the replay before.

# `DUEL_OLD_REPLAY`
DUEL_OLD_REPLAY
Now the option means that using distribution V1.
The option is for playing yrp files from version 0x1353.

# new API create_duel_v2
```cpp
OCGCORE_API intptr_t create_duel_v2(uint32_t seed_sequence[]);
```
The only difference is the seed is a sequence now.
The current length is 8.


# Removal
get_random_integer_old
The non-uniform distribution used before 2021.
It is not used now, and we should not keep this non-uniform distribution forever.


@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust


@DyXel 
Thank you for your advices.
They are very helpful, but I don't have much time.
Moving to Xoshiro256** might be done some time later.
