### PR TITLE
Revert "fix Debug.ReloadFieldBegin (#726)"

### DIFF
--- a/libdebug.cpp
+++ b/libdebug.cpp
@@ -149,6 +149,10 @@ int32_t scriptlib::debug_reload_field_begin(lua_State *L) {
 		pduel->game_field->core.duel_rule = 1;
 	else
 		pduel->game_field->core.duel_rule = CURRENT_RULE;
+	if (pduel->game_field->core.duel_rule == MASTER_RULE3) {
+		pduel->game_field->player[0].szone_size = 8;
+		pduel->game_field->player[1].szone_size = 8;
+	}
 	return 0;
 }
 int32_t scriptlib::debug_reload_field_end(lua_State *L) {


### PR DESCRIPTION
This reverts commit 26413fcae50693fa60101830e11430be229c90b3.

Single mode:
https://github.com/Fluorohydride/ygopro/blob/d5044ff888e0331659155b049b299340bfc1575a/gframe/single_mode.cpp#L85
preload_script(pduel, filename)

https://github.com/Fluorohydride/ygopro/blob/d5044ff888e0331659155b049b299340bfc1575a/gframe/single_mode.cpp#L129
start_duel(pduel, opt);

start_duel is called after loading the single script, so `szone_size` should be set in `Debug.LoadFieldBegin()`.
fix #782 