### PR TITLE
Fix rock-paper-scissors response validation

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -6515,37 +6515,3 @@ int32_t field::toss_dice(uint16_t step, effect * reason_effect, uint8_t reason_p
 	}
 	return TRUE;
 }
-int32_t field::rock_paper_scissors(uint16_t step, uint8_t repeat) {
-	switch (step) {
-	case 0: {
-		pduel->write_buffer8(MSG_ROCK_PAPER_SCISSORS);
-		pduel->write_buffer8(0);
-		return FALSE;
-	}
-	case 1: {
-		core.units.begin()->value1 = returns.ivalue[0];
-		pduel->write_buffer8(MSG_ROCK_PAPER_SCISSORS);
-		pduel->write_buffer8(1);
-		return FALSE;
-	}
-	case 2: {
-		int32_t hand0 = core.units.begin()->value1;
-		int32_t hand1 = returns.ivalue[0];
-		pduel->write_buffer8(MSG_HAND_RES);
-		pduel->write_buffer8(hand0 + (hand1 << 2));
-		if(hand0 == hand1) {
-			if(repeat) {
-				core.units.begin()->step = -1;
-				return FALSE;
-			} else
-				returns.ivalue[0] = PLAYER_NONE;
-		} else if((hand0 == 1 && hand1 == 2) || (hand0 == 2 && hand1 == 3) || (hand0 == 3 && hand1 == 1)) {
-			returns.ivalue[0] = 1;
-		} else {
-			returns.ivalue[0] = 0;
-		}
-		return TRUE;
-	}
-	}
-	return TRUE;
-}

--- a/playerop.cpp
+++ b/playerop.cpp
@@ -1055,3 +1055,51 @@ int32_t field::announce_number(int16_t step, uint8_t playerid) {
 		return TRUE;
 	}
 }
+int32_t field::rock_paper_scissors(uint16_t step, uint8_t repeat) {
+	auto check_valid = [&]() {
+		if(returns.ivalue[0] < 1 || returns.ivalue[0] > 3) {
+			pduel->write_buffer8(MSG_RETRY);
+			--core.units.begin()->step;
+			return false;
+		}
+		return true;
+	};
+	switch (step) {
+	case 0: {
+		pduel->write_buffer8(MSG_ROCK_PAPER_SCISSORS);
+		pduel->write_buffer8(0);
+		return FALSE;
+	}
+	case 1: {
+		if(!check_valid())
+			return FALSE;
+		core.units.begin()->value1 = returns.ivalue[0];
+		pduel->write_buffer8(MSG_ROCK_PAPER_SCISSORS);
+		pduel->write_buffer8(1);
+		return FALSE;
+	}
+	case 2: {
+		if(!check_valid())
+			return FALSE;
+		uint8_t hand0 = static_cast<uint8_t>(core.units.begin()->value1);
+		uint8_t hand1 = static_cast<uint8_t>(returns.ivalue[0]);
+		pduel->write_buffer8(MSG_HAND_RES);
+		pduel->write_buffer8(hand0 + (hand1 << 2));
+		if(hand0 == hand1) {
+			if(repeat) {
+				pduel->write_buffer8(MSG_ROCK_PAPER_SCISSORS);
+				pduel->write_buffer8(0);
+				core.units.begin()->step = 0;
+				return FALSE;
+			} else
+				returns.ivalue[0] = PLAYER_NONE;
+		} else if((hand0 == 1 && hand1 == 2) || (hand0 == 2 && hand1 == 3) || (hand0 == 3 && hand1 == 1)) {
+			returns.ivalue[0] = 1;
+		} else {
+			returns.ivalue[0] = 0;
+		}
+		return TRUE;
+	}
+	}
+	return TRUE;
+}


### PR DESCRIPTION
Game-internal rock-paper-scissors previously trusted the raw player response and accepted values outside the valid 1..3 hand range.

That meant invalid responses could be stored as player 0's hand, packed into MSG_HAND_RES, or shifted while resolving player 1's hand. In practice this could produce malformed hand-result messages and let an invalid response affect winner resolution instead of asking the same player to respond again.

This change moves the rock-paper-scissors player-response handling into playerop.cpp and validates each response before using it. Out-of-range values now emit MSG_RETRY and keep the processor on the same rock-paper-scissors step, so the same player must provide a valid hand before resolution continues.

The normal result logic is preserved for valid hands, including repeat ties and PLAYER_NONE for no-repeat ties. Hand values are also cast to uint8_t before packing MSG_HAND_RES.

Inspired by https://github.com/edo9300/ygopro-core/blob/2407cf72000d8155822330d1b3cd08acb7618f4d/playerop.cpp#L1122-L1130