### PR TITLE
fix select forced chain on DUEL_SIMPLE_AI

### DIFF
--- a/playerop.cpp
+++ b/playerop.cpp
@@ -341,6 +341,9 @@ int32_t field::select_chain(uint16_t step, uint8_t playerid, uint8_t spe_count) 
 				for(const auto& ch : core.current_chain)
 					if(ch.triggering_player == 1)
 						act = false;
+				for(const auto& ch : core.select_chains)
+					if(ch.flag & CHAIN_FORCED)
+						act = true;
 				if(act)
 					returns.ivalue[0] = 0;
 				else

--- a/playerop.cpp
+++ b/playerop.cpp
@@ -338,8 +338,9 @@ int32_t field::select_chain(uint16_t step, uint8_t playerid, uint8_t spe_count) 
 				returns.ivalue[0] = -1;
 			else {
 				bool act = true;
-				if(core.current_chain.size() && core.current_chain.back().triggering_player == 1)
-					act = false;
+				for(const auto& ch : core.current_chain)
+					if(ch.triggering_player == 1)
+						act = false;
 				for(const auto& ch : core.select_chains)
 					if(ch.flag & CHAIN_FORCED)
 						act = true;

--- a/playerop.cpp
+++ b/playerop.cpp
@@ -338,9 +338,8 @@ int32_t field::select_chain(uint16_t step, uint8_t playerid, uint8_t spe_count) 
 				returns.ivalue[0] = -1;
 			else {
 				bool act = true;
-				for(const auto& ch : core.current_chain)
-					if(ch.triggering_player == 1)
-						act = false;
+				if(core.current_chain.size() && core.current_chain.back().triggering_player == 1)
+					act = false;
 				for(const auto& ch : core.select_chains)
 					if(ch.flag & CHAIN_FORCED)
 						act = true;


### PR DESCRIPTION
When AI is asked to select a forced chain, it should always return a item.

before https://github.com/Fluorohydride/ygopro-core/pull/753 : always return the first item when forced
after https://github.com/Fluorohydride/ygopro-core/pull/753 : may return -1 when the current chain include the card of AI (broken, don't respond to forced chain)

after fix:
- return the first item if the chain is forced
- ~~don't chain only if the last chain is triggered by the AI itself (breaking change)~~

fix https://github.com/Fluorohydride/ygopro/issues/3025 , close https://github.com/Fluorohydride/ygopro-core/pull/838