### PR TITLE
Reduce SIZE_RETURN_VALUE from 512 to 256

### DIFF
--- a/common.h
+++ b/common.h
@@ -28,7 +28,7 @@ inline bool check_playerid(int32_t playerid) {
 #define FALSE 0
 
 #define SIZE_MESSAGE_BUFFER 0x2000u
-#define SIZE_RETURN_VALUE 512u
+#define SIZE_RETURN_VALUE 256u
 #define SIZE_AI_NAME 128u
 #define SIZE_HINT_MSG	1024u
 


### PR DESCRIPTION
The response length is stored in uint8, so the size should be 256. 