### PR TITLE
remove GitHub Release step from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,17 +62,6 @@ jobs:
           build/bin/x32/Release/ocgcore.dll
           build/bin/x64/Release/ocgcore.dll
 
-    - name: GitHub Release
-      if: github.event_name == 'push'
-      uses: salix5/action-automatic-releases@e0545bc14e9677f38aa573f1a52563022f987356 # node24
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "latest"
-        prerelease: true
-        title: "Development Build"
-        files: |
-          build/bin/x64/Release/ocgcore.dll
-
   build-linux:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
An alternative solution for the traditional release
The users can get the DLL file from workflow artifact.