### PR TITLE
Fix field negate chain

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -4068,6 +4068,14 @@ int32_t card::is_can_be_fusion_material(card* fcard, uint32_t summon_type) {
 		if(eset[i]->get_value(fcard, 1))
 			return FALSE;
 	}
+	eset.clear();
+	filter_effect(EFFECT_EXTRA_FUSION_MATERIAL, &eset);
+	if(eset.size()) {
+		for(effect_set::size_type i = 0; i < eset.size(); ++i)
+			if(eset[i]->get_value(fcard))
+				return TRUE;
+		return FALSE;
+	}
 	return TRUE;
 }
 int32_t card::is_can_be_synchro_material(card* scard, card* tuner) {

--- a/card.cpp
+++ b/card.cpp
@@ -4066,14 +4066,6 @@ int32_t card::is_can_be_fusion_material(card* fcard, uint32_t summon_type) {
 		if(eset[i]->get_value(fcard, 1))
 			return FALSE;
 	}
-	eset.clear();
-	filter_effect(EFFECT_EXTRA_FUSION_MATERIAL, &eset);
-	if(eset.size()) {
-		for(effect_set::size_type i = 0; i < eset.size(); ++i)
-			if(eset[i]->get_value(fcard))
-				return TRUE;
-		return FALSE;
-	}
 	return TRUE;
 }
 int32_t card::is_can_be_synchro_material(card* scard, card* tuner) {

--- a/operations.cpp
+++ b/operations.cpp
@@ -24,7 +24,7 @@ int32_t field::negate_chain(uint8_t chaincount) {
 		pchain.flag |= CHAIN_DISABLE_ACTIVATE;
 		pchain.disable_reason = core.reason_effect;
 		pchain.disable_player = core.reason_player;
-		if((pchain.triggering_effect->type & EFFECT_TYPE_ACTIVATE) && (phandler->current.location == LOCATION_SZONE)) {
+		if((pchain.triggering_effect->type & EFFECT_TYPE_ACTIVATE) && (phandler->is_has_relation(pchain)) && (phandler->current.location == LOCATION_SZONE)) {
 			phandler->set_status(STATUS_LEAVE_CONFIRMED, TRUE);
 			phandler->set_status(STATUS_ACTIVATE_DISABLED, TRUE);
 		}

--- a/operations.cpp
+++ b/operations.cpp
@@ -24,7 +24,7 @@ int32_t field::negate_chain(uint8_t chaincount) {
 		pchain.flag |= CHAIN_DISABLE_ACTIVATE;
 		pchain.disable_reason = core.reason_effect;
 		pchain.disable_player = core.reason_player;
-		if((pchain.triggering_effect->type & EFFECT_TYPE_ACTIVATE) && (phandler->is_has_relation(pchain)) && (phandler->current.location == LOCATION_SZONE)) {
+		if((pchain.triggering_effect->type & EFFECT_TYPE_ACTIVATE) && phandler->is_has_relation(pchain) && (phandler->current.location == LOCATION_SZONE)) {
 			phandler->set_status(STATUS_LEAVE_CONFIRMED, TRUE);
 			phandler->set_status(STATUS_ACTIVATE_DISABLED, TRUE);
 		}


### PR DESCRIPTION
If a Spell/Trap card that is going to have its activation negated leaves the field but it is put back in the S/T zone before this function (`field::negate_chain`) is executed, it should not be sent to the GY when the negation occurs because it is treated as a different copy of the card. Currently it will be sent to the GY, which is wrong

This pull requests adds an extra check for the chain relation before setting the status to the card

test scenario
```
Debug.SetAIName("Negate Activation")
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,5)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(66975205,0,0,LOCATION_HAND,0,POS_FACEDOWN)
Debug.AddCard(29369059,0,0,LOCATION_HAND,0,POS_FACEDOWN)
Debug.AddCard(93360904,0,0,LOCATION_HAND,0,POS_FACEDOWN)

Debug.AddCard(15180041,1,1,LOCATION_MZONE,1,POS_FACEUP_ATTACK)

Debug.ReloadFieldEnd()
Debug.ShowHint("GAME START!")
aux.BeginPuzzle()
```