### PR TITLE
add EFFECT_REVEAL_ONFIELD

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -403,7 +403,7 @@ uint32_t card::get_info_location() const {
 }
 uint32_t card::get_public_info_location() {
 	uint32_t info = get_info_location();
-	if((current.location & LOCATION_ONFIELD) && is_affected_by_effect(EFFECT_MIND_SCAN))
+	if((current.location & LOCATION_ONFIELD) && is_affected_by_effect(EFFECT_REVEAL_ONFIELD))
 		info |= (static_cast<uint32_t>(POS_REVEAL) << 24);
 	return info;
 }

--- a/card.cpp
+++ b/card.cpp
@@ -401,9 +401,9 @@ uint32_t card::get_info_location() const {
 		return c | (l << 8) | (s << 16) | (ss << 24);
 	}
 }
-uint32_t card::get_public_info_location() const {
+uint32_t card::get_public_info_location() {
 	uint32_t info = get_info_location();
-	if((current.location & LOCATION_ONFIELD) && const_cast<card*>(this)->is_affected_by_effect(EFFECT_PUBLIC))
+	if((current.location & LOCATION_ONFIELD) && is_affected_by_effect(EFFECT_MIND_SCAN))
 		info |= (static_cast<uint32_t>(POS_REVEAL) << 24);
 	return info;
 }

--- a/card.h
+++ b/card.h
@@ -218,7 +218,7 @@ public:
 
 	int32_t get_infos(byte* buf, uint32_t query_flag, int32_t use_cache = TRUE);
 	uint32_t get_info_location() const;
-	uint32_t get_public_info_location() const;
+	uint32_t get_public_info_location();
 	uint32_t get_original_code() const;
 	std::tuple<uint32_t, uint32_t> get_original_code_rule() const;
 	uint32_t get_code();

--- a/effect.cpp
+++ b/effect.cpp
@@ -504,7 +504,7 @@ int32_t effect::is_target(card* pcard) {
 	if((type & EFFECT_TYPE_TARGET) && !(type & EFFECT_TYPE_FIELD)) {
 		return is_fit_target_function(pcard);
 	}
-	if(!is_flag(EFFECT_FLAG_SET_AVAILABLE) && code != EFFECT_MIND_SCAN
+	if(!is_flag(EFFECT_FLAG_SET_AVAILABLE) && code != EFFECT_REVEAL_ONFIELD
 			&& (pcard->current.location & LOCATION_ONFIELD) && !pcard->is_position(POS_FACEUP))
 		return FALSE;
 	if(!is_flag(EFFECT_FLAG_IGNORE_RANGE)) {

--- a/effect.cpp
+++ b/effect.cpp
@@ -504,8 +504,8 @@ int32_t effect::is_target(card* pcard) {
 	if((type & EFFECT_TYPE_TARGET) && !(type & EFFECT_TYPE_FIELD)) {
 		return is_fit_target_function(pcard);
 	}
-	if(!is_flag(EFFECT_FLAG_SET_AVAILABLE) && code != EFFECT_PUBLIC && (pcard->current.location & LOCATION_ONFIELD)
-			&& !pcard->is_position(POS_FACEUP))
+	if(!is_flag(EFFECT_FLAG_SET_AVAILABLE) && code != EFFECT_MIND_SCAN
+			&& (pcard->current.location & LOCATION_ONFIELD) && !pcard->is_position(POS_FACEUP))
 		return FALSE;
 	if(!is_flag(EFFECT_FLAG_IGNORE_RANGE)) {
 		if(pcard->is_treated_as_not_on_field())

--- a/effect.h
+++ b/effect.h
@@ -534,6 +534,7 @@ const std::map<uint64_t, uint64_t> category_checklist{
 #define EFFECT_SYNCHRO_LEVEL_EX		373
 #define EFFECT_RITUAL_LEVEL_EX		374
 #define EFFECT_DOUBLE_XMATERIAL		375
+#define EFFECT_MIND_SCAN			376
 
 //#define EVENT_STARTUP		1000
 #define EVENT_FLIP			1001

--- a/effect.h
+++ b/effect.h
@@ -534,7 +534,7 @@ const std::map<uint64_t, uint64_t> category_checklist{
 #define EFFECT_SYNCHRO_LEVEL_EX		373
 #define EFFECT_RITUAL_LEVEL_EX		374
 #define EFFECT_DOUBLE_XMATERIAL		375
-#define EFFECT_MIND_SCAN			376
+#define EFFECT_REVEAL_ONFIELD			376
 
 //#define EVENT_STARTUP		1000
 #define EVENT_FLIP			1001


### PR DESCRIPTION
# EFFECT_REVEAL_ONFIELD
EFFECT_PUBLIC
The card is in public, and it is face-up now.

Mind Scan
You can confirm the ***face-down*** card your opponent control.

They are completely different effects.
I recommend that ygopro should add a new effect for this card.

# const_cast
const_cast is not recommended.
If you have to use const_cast, it means that the member function should not be `const` member.


For the script of Mind Scan:
The only difference is add change the effect code to EFFECT_REVEAL_ONFIELD.