### PR TITLE
use text mode in luaL_loadbufferx by default

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -139,7 +139,7 @@ int32_t interpreter::load_script(const char* script_name) {
 		return OPERATION_FAIL;
 	++no_action;
 	luaL_checkstack(current_state, 2, nullptr);
-	int32_t error = luaL_loadbuffer(current_state, (const char*)buffer, len, script_name) || lua_pcall(current_state, 0, 0, 0);
+	int32_t error = luaL_loadbufferx(current_state, (const char*)buffer, len, script_name, "t") || lua_pcall(current_state, 0, 0, 0);
 	if (error) {
 		interpreter::sprintf(pduel->strbuffer, "%s", lua_tostring(current_state, -1));
 		handle_message(pduel, 1);

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -14,7 +14,8 @@
 #include "ocgapi.h"
 #include "interpreter.h"
 
-interpreter::interpreter(duel* pd, bool enable_unsafe_libraries) : coroutines(256), pduel(pd) {
+interpreter::interpreter(duel* pd, bool enable_unsafe_libraries)
+	: coroutines(256), pduel(pd), enable_unsafe_feature(enable_unsafe_libraries) {
 	lua_state = luaL_newstate();
 	current_state = lua_state;
 	std::memcpy(lua_getextraspace(lua_state), &pd, LUA_EXTRASPACE); //set_duel_info
@@ -139,7 +140,11 @@ int32_t interpreter::load_script(const char* script_name) {
 		return OPERATION_FAIL;
 	++no_action;
 	luaL_checkstack(current_state, 2, nullptr);
-	int32_t error = luaL_loadbufferx(current_state, (const char*)buffer, len, script_name, "t") || lua_pcall(current_state, 0, 0, 0);
+	int32_t error = 0;
+	if (enable_unsafe_feature)
+		error = luaL_loadbuffer(current_state, (const char*)buffer, len, script_name) || lua_pcall(current_state, 0, 0, 0);
+	else
+		error = luaL_loadbufferx(current_state, (const char*)buffer, len, script_name, "t") || lua_pcall(current_state, 0, 0, 0);
 	if (error) {
 		interpreter::sprintf(pduel->strbuffer, "%s", lua_tostring(current_state, -1));
 		handle_message(pduel, 1);

--- a/interpreter.h
+++ b/interpreter.h
@@ -52,6 +52,7 @@ public:
 	coroutine_map coroutines;
 	int32_t no_action{};
 	int32_t call_depth{};
+	bool enable_unsafe_feature{};
 
 	explicit interpreter(duel* pd, bool enable_unsafe_libraries);
 	~interpreter();


### PR DESCRIPTION
https://www.lua.org/manual/5.4/manual.html#luaL_loadbuffer
```c
int luaL_loadbuffer (lua_State *L,
                     const char *buff,
                     size_t sz,
                     const char *name);
```
Equivalent to luaL_loadbufferx with mode equal to NULL.

```c
int luaL_loadbufferx (lua_State *L,
                      const char *buff,
                      size_t sz,
                      const char *name,
                      const char *mode);
```
The string mode works as in the function lua_load.

https://www.lua.org/manual/5.4/manual.html#lua_load
```c
int lua_load (lua_State *L,
              lua_Reader reader,
              void *data,
              const char *chunkname,
              const char *mode);
```
lua_load automatically detects whether the chunk is text or binary and loads it accordingly (see program luac). The string mode works as in function load, with the addition that a NULL value is equivalent to the string "bt". 


https://www.lua.org/manual/5.4/manual.html#pdf-load
**The string mode controls whether the chunk can be text or binary (that is, a precompiled chunk).
It may be the string "b" (only binary chunks), "t" (only text chunks), or "bt" (both binary and text). The default is "bt".
It is safe to load malformed binary chunks; load signals an appropriate error. However, Lua does not check the consistency of the code inside binary chunks; running maliciously crafted bytecode can crash the interpreter.**

----
lua_load 系列函數
預設值是接受text/binary chunks
也就是會接受預先編譯的腳本檔案

預先編譯的腳本是binary file
無法透過事先檢查腳本文件來確認檔案內容
由於ygopro的單人模式也是使用Lua腳本呼叫Debug Library
關閉binary mode 只保留text mode比較能避免執行有潛在惡意內容的腳本

@mercury233 
@purerosefallen 
@Wind2009-Louse
@fallenstardust

