### PR TITLE
Fix send_to capability check to respect overridden reason_player

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -3935,11 +3935,11 @@ int32_t field::send_to(uint16_t step, group * targets, effect * reason_effect, u
 			if(!(reason & REASON_RULE) &&
 			        (pcard->get_status(STATUS_SUMMONING | STATUS_SPSUMMON_STEP)
 			         || ((pcard->current.reason & REASON_EFFECT) && !pcard->is_affect_by_effect(pcard->current.reason_effect))
-			         || (dest == LOCATION_HAND && !pcard->is_capable_send_to_hand(reason_player))
-			         || (dest == LOCATION_DECK && !pcard->is_capable_send_to_deck(reason_player, send_activating))
-			         || (dest == LOCATION_REMOVED && !pcard->is_removeable(reason_player, pcard->sendto_param.position, reason))
-			         || (dest == LOCATION_GRAVE && !pcard->is_capable_send_to_grave(reason_player))
-			         || (dest == LOCATION_EXTRA && !pcard->is_capable_send_to_extra(reason_player)))) {
+			         || (dest == LOCATION_HAND && !pcard->is_capable_send_to_hand(pcard->current.reason_player))
+			         || (dest == LOCATION_DECK && !pcard->is_capable_send_to_deck(pcard->current.reason_player, send_activating))
+			         || (dest == LOCATION_REMOVED && !pcard->is_removeable(pcard->current.reason_player, pcard->sendto_param.position, reason))
+			         || (dest == LOCATION_GRAVE && !pcard->is_capable_send_to_grave(pcard->current.reason_player))
+			         || (dest == LOCATION_EXTRA && !pcard->is_capable_send_to_extra(pcard->current.reason_player)))) {
 				pcard->current.reason = pcard->temp.reason;
 				pcard->current.reason_player = pcard->temp.reason_player;
 				pcard->current.reason_effect = pcard->temp.reason_effect;

--- a/operations.cpp
+++ b/operations.cpp
@@ -3935,11 +3935,11 @@ int32_t field::send_to(uint16_t step, group * targets, effect * reason_effect, u
 			if(!(reason & REASON_RULE) &&
 			        (pcard->get_status(STATUS_SUMMONING | STATUS_SPSUMMON_STEP)
 			         || ((pcard->current.reason & REASON_EFFECT) && !pcard->is_affect_by_effect(pcard->current.reason_effect))
-			         || (dest == LOCATION_HAND && !pcard->is_capable_send_to_hand(core.reason_player))
-			         || (dest == LOCATION_DECK && !pcard->is_capable_send_to_deck(core.reason_player, send_activating))
-			         || (dest == LOCATION_REMOVED && !pcard->is_removeable(core.reason_player, pcard->sendto_param.position, reason))
-			         || (dest == LOCATION_GRAVE && !pcard->is_capable_send_to_grave(core.reason_player))
-			         || (dest == LOCATION_EXTRA && !pcard->is_capable_send_to_extra(core.reason_player)))) {
+			         || (dest == LOCATION_HAND && !pcard->is_capable_send_to_hand(reason_player))
+			         || (dest == LOCATION_DECK && !pcard->is_capable_send_to_deck(reason_player, send_activating))
+			         || (dest == LOCATION_REMOVED && !pcard->is_removeable(reason_player, pcard->sendto_param.position, reason))
+			         || (dest == LOCATION_GRAVE && !pcard->is_capable_send_to_grave(reason_player))
+			         || (dest == LOCATION_EXTRA && !pcard->is_capable_send_to_extra(reason_player)))) {
 				pcard->current.reason = pcard->temp.reason;
 				pcard->current.reason_player = pcard->temp.reason_player;
 				pcard->current.reason_effect = pcard->temp.reason_effect;


### PR DESCRIPTION
# Fix send_to capability check to respect overridden reason_player

## Summary / 摘要

- **EN:** Use the process `reason_player` (including `Duel.SendtoHand`'s optional 4th argument) when checking whether a card can be sent to hand/deck/grave/etc., instead of always using `core.reason_player`.
- **ZH:** 在判断卡牌能否送入墓地/手卡/卡组等时，改用流程传入的 `reason_player`（含 `Duel.SendtoHand` 可选第 4 参数），而不再始终使用 `core.reason_player`。

## Problem / 问题

**EN:**

`Duel.SendtoHand` gained an optional 4th parameter `reason_player` (see #499 / commit that updated `Duel.SendtoHand`) so scripts can treat another player as the one performing the send (e.g. “your opponent adds a card from their Deck to their hand” while the effect controller is you).

However, `field::send_to` step 0 still checked capability with `core.reason_player` (the effect activator). When that differed from the overridden `reason_player`, cards could pass `Card.IsAbleToHand(p)` (checked with `p`) but fail in `SendtoHand` (checked with the activator).

**ZH:**

`Duel.SendtoHand` 已支持可选第 4 参数 `reason_player`（见 #499 及相关提交），用于让脚本把“执行加入手卡的玩家”指定为另一名玩家（例如效果控制者是对方，但实际是你把自身卡组的卡加入手卡）。

但 `field::send_to` 的 step 0 仍用 `core.reason_player`（效果发动者）做能力判定。当它与覆盖后的 `reason_player` 不一致时，会出现：`Card.IsAbleToHand(p)`（按 `p` 判定）可通过，而 `SendtoHand`（按发动者判定）失败——能选卡却加不进手卡。

### Example / 示例

**EN:**

1. Player A controls a monster with `EFFECT_CANNOT_TO_HAND` (`EFFECT_FLAG_PLAYER_TARGET`, `SetTargetRange(0,1)`): opponent cannot add cards from the Deck to the hand.
2. Player B activates an effect: “the opponent adds 1 card from their Deck to their hand.”
3. Player A selects a card from their Deck (`IsAbleToHand(A)` succeeds; A is not restricted).
4. Before this fix: `SendtoHand(g, A, REASON_EFFECT, A)` still checked capability as player B → blocked by A’s continuous effect.
5. After this fix: capability is checked as player A → succeeds as intended.

**ZH:**

1. 玩家 A 场上有怪兽：`EFFECT_CANNOT_TO_HAND`（`EFFECT_FLAG_PLAYER_TARGET`，`SetTargetRange(0,1)`）——对方不能把卡组的卡加入手卡。
2. 玩家 B 发动效果：“对方将自身卡组的 1 张卡加入手卡。”
3. 玩家 A 从自己卡组选卡（`IsAbleToHand(A)` 通过；限制不作用于 A）。
4. 修复前：`SendtoHand(g, A, REASON_EFFECT, A)` 仍按玩家 B 做能力判定 → 被 A 的永续效果挡住。
5. 修复后：按玩家 A 判定 → 按规则应成功。

## Change / 修改

**EN:** In `field::send_to` (step 0), replace `core.reason_player` with the `reason_player` argument for:

- `is_capable_send_to_hand`
- `is_capable_send_to_deck`
- `is_removeable`
- `is_capable_send_to_grave`
- `is_capable_send_to_extra`

This matches the destroy path, which already uses the process `reason_player` for similar checks.

If the 4th argument is omitted, `Duel.SendtoHand` still defaults `reason_player` to `core.reason_player`, so existing calls without the 4th parameter keep the same behavior.

**ZH:** 在 `field::send_to`（step 0）中，将下列判定的 `core.reason_player` 改为参数 `reason_player`：

- `is_capable_send_to_hand`
- `is_capable_send_to_deck`
- `is_removeable`
- `is_capable_send_to_grave`
- `is_capable_send_to_extra`

与破坏流程中已使用流程 `reason_player` 的写法一致。

若不传第 4 参数，`Duel.SendtoHand` 仍将 `reason_player` 设为 `core.reason_player`，原有不传第 4 参数的调用行为不变。