### PR TITLE
fix lingering EFFECT_ATTACK_DISABLED after damage calculation negation

### DIFF
--- a/processor.cpp
+++ b/processor.cpp
@@ -3235,6 +3235,8 @@ int32_t field::process_battle_command(uint16_t step) {
 	}
 	case 39: {
 		//end of damage step
+		if(core.attacker->is_status(STATUS_ATTACK_CANCELED))
+			core.attacker->reset(EFFECT_ATTACK_DISABLED, RESET_CODE);
 		core.attacker->set_status(STATUS_OPPO_BATTLE, FALSE);
 		if(core.attack_target)
 			core.attack_target->set_status(STATUS_OPPO_BATTLE, FALSE);


### PR DESCRIPTION
Fixes #845.

When `Duel.NegateAttack()` is called during `EVENT_PRE_DAMAGE_CALCULATE`, the attack is canceled after the existing Battle Step cleanup path for `EFFECT_ATTACK_DISABLED` (case 11) has already passed. This left the temporary marker on the attacking monster, causing it to be treated as unable to attack on later turns.