### PR TITLE
Revise field::get_fusion_material

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -4066,6 +4066,14 @@ int32_t card::is_can_be_fusion_material(card* fcard, uint32_t summon_type) {
 		if(eset[i]->get_value(fcard, 1))
 			return FALSE;
 	}
+	eset.clear();
+	filter_effect(EFFECT_EXTRA_FUSION_MATERIAL, &eset);
+	if(eset.size()) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i)
+			if(eset[i]->get_value(fcard))
+				return TRUE;
+		return FALSE;
+	}
 	return TRUE;
 }
 int32_t card::is_can_be_synchro_material(card* scard, card* tuner) {


### PR DESCRIPTION
ref: https://github.com/Fluorohydride/ygopro-scripts/pull/2961

Search for more locations about cards affected by `EFFECT_EXTRA_FUSION_MATERIAL`.