### PR TITLE
Feat: Add Lua API Effect.RestoreCountLimit

### DIFF
--- a/effect.cpp
+++ b/effect.cpp
@@ -682,6 +682,21 @@ void effect::dec_count(uint8_t playerid) {
 			pduel->game_field->add_effect_code(count_code, playerid);
 	}
 }
+void effect::inc_count(uint8_t playerid) {
+	if(!is_flag(EFFECT_FLAG_COUNT_LIMIT))
+		return;
+	// count_code == count_limit_max will always be true if count_code is set
+	if((count_code == 0 || is_flag(EFFECT_FLAG_NO_TURN_RESET)) && count_limit < count_limit_max)
+		count_limit += 1;
+	if(count_code) {
+		uint32_t limit_code = count_code & MAX_CARD_ID;
+		uint32_t limit_type = count_code & 0xf0000000;
+		if(limit_code == EFFECT_COUNT_CODE_SINGLE)
+			pduel->game_field->dec_effect_code(limit_type | get_handler()->activate_count_id, PLAYER_NONE);
+		else
+			pduel->game_field->dec_effect_code(count_code, playerid);
+    }
+}
 void effect::recharge() {
 	if(is_flag(EFFECT_FLAG_COUNT_LIMIT)) {
 		count_limit = count_limit_max;

--- a/effect.h
+++ b/effect.h
@@ -93,6 +93,7 @@ public:
 	int32_t is_monster_effect() const;
 	int32_t reset(uint32_t reset_level, uint32_t reset_type);
 	void dec_count(uint8_t playerid = PLAYER_NONE);
+	void inc_count(uint8_t playerid = PLAYER_NONE);
 	void recharge();
 	int32_t get_value(uint32_t extraargs = 0);
 	int32_t get_value(card* pcard, uint32_t extraargs = 0);

--- a/scriptlib.h
+++ b/scriptlib.h
@@ -366,6 +366,7 @@ public:
 	static int32_t effect_get_activate_sequence(lua_State *L);
 	static int32_t effect_check_count_limit(lua_State *L);
 	static int32_t effect_use_count_limit(lua_State *L);
+	static int32_t effect_restore_count_limit(lua_State* L);
 	static void open_effectlib(lua_State *L);
 
 	//Group functions


### PR DESCRIPTION
To support robust internal simulations and strict “once per name” limits (e.g. for [Drake Shark](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=20478&request_locale=ja)), I’ve added a new API in ygo-core:

```lua
--- Manually adjust the available usage count of effect `e` for player `p` by `count` times.
--- `oath_only` restricts restoration to oath‐flagged uses (e.g., from the “Pop-Up” effect), though no such case is currently implemented.
---@param e Effect           -- The effect instance whose usage count to restore.
---@param p integer          -- Player ID (0 for first player, 1 for second player).
---@param count? integer     -- Number of uses to restore (default: 1).
---@param oath_only? boolean -- If true, only restore usages counted with EFFECT_FLAG_OATH (default: false).
function Effect.RestoreCountLimit(e, p, count, oath_only) end
```

# Why This API Is Necessary

Temporary Blocking: During DFS or UI-driven “what-if” simulations, I need to mark an effect as used—preventing further CheckCountLimit successes on that branch—without permanently consuming it.

Reliable Rollback: Previously, `UseCountLimit(tp, -1)` had no effect (but some long loop and game frozen, guard added in this PR as well) on the engine’s internal counter; simulations leaked state into the real duel. With RestoreCountLimit, I can now correctly undo each tentative UseCountLimit.

Strict Per-Name Enforcement: For cards like Drake Shark that are “once per card name,” I must both block additional uses during simulation and restore them afterward. This API ensures that legitimate plays aren’t wrongly blocked (or allowed twice) by my internal logic.

# Test Card
I used the following script to validate RestoreCountLimit across different count-limit scopes:
```lua
--- test restore
local s,id,o=GetID()
function s.initial_effect(c)
	--- once per duel
	local e0=Effect.CreateEffect(c)
	e0:SetType(EFFECT_TYPE_IGNITION)
	e0:SetRange(LOCATION_MZONE)
	e0:SetDescription(aux.Stringid(id,0))
	e0:SetCountLimit(1,EFFECT_COUNT_CODE_DUEL)
	e0:SetOperation(function (e,tp,eg,ep,ev,re,r,rp) e:RestoreCountLimit(tp) end)
	c:RegisterEffect(e0)
	--- once per card id
	local e1=Effect.CreateEffect(c)
	e1:SetType(EFFECT_TYPE_IGNITION)
	e1:SetRange(LOCATION_MZONE)
	e1:SetDescription(aux.Stringid(id,1))
	e1:SetCountLimit(1,id)
	e1:SetOperation(function (e,tp,eg,ep,ev,re,r,rp) e:RestoreCountLimit(tp) end)
	c:RegisterEffect(e1)
	-- once per card
	local e2=Effect.CreateEffect(c)
	e2:SetType(EFFECT_TYPE_IGNITION)
	e2:SetRange(LOCATION_MZONE)
	e2:SetDescription(aux.Stringid(id,2))
	e2:SetCountLimit(1)
	e2:SetOperation(function (e,tp,eg,ep,ev,re,r,rp) e:RestoreCountLimit(tp) end)
	c:RegisterEffect(e2)
	-- once per card, shared
	local e3=Effect.CreateEffect(c)
	e3:SetType(EFFECT_TYPE_IGNITION)
	e3:SetRange(LOCATION_MZONE)
	e3:SetDescription(aux.Stringid(id,3))
	e3:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
	e3:SetOperation(function (e,tp,eg,ep,ev,re,r,rp) e:RestoreCountLimit(tp) end)
	c:RegisterEffect(e3)
	-- once per card, shared
	local e4=Effect.CreateEffect(c)
	e4:SetType(EFFECT_TYPE_IGNITION)
	e4:SetRange(LOCATION_MZONE)
	e4:SetDescription(aux.Stringid(id,4))
	e4:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
	e4:SetOperation(function (e,tp,eg,ep,ev,re,r,rp) e:RestoreCountLimit(tp) end)
	c:RegisterEffect(e4)
end
```


This test confirms that for each scope—duel, per-card-ID, per-instance, and shared—the call to RestoreCountLimit correctly decrements the counter and allows repeated operations only when intended.