### PR TITLE
Fix EFFECT_EXTRA_SYNCHRO_MATERIAL

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -4093,18 +4093,6 @@ int32_t card::is_can_be_synchro_material(card* scard, card* tuner) {
 	for(effect_set::size_type i = 0; i < eset.size(); ++i)
 		if(eset[i]->get_value(scard))
 			return FALSE;
-	if(scard && !(current.location == LOCATION_MZONE && current.controler == scard->current.controler)) {
-		eset.clear();
-		filter_effect(EFFECT_EXTRA_SYNCHRO_MATERIAL, &eset);
-		if(eset.size()) {
-			for(effect_set::size_type i = 0; i < eset.size(); ++i) {
-				if(!eset[i]->check_count_limit(scard->current.controler))
-					continue;
-				if(eset[i]->get_value(scard))
-					return TRUE;
-			}
-		}
-	}
 	return TRUE;
 }
 int32_t card::is_can_be_ritual_material(card* scard) {

--- a/card.cpp
+++ b/card.cpp
@@ -4103,7 +4103,6 @@ int32_t card::is_can_be_synchro_material(card* scard, card* tuner) {
 				if(eset[i]->get_value(scard))
 					return TRUE;
 			}
-			return FALSE;
 		}
 	}
 	return TRUE;


### PR DESCRIPTION
If a monster has EFFECT_EXTRA_SYNCHRO_MATERIAL, even if it doesn't meet the value, it should still be able to be synchro material by other materials with effect like EFFECT_HAND_SYNCHRO.

Test puzzle:
```lua
--[[message TEST]]
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_TEST_MODE)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(97682931,0,0,LOCATION_HAND,3,POS_FACEUP_ATTACK)

Debug.AddCard(39552864,0,0,LOCATION_MZONE,1,POS_FACEUP_ATTACK)
Debug.AddCard(60071928,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK)
Debug.AddCard(39552864,0,0,LOCATION_MZONE,3,POS_FACEUP_ATTACK)

Debug.AddCard(821049,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)
Debug.AddCard(55863245,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)

Debug.ReloadFieldEnd()
```