### PR TITLE
 refactor mtrandom constructors, shuffle_vector

### DIFF
--- a/mtrandom.h
+++ b/mtrandom.h
@@ -24,14 +24,14 @@ public:
 		: rng(q) {}
 	explicit mtrandom(std::seed_seq&& q)
 		: rng(q) {}
-	mtrandom(uint32_t seq[], size_t len)
+	mtrandom(const uint32_t seq[], size_t len)
 		: mtrandom(std::seed_seq(seq, seq + len)) {}
 	
 	mtrandom(const mtrandom& other) = delete;
 	void operator=(const mtrandom& other) = delete;
 
 	// mersenne_twister_engine
-	void seed(uint32_t seq[], size_t len) {
+	void seed(const uint32_t seq[], size_t len) {
 		std::seed_seq q(seq, seq + len);
 		rng.seed(q);
 	}

--- a/mtrandom.h
+++ b/mtrandom.h
@@ -16,16 +16,15 @@ class mtrandom {
 public:
 	const unsigned int rand_max{ std::mt19937::max() };
 
-	mtrandom() :
-		rng() {}
-	mtrandom(uint32_t seq[], size_t len) {
-		std::seed_seq q(seq, seq + len);
-		rng.seed(q);
-	}
-	explicit mtrandom(uint_fast32_t value) :
-		rng(value) {}
-	mtrandom(std::seed_seq& q) :
-		rng(q) {}
+	mtrandom() = default;
+	explicit mtrandom(uint_fast32_t value)
+		: rng(value) {}
+	explicit mtrandom(std::seed_seq& q)
+		: rng(q) {}
+	explicit mtrandom(std::seed_seq&& q)
+		: rng(q) {}
+	mtrandom(uint32_t seq[], size_t len)
+		: mtrandom(std::seed_seq(seq, seq + len)) {}
 	
 	mtrandom(const mtrandom& other) = delete;
 	void operator=(const mtrandom& other) = delete;

--- a/mtrandom.h
+++ b/mtrandom.h
@@ -8,6 +8,7 @@
 #ifndef MTRANDOM_H_
 #define MTRANDOM_H_
 
+#include <cstdint>
 #include <random>
 #include <vector>
 #include <utility>
@@ -77,13 +78,16 @@ public:
 	void shuffle_vector(std::vector<T>& v, int first, int last, int version) {
 		if ((size_t)last > v.size())
 			last = (int)v.size();
-		auto distribution = &mtrandom::get_random_integer_v2;
+		auto shuffle = [&](auto&& distribution) {
+			for (int i = first; i < last - 1; ++i) {
+				int r = distribution(i, last - 1);
+				std::swap(v[i], v[r]);
+			}
+		};
 		if (version == 1)
-			distribution = &mtrandom::get_random_integer_v1;
-		for (int i = first; i < last - 1; ++i) {
-			int r = (this->*distribution)(i, last - 1);
-			std::swap(v[i], v[r]);
-		}
+			shuffle([this](int l, int h) { return get_random_integer_v1(l, h); });
+		else
+			shuffle([this](int l, int h) { return get_random_integer_v2(l, h); });
 	}
 
 	template<typename T>


### PR DESCRIPTION
# constructors
```cpp
mtrandom() = default;
```
Using default is better than writing an empty function.

```cpp
explicit mtrandom(std::seed_seq& q)
	: rng(q) {}
```
Add `explicit` to ctor with only 1 parameter.

```cpp
explicit mtrandom(std::seed_seq&& q)
	: rng(q) {}
```
Add the ctor with rvalue reference for the next one.

```cpp
mtrandom(const uint32_t seq[], size_t len)
	: mtrandom(std::seed_seq(seq, seq + len)) {}
```
Before:
rng is initialize to default seed
rng is initialized to seed sequence

After:
rng is initialized to seed sequence

# shuffle_vector
Use lambda expressions to select a distribution.
The shuffle logic does not change.


@Wind2009-Louse