### PR TITLE
add new option for interpreter to manage unsafe libraries

### DIFF
--- a/duel.cpp
+++ b/duel.cpp
@@ -16,7 +16,7 @@
 #include "buffer.h"
 
 duel::duel() {
-	lua = new interpreter(this);
+	lua = new interpreter(this, false);
 	game_field = new field(this);
 	game_field->temp_card = new_card(TEMP_CARD_ID);
 	message_buffer.reserve(SIZE_MESSAGE_BUFFER);

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -14,7 +14,7 @@
 #include "ocgapi.h"
 #include "interpreter.h"
 
-interpreter::interpreter(duel* pd): coroutines(256) {
+interpreter::interpreter(duel* pd, bool enable_unsafe_libraries): coroutines(256) {
 	lua_state = luaL_newstate();
 	current_state = lua_state;
 	pduel = pd;
@@ -32,15 +32,20 @@ interpreter::interpreter(duel* pd): coroutines(256) {
 	lua_pop(lua_state, 1);
 	luaL_requiref(lua_state, "math", luaopen_math, 1);
 	lua_pop(lua_state, 1);
+	if (enable_unsafe_libraries) {
+		luaL_requiref(lua_state, "io", luaopen_io, 1);
+		lua_pop(lua_state, 1);
+	}
+
 	auto nil_out = [&](const char* name) {
 		lua_pushnil(lua_state);
 		lua_setglobal(lua_state, name);
 	};
 	nil_out("collectgarbage");
-#ifndef ENABLE_UNSAFE_LIBRARIES
-	nil_out("dofile");
-	nil_out("loadfile");
-#endif // ENABLE_UNSAFE_LIBRARIES
+	if (!enable_unsafe_libraries) {
+		nil_out("dofile");
+		nil_out("loadfile");
+	}
 	//open all libs
 	scriptlib::open_cardlib(lua_state);
 	scriptlib::open_effectlib(lua_state);

--- a/interpreter.h
+++ b/interpreter.h
@@ -53,7 +53,7 @@ public:
 	int32_t no_action;
 	int32_t call_depth;
 
-	explicit interpreter(duel* pd);
+	explicit interpreter(duel* pd, bool enable_unsafe_libraries);
 	~interpreter();
 
 	void register_card(card* pcard);


### PR DESCRIPTION
based on the constructor of interpreter in edopro

Reference
https://github.com/edo9300/ygopro-core/blob/e2f5d6de3fbd85d6c126e9adbb32c9e15c34c50b/interpreter.cpp#L60


@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust